### PR TITLE
Large amounts of whitespace in Button-group code blocks

### DIFF
--- a/_includes/collections/button-groups/filters.html
+++ b/_includes/collections/button-groups/filters.html
@@ -37,11 +37,11 @@
             </button>
         </div>
     </div>
-    {% highlight html %}
-    <div class="btn-group inline-group ig-sm">
-        <button></button>
-        <button></button>
-    </div>
-    {% endhighlight %}
+{% highlight html %}
+<div class="btn-group inline-group ig-sm">
+    <button></button>
+    <button></button>
+</div>
+{% endhighlight %}
 
 </section>

--- a/_includes/collections/button-groups/groups.html
+++ b/_includes/collections/button-groups/groups.html
@@ -17,9 +17,9 @@
     <div class="well" data-example-id="btn-tags">
         {% include markup-templates/buttons/styled-as-button.html %}
     </div>
-    {% highlight html %}
-    {% include markup-templates/buttons/styled-as-button.html %}
-    {% endhighlight %}
+{% highlight html %}
+{% include markup-templates/buttons/styled-as-button.html %}
+{% endhighlight %}
 
     <div class="bs-callout bs-callout-warning" id="callout-btn-group-tooltips">
         <h5>Tooltips &amp; popovers in button groups require special setting</h5>
@@ -57,14 +57,14 @@
             <button type="button" class="btn btn-default">4</button>
         </div>
     </div>
-    {% highlight html %}
-    <div class="btn-group" role="group">
-        <button type="button" class="btn btn-default">1</button>
-        <button type="button" class="btn btn-default">2</button>
-        <button type="button" class="btn btn-default">3</button>
-        <button type="button" class="btn btn-default">4</button>
-    </div>
-    {% endhighlight %}
+{% highlight html %}
+<div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">1</button>
+    <button type="button" class="btn btn-default">2</button>
+    <button type="button" class="btn btn-default">3</button>
+    <button type="button" class="btn btn-default">4</button>
+</div>
+{% endhighlight %}
 
     <h3 id="inli">Non collapsed Button Groups</h3>
 
@@ -80,14 +80,14 @@
             <button type="button" class="btn btn-default">4</button>
         </div>
     </div>
-    {% highlight html %}
-    <div class="btn-group inline-group" role="group">
-        <button type="button" class="btn btn-default">1</button>
-        <button type="button" class="btn btn-default">2</button>
-        <button type="button" class="btn btn-default">3</button>
-        <button type="button" class="btn btn-default">4</button>
-    </div>
-    {% endhighlight %}
+{% highlight html %}
+<div class="btn-group inline-group" role="group">
+    <button type="button" class="btn btn-default">1</button>
+    <button type="button" class="btn btn-default">2</button>
+    <button type="button" class="btn btn-default">3</button>
+    <button type="button" class="btn btn-default">4</button>
+</div>
+{% endhighlight %}
 
     Button group alignment
 
@@ -129,12 +129,12 @@
             <button type="button" class="btn btn-default">Right</button>
         </div>
     </div>
-    {% highlight html %}
-    <div class="btn-group btn-group-lg" role="group" aria-label="...">...</div>
-    <div class="btn-group" role="group" aria-label="...">...</div>
-    <div class="btn-group btn-group-sm" role="group" aria-label="...">...</div>
-    <div class="btn-group btn-group-xs" role="group" aria-label="...">...</div>
-    {% endhighlight %}
+{% highlight html %}
+<div class="btn-group btn-group-lg" role="group" aria-label="...">...</div>
+<div class="btn-group" role="group" aria-label="...">...</div>
+<div class="btn-group btn-group-sm" role="group" aria-label="...">...</div>
+<div class="btn-group btn-group-xs" role="group" aria-label="...">...</div>
+{% endhighlight %}
 
     <h3 id="btn-groups-justified" class="status status-chat">Justified button groups</h3>
 
@@ -161,11 +161,11 @@
             <a href="#" class="btn btn-default" role="button">Right</a>
         </div>
     </div>
-    {% highlight html %}
-    <div class="btn-group btn-group-justified" role="group" aria-label="...">
-        ...
-    </div>
-    {% endhighlight %}
+{% highlight html %}
+<div class="btn-group btn-group-justified" role="group" aria-label="...">
+    ...
+</div>
+{% endhighlight %}
 
     <div class="bs-callout bs-callout-warning" id="callout-btn-group-anchor-btn">
         <h5>Links acting as buttons</h5>
@@ -194,17 +194,17 @@
             </div>
         </div>
     </div>
-    {% highlight html %}
-    <div class="btn-group btn-group-justified" role="group" aria-label="...">
-        <div class="btn-group" role="group">
-            <button type="button" class="btn btn-default">Left</button>
-        </div>
-        <div class="btn-group" role="group">
-            <button type="button" class="btn btn-default">Middle</button>
-        </div>
-        <div class="btn-group" role="group">
-            <button type="button" class="btn btn-default">Right</button>
-        </div>
+{% highlight html %}
+<div class="btn-group btn-group-justified" role="group" aria-label="...">
+    <div class="btn-group" role="group">
+        <button type="button" class="btn btn-default">Left</button>
     </div>
-    {% endhighlight %}
+    <div class="btn-group" role="group">
+        <button type="button" class="btn btn-default">Middle</button>
+    </div>
+    <div class="btn-group" role="group">
+        <button type="button" class="btn btn-default">Right</button>
+    </div>
+</div>
+{% endhighlight %}
 </section>

--- a/_includes/collections/button-groups/pairing.html
+++ b/_includes/collections/button-groups/pairing.html
@@ -14,11 +14,11 @@
             </div>
         </div>
     </div>
-    {% highlight html %}
-    <div class="btn-group inline-group text-center">
-        <button type="button" class="btn btn-primary">Button with a large CTA</button>
-        <button type="button" class="btn btn-default">Secondary</button>
-    </div>
-    {% endhighlight %}
+{% highlight html %}
+<div class="btn-group inline-group text-center">
+    <button type="button" class="btn btn-primary">Button with a large CTA</button>
+    <button type="button" class="btn btn-default">Secondary</button>
+</div>
+{% endhighlight %}
 
 </section>


### PR DESCRIPTION
The current version of rouge/liquid seems to add more whitespace to code blocks that is waned - 
issue 216, for now reformatting the code samples to eliminate as much as possible
