### PR TITLE
bugfix for IE 11 not understanding .004, .003 0r .005 seem fine but w…

### DIFF
--- a/src/less/definitions/globals/reset.less
+++ b/src/less/definitions/globals/reset.less
@@ -20,7 +20,6 @@
 
 html, html a {
     -webkit-font-smoothing: antialiased;
-    text-shadow: 1px 1px 1px rgba(0,0,0,0.004);
     -moz-osx-font-smoothing: grayscale;
 }
 html {


### PR DESCRIPTION
…hat is really needed are the fixes got Mozilla and webkit which exist as prefix already and the text shadow is redundant with the visual regression showing no variation

http://issues.rei.com/browse/PLIB-293
