### PR TITLE
fixed typos in the groups documentation

### DIFF
--- a/backstop.json
+++ b/backstop.json
@@ -96,7 +96,7 @@
             "[data-example-id='content-containers-well']",
             "[data-example-id='content-containers-tile']",
             "[data-example-id='content-containers-card']",
-            "[data-example-id='defaut-flex-display']",
+            "[data-example-id='default-flex-display']",
             "[data-example-id='fixed-group-display']",
             "[data-example-id='overflow-group-display']"
         ],

--- a/docs_src/_includes/layouts/groups/group.html
+++ b/docs_src/_includes/layouts/groups/group.html
@@ -1,8 +1,8 @@
-<p>Groups provide unique content grid and grid gutter options and also allow content containers such as card, tile and well various flex display options. Groups are intended to be homogenous rather than mixed.</p>
+<p>Groups provide unique content grid and grid gutter options and also allow content containers such as card, tile and well various and flex display options. Groups are intended to be homogenous rather than mixed.</p>
 
 <h2>Group grid</h2>
-<p>Like our Page Grid, Groups make use of columns for container separation and any gutter spacing requierments. These work in the same manner as the page grid columns and support display variation at the breakpoint level.</p>
-<cdr-card-docs example-title="Grid Colunms changing display at breakpoints" element-id="group-grid">
+<p>Like our Page Grid, Groups make use of columns for container separation and any gutter spacing requirements. These work in the same manner as the page grid columns and support display variation at the breakpoint level.</p>
+<cdr-card-docs example-title="Grid Columns changing display at breakpoints" element-id="group-grid">
     <yield to="example">
         <div class="group group-display-fixed" data-theme="light-20">
             <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
@@ -698,7 +698,7 @@
 </cdr-card-docs>
 
 <h2>Flex display options</h2>
-<cdr-card-docs example-title="Defaut flex display" element-id="defaut-flex-display">
+<cdr-card-docs example-title="Default flex display" element-id="default-flex-display">
     <yield to="example-description">
     <p> Without providing any <code>.group-display-*</code> classes to your Group, you will have a display type that is consistent with the float display provided by the defalt page grid.</p>
     </yield>
@@ -800,7 +800,7 @@
 
 <cdr-card-docs example-title="Overflow group display" element-id="overflow-group-display">
     <yield to="example-description">
-        <p>Overflow changes the wrapping proporty to no wrap and allows for a horizontal scroll. This is available for the fixed or default group-display settings.</p>
+        <p>Overflow changes the wrapping property to no wrap and allows for a horizontal scroll. This is available for the fixed or default group-display settings.</p>
     </yield>
     <yield to="example">
         <div class="group group-display-fixed group-gutter-xs-open-10 group-display-overflow">


### PR DESCRIPTION
Fixed a few typos I found on the groups docs. I'm not sure if changing the `element-id` breaks anything. Looks like it might be something that is referenced elsewhere.