### PR TITLE
Fix title error and correct header to head

### DIFF
--- a/docs_src/_layouts/default.html
+++ b/docs_src/_layouts/default.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <header role="banner">
+  <head>
     <!-- Meta, title, CSS, favicons, etc. -->
-    {% include /header.html %}
-  </header>
+    {% include header.html %}
+  </head>
   <body>
     <div>
       <a id="skippy" class="skip-nav-link sr-only sr-only-focusable" href="#content">

--- a/docs_src/_layouts/home.html
+++ b/docs_src/_layouts/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-us">
   <head>
     <!-- Meta, title, CSS, favicons, etc. -->
     {% include header.html %}


### PR DESCRIPTION
HTML sniffer errors related to title are because it was in the wrong element (header instead of head)