### PR TITLE
Large amounts of whitespace in list-group code blocks

### DIFF
--- a/_includes/collections/list-groups/css-list-group.html
+++ b/_includes/collections/list-groups/css-list-group.html
@@ -6,9 +6,9 @@
   <div class="well" data-example-id="simple-list-group">
   {% include /markup-templates/list-group/list-group.html%}
   </div>
-  {% highlight html %}
-  {% include /markup-templates/list-group/list-group.html param="default"%}
-  {% endhighlight %}
+{% highlight html %}
+{% include /markup-templates/list-group/list-group.html param="default"%}
+{% endhighlight %}
 
   <h3 id="list-group-sort" class="status status-warning">Sorting example</h3>
   <p>
@@ -21,7 +21,7 @@
       {% include /markup-templates/list-group/list-group-sort.html%}
   </div>
 {% highlight html %}
-   {% include /markup-templates/list-group/list-group-sort.html param="default"%}
+{% include /markup-templates/list-group/list-group-sort.html param="default"%}
 {% endhighlight %}
 
 <h3 id="list-group-filter" class="status status-warning">Filter Menu</h3>
@@ -31,7 +31,7 @@
       {% include /markup-templates/list-group/list-group-filter.html %}
   </div>
 {% highlight html %}
-   {% include /markup-templates/list-group/list-group-filter.html %}
+{% include /markup-templates/list-group/list-group-filter.html %}
 {% endhighlight %}
 
 <h3 id="list-group-menu" class="status status-warning">Menu</h3>
@@ -39,7 +39,7 @@
       {% include /markup-templates/list-group/list-group-menu.html%}
   </div>
 {% highlight html %}
-   {% include /markup-templates/list-group/list-group-menu.html%}
+{% include /markup-templates/list-group/list-group-menu.html%}
 {% endhighlight %}
 
 </section>

--- a/_includes/collections/list-groups/css-nav-lists.html
+++ b/_includes/collections/list-groups/css-nav-lists.html
@@ -9,13 +9,13 @@
   <div class="well" data-example-id="" role="navigation">
     {% include /markup-templates/lists/nav-list.html param="nav" %}
   </div>
-  {% highlight html %}
-      {% include /markup-templates/lists/nav-list.html param="nav" %}
-  {% endhighlight %}
+{% highlight html %}
+{% include /markup-templates/lists/nav-list.html param="nav" %}
+{% endhighlight %}
   <div class="well" data-example-id="" role="navigation">
     {% include /markup-templates/lists/nav-list.html param="menu" %}
   </div>
-  {% highlight html %}
-      {% include /markup-templates/lists/nav-list.html param="menu" %}
-  {% endhighlight %}
+{% highlight html %}
+{% include /markup-templates/lists/nav-list.html param="menu" %}
+{% endhighlight %}
 </section>

--- a/_includes/markup-templates/lists/nav-list.html
+++ b/_includes/markup-templates/lists/nav-list.html
@@ -1,9 +1,9 @@
-{% for item in site.data.list-names %}
-    {% if item.type == include.param %}
-       <ul class="{{item.class}}">
-            <li class="active"><a href="#">Home</a></li>
-            <li><a href="#">Profile</a></li>
-            <li><a href="#">Messages</a></li>
-        </ul>
-    {% endif %}
-{% endfor %}
+{% for item in site.data.list-names %}{%
+if item.type == include.param %}
+<ul class="{{item.class}}">
+    <li class="active"><a href="#">Home</a></li>
+    <li><a href="#">Profile</a></li>
+    <li><a href="#">Messages</a></li>
+</ul>{%
+endif %}{%
+endfor %}


### PR DESCRIPTION
The current version of rouge/liquid seems to add more whitespace to code blocks that is waned - 
issue 216, for now reformatting the code samples to eliminate as much as possible
