### PR TITLE
fix(list): fix list nesting examples, update css to maintain look

### DIFF
--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -12,11 +12,11 @@ Note: type doesn't affect the modifier.
 <cdr-list>
   <li>List default</li>
   <li>List default</li>
-  <cdr-list>
+  <ul is="cdr-list">
     <li>List default - nested</li>
     <li>List default - nested</li>
     <li>List default - nested</li>
-  </cdr-list>
+  </ul>
 </cdr-list>
 ```
 

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -11,13 +11,12 @@ Note: type doesn't affect the modifier.
 ```
 <cdr-list>
   <li>List default</li>
-  <li>List default
-    <cdr-list>
-      <li>List default - nested</li>
-      <li>List default - nested</li>
-      <li>List default - nested</li>
-    </cdr-list>
-  </li>
+  <li>List default</li>
+  <cdr-list>
+    <li>List default - nested</li>
+    <li>List default - nested</li>
+    <li>List default - nested</li>
+  </cdr-list>
 </cdr-list>
 ```
 

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -11,12 +11,13 @@ Note: type doesn't affect the modifier.
 ```
 <cdr-list>
   <li>List default</li>
-  <li>List default</li>
-  <ul is="cdr-list">
-    <li>List default - nested</li>
-    <li>List default - nested</li>
-    <li>List default - nested</li>
-  </ul>
+  <li>List default
+    <ul is="cdr-list">
+      <li>List default - nested</li>
+      <li>List default - nested</li>
+      <li>List default - nested</li>
+    </ul>
+  </li>
 </cdr-list>
 ```
 

--- a/src/components/list/cdrList.vue
+++ b/src/components/list/cdrList.vue
@@ -17,6 +17,12 @@
 <script>
 import modifier from '../../mixins/modifier';
 
+/**
+ * Note:
+ * Nesting doesn't follow typical html ul/li nesting
+ * @see {@link https://github.com/vuejs/vue/issues/2543} for further details.
+ * @see examples for how to nest.
+ */
 export default {
   name: 'CdrList',
   mixins: [modifier],

--- a/src/components/list/cdrList.vue
+++ b/src/components/list/cdrList.vue
@@ -19,9 +19,8 @@ import modifier from '../../mixins/modifier';
 
 /**
  * Note:
- * Nesting doesn't follow typical html ul/li nesting
- * @see {@link https://github.com/vuejs/vue/issues/2543} for further details.
- * @see examples for how to nest.
+ * Nesting requires using is="cdr-list"
+ * @see {@link https://vuejs.org/v2/guide/components.html#DOM-Template-Parsing-Caveats}
  */
 export default {
   name: 'CdrList',

--- a/src/components/list/examples/demo/Default.vue
+++ b/src/components/list/examples/demo/Default.vue
@@ -22,17 +22,15 @@
     </cdr-list>
 
     <cdr-list>
-      <li>List Nested
-        <cdr-list>
-          <li>List default - nested</li>
-          <li>List default - nested
-            <cdr-list modifier="numbered">
-              <li>List default - nested - numbered</li>
-              <li>List default - nested - numbered</li>
-            </cdr-list>
-          </li>
+      <li>List Nested</li>
+      <cdr-list>
+        <li>List default - nested</li>
+        <li>List default - nested</li>
+        <cdr-list modifier="numbered">
+          <li>List default - nested - numbered</li>
+          <li>List default - nested - numbered</li>
         </cdr-list>
-      </li>
+      </cdr-list>
     </cdr-list>
   </div>
 </template>

--- a/src/components/list/examples/demo/Default.vue
+++ b/src/components/list/examples/demo/Default.vue
@@ -22,15 +22,19 @@
     </cdr-list>
 
     <cdr-list>
-      <li>List Nested</li>
-      <cdr-list>
-        <li>List default - nested</li>
-        <li>List default - nested</li>
-        <cdr-list modifier="numbered">
-          <li>List default - nested - numbered</li>
-          <li>List default - nested - numbered</li>
-        </cdr-list>
-      </cdr-list>
+      <li>List Nested
+        <ul is="cdr-list">
+          <li>List default - nested</li>
+          <li>List default - nested
+            <ul
+              is="cdr-list"
+              modifier="numbered">
+              <li>List default - nested - numbered</li>
+              <li>List default - nested - numbered</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
     </cdr-list>
   </div>
 </template>

--- a/src/components/list/examples/demo/Ordered.vue
+++ b/src/components/list/examples/demo/Ordered.vue
@@ -23,7 +23,7 @@
       <li>List ordered - spread</li>
     </cdr-list>
 
-    <cdr-list list-type="ol">
+    <!-- <cdr-list list-type="ol">
       <li>List ordered Nested</li>
       <cdr-list list-type="ol">
         <li>List ordered - nested</li>
@@ -35,6 +35,25 @@
           <li>List ordered - nested - numbered</li>
         </cdr-list>
       </cdr-list>
+    </cdr-list> -->
+
+    <cdr-list list-type="ol">
+      <li>List ordered Nested
+        <ul
+          is="cdr-list"
+          list-type="ol">
+          <li>List ordered - nested</li>
+          <li>List ordered - nested
+            <ul
+              is="cdr-list"
+              list-type="ol"
+              modifier="numbered">
+              <li>List ordered - nested - numbered</li>
+              <li>List ordered - nested - numbered</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
     </cdr-list>
   </div>
 </template>

--- a/src/components/list/examples/demo/Ordered.vue
+++ b/src/components/list/examples/demo/Ordered.vue
@@ -23,20 +23,6 @@
       <li>List ordered - spread</li>
     </cdr-list>
 
-    <!-- <cdr-list list-type="ol">
-      <li>List ordered Nested</li>
-      <cdr-list list-type="ol">
-        <li>List ordered - nested</li>
-        <li>List ordered - nested</li>
-        <cdr-list
-          list-type="ol"
-          modifier="numbered">
-          <li>List ordered - nested - numbered</li>
-          <li>List ordered - nested - numbered</li>
-        </cdr-list>
-      </cdr-list>
-    </cdr-list> -->
-
     <cdr-list list-type="ol">
       <li>List ordered Nested
         <ul

--- a/src/components/list/examples/demo/Ordered.vue
+++ b/src/components/list/examples/demo/Ordered.vue
@@ -24,19 +24,17 @@
     </cdr-list>
 
     <cdr-list list-type="ol">
-      <li>List ordered Nested
-        <cdr-list list-type="ol">
-          <li>List ordered - nested</li>
-          <li>List ordered - nested
-            <cdr-list
-              list-type="ol"
-              modifier="numbered">
-              <li>List ordered - nested - numbered</li>
-              <li>List ordered - nested - numbered</li>
-            </cdr-list>
-          </li>
+      <li>List ordered Nested</li>
+      <cdr-list list-type="ol">
+        <li>List ordered - nested</li>
+        <li>List ordered - nested</li>
+        <cdr-list
+          list-type="ol"
+          modifier="numbered">
+          <li>List ordered - nested - numbered</li>
+          <li>List ordered - nested - numbered</li>
         </cdr-list>
-      </li>
+      </cdr-list>
     </cdr-list>
   </div>
 </template>

--- a/src/components/list/styles/cdrList.pcss
+++ b/src/components/list/styles/cdrList.pcss
@@ -36,11 +36,8 @@
   /* nesting
     ---------- */
 
-  & > li {
-    & > ul,
-    & > ol {
-      margin-top: $list-nesting-margin-top;
-    }
+  & > & {
+    margin-top: $list-nesting-margin-top;
   }
 
   /* Style variants

--- a/src/components/list/styles/cdrList.pcss
+++ b/src/components/list/styles/cdrList.pcss
@@ -36,8 +36,10 @@
   /* nesting
     ---------- */
 
-  & > & {
-    margin-top: $list-nesting-margin-top;
+  & > li {
+    & > .cdr-list {
+      margin-top: $list-nesting-margin-top;
+    }
   }
 
   /* Style variants


### PR DESCRIPTION
affects: @rei/cdr-list

Although our markup was technically correct, vue actually parses the structure a little differently and has an option for avoiding hoisting to keep proper output.

See https://vuejs.org/v2/guide/components.html#DOM-Template-Parsing-Caveats