### PR TITLE
Adopting a synchronous strategy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,6 +43,7 @@ var browserify          = require( 'browserify' );
 var glob                = require( 'glob' );
 var del                 = require( 'del' );
 var es                  = require( 'event-stream' );
+var runSequence         = require( 'run-sequence' );
 
 var pkg                 = require( './package.json' );
 
@@ -161,9 +162,7 @@ var PA11Y_OPTIONS = pkg.pa11y;
 
 // --[ Default ]----------------------------------------------------------------
 gulp.task( 'default', [
-    'css',
-    'js',
-    'docs'
+    'master'
 ] );
 
 
@@ -244,6 +243,26 @@ gulp.task( 'accessibility:audit-exp', [
 
 
 
+
+//      /$$      /$$                       /$$                        
+//     | $$$    /$$$                      | $$                        
+//     | $$$$  /$$$$  /$$$$$$   /$$$$$$$ /$$$$$$    /$$$$$$   /$$$$$$ 
+//     | $$ $$/$$ $$ |____  $$ /$$_____/|_  $$_/   /$$__  $$ /$$__  $$
+//     | $$  $$$| $$  /$$$$$$$|  $$$$$$   | $$    | $$$$$$$$| $$  \__/
+//     | $$\  $ | $$ /$$__  $$ \____  $$  | $$ /$$| $$_____/| $$      
+//     | $$ \/  | $$|  $$$$$$$ /$$$$$$$/  |  $$$$/|  $$$$$$$| $$      
+//     |__/     |__/ \_______/|_______/    \___/   \_______/|__/      
+//   
+//   
+//   
+
+// This will run in this order: 
+// * js and css in parallel 
+// * docs 
+// * Finally call the callback function 
+gulp.task( 'master', function( callback ) {
+  runSequence( [ 'js', 'css' ], 'docs', callback );
+});
 
 
 
@@ -393,7 +412,7 @@ gulp.task( 'js:test:inject', [ 'js:test:browserify-single-components' ], functio
 // Qunit test the components
 
 gulp.task( 'js:test:qunit', [ 'js:test:inject' ], function () {
-    console.log( PATHS.TEST )
+    console.log( PATHS.TEST );
     // Test that bad boy!
     return gulp.src( path.join( PATHS.TEST, '/tmp/js/tests/index.html' ) )
         .pipe( qunit( {
@@ -431,13 +450,13 @@ gulp.task( 'docs:clean-copied-less', function() { return del( [ PATHS.DOCS_SRC +
 
 
 // Build REI-Cedar CSS and copy into docs_src directory
-gulp.task( 'docs:copy-css', [ 'docs:clean-copied-from-src', 'css' ], function () {
+gulp.task( 'docs:copy-css', [ 'docs:clean-copied-from-src' ], function () {
     return gulp.src( path.join( PATHS.DIST, '*.css' ) )
         .pipe( gulp.dest( path.join( PATHS.DOCS_SRC ) ) );
 } );
 
 // Build old Bootstrap JS and copy into the docs_src directory
-gulp.task( 'docs:copy-js', [ 'docs:clean-copied-from-src', 'js' ], function () {
+gulp.task( 'docs:copy-js', [ 'docs:clean-copied-from-src' ], function () {
     return gulp.src( path.join( PATHS.DIST, '*.js' ) )
         .pipe( gulp.dest( path.join( PATHS.DOCS_SRC ) ) );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2138,7 +2138,8 @@
         },
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.5 <4.0.0"
+          "from": "graceful-fs@3.0.8",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "hawk": {
           "version": "3.1.3",
@@ -4785,7 +4786,8 @@
       "dependencies": {
         "balanced-match": {
           "version": "0.1.0",
-          "from": "balanced-match@>=0.1.0 <0.2.0"
+          "from": "balanced-match@0.1.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
         }
       }
     },
@@ -4907,6 +4909,11 @@
       "version": "1.1.4",
       "from": "run-parallel@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.4.tgz"
+    },
+    "run-sequence": {
+      "version": "1.1.5",
+      "from": "run-sequence@>=1.1.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.1.5.tgz"
     },
     "run-series": {
       "version": "1.1.4",
@@ -5098,7 +5105,8 @@
       "dependencies": {
         "duplexer2": {
           "version": "0.1.4",
-          "from": "duplexer2@>=0.1.0 <0.2.0"
+          "from": "duplexer2@0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
         }
       }
     },
@@ -5287,7 +5295,8 @@
       "dependencies": {
         "async": {
           "version": "1.4.2",
-          "from": "async@>=1.4.0 <1.5.0"
+          "from": "async@1.4.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-streamify": "^1.0.2",
     "gulp-uglify": "^1.5.2",
     "pa11y": "^3.5.1",
+    "run-sequence": "^1.1.5",
     "vinyl-source-stream": "^1.1.0"
   },
   "engines": {


### PR DESCRIPTION
This adds in a plugin that will allow us to more easily define
synchronous tasks for the gulp file. Until the release of Gulp 4.0 this
seems like a reasonable solution to serve our requirements for
synchronous thingies.

This also removes the duplicity around the `docs` task which was kicking off the `js` and `css` jobs a second time. The new workflow will be that docs only copies the existing compiled assets (if they are there). If one wants to bring in the compiled Cedar deliverables into the docs then they would need to run either the master `gulp` task or `js` and `css` individually. 
