### PR TITLE
Large amounts of whitespace in code blocks

### DIFF
--- a/_includes/collections/breadcrumbs/breadcrumbs.html
+++ b/_includes/collections/breadcrumbs/breadcrumbs.html
@@ -5,23 +5,21 @@
     <div class="well" data-example-id="list-breadcrumbs">
         {% include markup-templates/lists/breadcrumb.html param="breadcrumbs" %}
     </div>
-    {% highlight html %}
-    {% include markup-templates/lists/breadcrumb.html param="breadcrumbs" %}
-    {% endhighlight %}
+{% highlight html %}
+{% include markup-templates/lists/breadcrumb.html param="breadcrumbs" %}
+{% endhighlight %}
     <h4 class="status status-warning"> Explore Breadcrumb</h4>
     <div class="well">
         {% include markup-templates/lists/breadcrumb.html param="breadcrumbs-explore" %}
     </div>
-    {% highlight html %}
-    {% include markup-templates/lists/breadcrumb.html param="breadcrumbs-explore" %}
-    {% endhighlight %}
-
+{% highlight html %}
+{% include markup-templates/lists/breadcrumb.html param="breadcrumbs-explore" %}
+{% endhighlight %}
     <h4 class="status status-warning"> Outlet Breadcrumb</h4>
     <div class="well">
         {% include markup-templates/lists/breadcrumb.html param="breadcrumbs-outlet" %}
     </div>
-    {% highlight html %}
-    {% include markup-templates/lists/breadcrumb.html param="breadcrumbs-outlet" %}
-    {% endhighlight %}
-
+{% highlight html %}
+{% include markup-templates/lists/breadcrumb.html param="breadcrumbs-outlet" %}
+{% endhighlight %}
 </section>

--- a/_includes/markup-templates/lists/breadcrumb.html
+++ b/_includes/markup-templates/lists/breadcrumb.html
@@ -1,5 +1,5 @@
-{% for item in site.data.list-names %}
-{% if item.type == include.param %}
+{% for item in site.data.list-names %}{%
+if item.type == include.param %}
 <ol class="{{item.class}}" itemscope itemtype="http://schema.org/BreadcrumbList">
     <li itemprop="itemListElement" itemscope
         itemtype="http://schema.org/ListItem">
@@ -19,6 +19,6 @@
             <span itemprop="name">Item 3</span></a>
         <meta itemprop="position" content="3" />
     </li>
-</ol>
-{% endif %}
-{% endfor %}
+</ol>{%
+endif %}{%
+endfor %}


### PR DESCRIPTION
The current version of rouge/liquid seems to add more whitespace to code blocks that is waned - 
[issue 216](https://github.com/Shopify/liquid/issues/216), for now reformatting the code samples to eliminate as much as possible
