### PR TITLE
Change the implementation of ratio items to ensure expected cross-bro…

### DIFF
--- a/src/less/definitions/utilities/utilities.less
+++ b/src/less/definitions/utilities/utilities.less
@@ -257,13 +257,13 @@
  *
  ********************************************************************/
 
- .utility-aspect-ratio {
-     position: relative;
-     overflow: hidden;
- }
  .utility-aspect-ratio ( @ratio: 1 ) {
-     &:extend( .utility-aspect-ratio );
-     padding-bottom: 100% * @ratio;
+     &:before {
+       content: '';
+       display: block;
+       height: 0;
+       padding-bottom: 100% * @ratio;
+    }
  }
  .utility-aspect-ratio ( @ratio; @align-contents: center ) {
      > div {

--- a/src/less/mixins/images.less
+++ b/src/less/mixins/images.less
@@ -146,7 +146,8 @@
 
 
 .img-frame ( @aspect; @crop; @anchor ) {
-    &:extend( .utility-aspect-ratio );
+    position: relative;
+    overflow: hidden;
 }
 
 .img-frame ( @aspect; @crop: true; @anchor ) when ( ispixel( @crop ) ){


### PR DESCRIPTION
…wser appearance when present inside of a flex layout. In a flex layout, flex items inherit their padding-bottom property from the height of the container, unlike block, so when there is no explicit height set the items have no height gained from the ratio. Example of problem here: http://stackoverflow.com/questions/23717953/padding-bottom-top-in-flexbox-layout
