### PR TITLE
Added option to build jekyll docs with docker.

### DIFF
--- a/docs_src/index.html
+++ b/docs_src/index.html
@@ -19,7 +19,7 @@ slug: main
 
                 <p class="version">Implemented by the {{ site.data.package.longName }} v{{ site.data.package.version }}</p>
                 <a href="{{ site.data.package.urls.repo }}" type="button" class="btn btn-primary btn-explore">
-                    View the project on Stash <span class="icon icon-rei-tree-arrow" aria-hidden="true"></span>
+                    View the project on Github <span class="icon icon-rei-tree-arrow" aria-hidden="true"></span>
                 </a>
             </div>
         </div>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -427,7 +427,6 @@ gulp.task( 'docs:less:compile', [ 'docs:clean', 'docs:copy-all' ], () => {
 } );
 
 gulp.task( 'docs:jekyll', [ 'docs:less:compile' ], gulpCallBack => {
-gulp.task( 'docs:jekyll', [ 'docs:less:compile' ], gulpCallBack => {
 
     if ( USE_DOCKER ) {
         console.log('Using docker for jekyll build')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -430,7 +430,7 @@ gulp.task( 'docs:jekyll', [ 'docs:less:compile' ], gulpCallBack => {
 
     if ( USE_DOCKER ) {
         console.log('Using docker for jekyll build')
-        process.exec( `docker run --rm -v "${__dirname}:/data" reicoop/jekyll:3.4.3 build`, (err, stdout, stderr) => {
+        process.exec( `docker run --rm -v "${__dirname}:/data" reicoop/jekyll:2.5.3 build`, (err, stdout, stderr) => {
             console.log(stdout);
         } ).on( 'exit', code => gulpCallBack( code === 0 ? null : 'ERROR: Docker process failed: ' + code ) )
     } else {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -430,7 +430,7 @@ gulp.task( 'docs:jekyll', [ 'docs:less:compile' ], gulpCallBack => {
 
     if ( USE_DOCKER ) {
         console.log('Using docker for jekyll build')
-        process.exec( `docker run --rm -v "${__dirname}:/data" reicoop/jekyll:2.5.3 build`, (err, stdout, stderr) => {
+        process.exec( `docker run --rm -v "${__dirname}:/data" reicoop/jekyll:3.4.3 build`, (err, stdout, stderr) => {
             console.log(stdout);
         } ).on( 'exit', code => gulpCallBack( code === 0 ? null : 'ERROR: Docker process failed: ' + code ) )
     } else {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://rei.github.io/rei-cedar/",
   "scripts": {
     "build": "gulp",
+    "build-docker": "gulp build-docker",
     "build-docs": "gulp docs",
     "accessibility:audit-templates": "gulp accessibility:audit-templates",
     "accessibility:audit-docs": "gulp accessibility:audit-docs",


### PR DESCRIPTION
This adds support to build the Jekyll docs with Docker.  The intent is to make the build a little more portable so that machines don't have to have the ruby/jekyll environment installed.  Could expand this to include npm as well, but starting here.