### PR TITLE
Fixing the file injection sequence for qunit

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -402,7 +402,7 @@ gulp.task( 'js:test:browserify-single-components', [ 'js:test:copy' ], function(
 // Inject files into js/tests/index.html for testing
 
 gulp.task( 'js:test:inject', [ 'js:test:browserify-single-components' ], function () {
-    gulp.src( PATHS.TEST + '/tmp/js/tests/index.html' )
+    return gulp.src( PATHS.TEST + '/tmp/js/tests/index.html' )
         // Get all test files and inject into index.html
         .pipe( inject( gulp.src( [ PATHS.TEST + '/tmp/js/tests/unit/*.js'], { read: false } ), { name: 'tests', relative: true } ) )
         .pipe( gulp.dest( PATHS.TEST + '/tmp/js/tests' ) );
@@ -412,7 +412,6 @@ gulp.task( 'js:test:inject', [ 'js:test:browserify-single-components' ], functio
 // Qunit test the components
 
 gulp.task( 'js:test:qunit', [ 'js:test:inject' ], function () {
-    console.log( PATHS.TEST );
     // Test that bad boy!
     return gulp.src( path.join( PATHS.TEST, '/tmp/js/tests/index.html' ) )
         .pipe( qunit( {


### PR DESCRIPTION
There was a race condition where files were not being injected in the
correct order for qunit tests. This change returns the stream to the
injection that gulp actually knows when the task is done and should
prevent the race condition from happening.
