### PR TITLE
feat(docs): added route for buttons

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,7 +62,7 @@
       class="cpg-section"
       data-backstop="caption"
     />
-
+    <router-view />
   </div>
 </template>
 

--- a/src/dev.js
+++ b/src/dev.js
@@ -3,6 +3,20 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 import Buttons from 'componentsdir/button/examples/Buttons';
+import Cards from 'componentsdir/card/examples/Cards';
+import ActivityCards from 'compositionsdir/activityCard/examples/activity';
+import CheckBoxes from 'componentsdir/checkbox/examples/checkboxes';
+import Grids from 'componentsdir/grid/examples/Grid';
+import Icons from 'componentsdir/icon/examples/Icons';
+import Images from 'componentsdir/image/examples/Images';
+import Links from 'componentsdir/link/examples/Links';
+import Lists from 'componentsdir/list/examples/Lists';
+import MediaObjects from 'componentsdir/mediaObject/examples/mediaObject';
+import Quotes from 'componentsdir/quote/examples/Quote';
+import Radios from 'componentsdir/radio/examples/Radios';
+import Ratings from 'componentsdir/rating/examples/Ratings';
+import Selects from 'componentsdir/select/examples/Selects';
+import Texts from 'componentsdir/text/examples/Text';
 
 import './css/main.postcss';
 import './cdr-assets/dist/cdr-fonts.min.css';
@@ -15,6 +29,20 @@ Vue.use(VueRouter);
 const routes = [
   { path: '/', component: App },
   { path: '/buttons', component: Buttons },
+  { path: '/cards', component: Cards },
+  { path: '/checkboxes', component: CheckBoxes },
+  { path: '/grids', component: Grids },
+  { path: '/activitycards', component: ActivityCards },
+  { path: '/icons', component: Icons },
+  { path: '/images', component: Images },
+  { path: '/links', component: Links },
+  { path: '/lists', component: Lists },
+  { path: '/mediaobjects', component: MediaObjects },
+  { path: '/quotes', component: Quotes },
+  { path: '/radios', component: Radios },
+  { path: '/ratings', component: Ratings },
+  { path: '/selects', component: Selects },
+  { path: '/texts', component: Texts },
 ];
 
 const router = new VueRouter({ routes });

--- a/src/dev.js
+++ b/src/dev.js
@@ -2,6 +2,7 @@
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue';
 import VueRouter from 'vue-router';
+import Buttons from 'componentsdir/button/examples/Buttons';
 
 import './css/main.postcss';
 import './cdr-assets/dist/cdr-fonts.min.css';
@@ -13,6 +14,7 @@ Vue.use(VueRouter);
 
 const routes = [
   { path: '/', component: App },
+  { path: '/buttons', component: Buttons },
 ];
 
 const router = new VueRouter({ routes });

--- a/src/dev.js
+++ b/src/dev.js
@@ -4,7 +4,6 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 import Buttons from 'componentsdir/button/examples/Buttons';
 import Cards from 'componentsdir/card/examples/Cards';
-import ActivityCards from 'compositionsdir/activityCard/examples/activity';
 import CheckBoxes from 'componentsdir/checkbox/examples/checkboxes';
 import Grids from 'componentsdir/grid/examples/Grid';
 import Icons from 'componentsdir/icon/examples/Icons';
@@ -17,6 +16,10 @@ import Radios from 'componentsdir/radio/examples/Radios';
 import Ratings from 'componentsdir/rating/examples/Ratings';
 import Selects from 'componentsdir/select/examples/Selects';
 import Texts from 'componentsdir/text/examples/Text';
+
+import ActivityCards from 'compositionsdir/activityCard/examples/activity';
+import Captions from 'compositionsdir/caption/examples/Caption';
+import Searches from 'compositionsdir/search/examples/searchbox';
 
 import './css/main.postcss';
 import './cdr-assets/dist/cdr-fonts.min.css';
@@ -32,7 +35,6 @@ const routes = [
   { path: '/cards', component: Cards },
   { path: '/checkboxes', component: CheckBoxes },
   { path: '/grids', component: Grids },
-  { path: '/activitycards', component: ActivityCards },
   { path: '/icons', component: Icons },
   { path: '/images', component: Images },
   { path: '/links', component: Links },
@@ -43,6 +45,10 @@ const routes = [
   { path: '/ratings', component: Ratings },
   { path: '/selects', component: Selects },
   { path: '/texts', component: Texts },
+
+  { path: '/activitycards', component: ActivityCards },
+  { path: '/captions', component: Captions },
+  { path: '/searches', component: Searches },
 ];
 
 const router = new VueRouter({ routes });


### PR DESCRIPTION
in order to enhance testing and documentation, components should be broken
into their own component pages.  This is a minimal change that would not preclude the full front page, but would add the /button routes.  On merge to cedar2, all routes should be added.

component pages:
http://localhost:3000/#/buttons
http://localhost:3000/#/cards
http://localhost:3000/#/checkboxes
http://localhost:3000/#/grids
http://localhost:3000/#/icons
http://localhost:3000/#/images
http://localhost:3000/#/links
http://localhost:3000/#/lists
http://localhost:3000/#/mediaObjects
http://localhost:3000/#/quotes
http://localhost:3000/#/ratings
http://localhost:3000/#/radios
http://localhost:3000/#/selects
http://localhost:3000/#/texts

compositions:
http://localhost:3000/#/activitycards
http://localhost:3000/#/captions
http://localhost:3000/#/searches

Should be compared against the relevant area in http://localhost:3000/#/