### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "docs": "vue-styleguidist server",
     "build:docs": "vue-styleguidist build"
   },
-  "dependencies": {
+  "main": "release/cedar.js",
+  "peerDependencies": {
     "vue": "^2.3.4"
   },
   "devDependencies": {
@@ -109,6 +110,7 @@
     "svgxuse": "^1.2.4",
     "tenon-node": "^0.4.0",
     "url-loader": "^0.5.9",
+    "vue": "^2.3.4",
     "vue-loader": "^12.2.1",
     "vue-router": "^2.7.0",
     "vue-style-loader": "^3.0.1",


### PR DESCRIPTION
adding main - we can't use it in our project without this
changing Vue from dependency to peerDependency - prevents us installing two different versions of Vue
adding Vue to devDependencies - lets you all develop with Vue installed