### PR TITLE
feat(lerna-semantic-release): replaced standard changelog with lerna-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,63 @@
+<a name="18.6.1"></a>
+## [18.6.1](https://github.com/rei/rei-cedar/compare/v5.0.0-alpha.1...v18.6.1) (2018-06-27)
+
+
+### Bug Fixes
+
+* **cdr-img:** the radius validator did not have the correct values, removing them and updating radiu ([c39066d](https://github.com/rei/rei-cedar/commit/c39066d))
+* **select:** fix bug with selenium interaction ([18fbab3](https://github.com/rei/rei-cedar/commit/18fbab3))
+* **select:** update variable name ([dbdc0e4](https://github.com/rei/rei-cedar/commit/dbdc0e4))
+
+
+### Features
+
+* **breadcrumb:** breadcrumb component is ready for pr ([984a31c](https://github.com/rei/rei-cedar/commit/984a31c))
+* **breadcrumb:** final cleanup after pr comments ([34467e9](https://github.com/rei/rei-cedar/commit/34467e9))
+* **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+* **cedar proving grounds:** loops through all the routes, which have been moved to routes.js, and e ([7cda2b3](https://github.com/rei/rei-cedar/commit/7cda2b3))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **grid:** consolidate col's alignSelf props to single alignSelf ([0058ad0](https://github.com/rei/rei-cedar/commit/0058ad0))
+* **grid:** consolidate col's offsetLeft props to just offsetLeft ([ecc3294](https://github.com/rei/rei-cedar/commit/ecc3294))
+* **grid:** consolidate col's offsetRight props to single offsetRight ([b812e99](https://github.com/rei/rei-cedar/commit/b812e99))
+* **grid:** consolidate col's span props to just span ([a3ef361](https://github.com/rei/rei-cedar/commit/a3ef361))
+* **grid:** move col and row to single package ([b0469b6](https://github.com/rei/rei-cedar/commit/b0469b6))
+* **grid:** update align prop to accept responsive values ([1907de8](https://github.com/rei/rei-cedar/commit/1907de8))
+* **grid:** update col and justify props to accept responsive values ([c572a51](https://github.com/rei/rei-cedar/commit/c572a51))
+* **grid:** update gutter prop to accept responsive values ([a3f613f](https://github.com/rei/rei-cedar/commit/a3f613f))
+* **grid:** update row's nowrap prop to accept responsive values ([6dd3514](https://github.com/rei/rei-cedar/commit/6dd3514))
+* **grid:** update vertical prop to be a string and accept responsive values ([008f05b](https://github.com/rei/rei-cedar/commit/008f05b))
+* **grid:** update wrap prop to be a string and accept responsive values ([cfe2d8a](https://github.com/rei/rei-cedar/commit/cfe2d8a))
+* **link:** use css modules for link ([6b244d2](https://github.com/rei/rei-cedar/commit/6b244d2))
+* **link:** use css modules with link ([bfb98f9](https://github.com/rei/rei-cedar/commit/bfb98f9))
+* **proving grounds:** removes cruft ([ae8c943](https://github.com/rei/rei-cedar/commit/ae8c943))
+* **tokens:** consume [@rei](https://github.com/rei)/cdr-tokens package ([f094978](https://github.com/rei/rei-cedar/commit/f094978))
+
+
+### BREAKING CHANGES
+
+* **grid:** alignSelfSm, alignSelfMd, alignSelfLg consolidated to just alignSelf that accepts responsive
+modifiers
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **grid:** offsetLeftSm, offsetLeftMd, offsetLeftLg consolidated to just offsetLeft that accepts responsive
+modifiers
+* **grid:** spanSm, spanMd, spanLg removed and span accepts responsive modifiers
+* **grid:** change row's nowrap prop from boolean to string. Remove nowrapSm, nowrapMd, nowrapLg in favor of
+using nowrap with responsive modifiers
+* **grid:** remove wrapSm, wrapMd, wrapLg in favor of using wrap with responsive modifiers
+* **grid:** vertical prop is now a string instead of boolean. verticalSm, verticalMd, verticalLg removed and now
+supports responsive modifiers
+* **grid:** offsetRightSm, offsetRightMd, offsetRightLg consolidated to just offsetRight that accepts responsive modifiers
+* **grid:** alignSm, alignMd, alignLg replaced with just align that accepts responsive values
+* **grid:** colsSm, colsMd, colsLg replaced with just cols prop. justifySm, justifyMd, justifyLg replaced with
+just justify prop
+* **buttons:** Buttons use css modules
+* **grid:** grid css is no longer in cdr-assets, col and row are no longer their own packages
+* **link:** link uses css modules
+* **link:** link now uses css modules
+* **grid:** gutterSm, gutterMd, gutterLg replaced with just gutter
+
+
+
 <a name="5.0.0-0"></a>
 # [5.0.0-0](https://github.com/rei/rei-cedar/compare/v4.3.4-0...v5.0.0-0) (2018-01-29)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rei-cedar",
-  "version": "5.0.0-0",
+  "version": "18.06.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -379,6 +379,80 @@
         "conventional-changelog": "0.0.17"
       }
     },
+    "@semantic-release/condition-travis": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/condition-travis/-/condition-travis-5.0.2.tgz",
+      "integrity": "sha1-9Lt3emxttVZdcHVKm2KSM71KZZc=",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "1.0.0",
+        "semver": "5.5.0",
+        "travis-deploy-once": "1.0.0-node-0.10-support"
+      }
+    },
+    "@semantic-release/error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-1.0.0.tgz",
+      "integrity": "sha1-u4+O7t1cf4xG+Ws37znhuMN2wcw=",
+      "dev": true
+    },
+    "@semantic-release/last-release-npm": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/last-release-npm/-/last-release-npm-1.2.1.tgz",
+      "integrity": "sha1-/3SBQuzxU1S4M6hroYIF9/zllO4=",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "1.0.0",
+        "npm-registry-client": "7.5.0",
+        "npmlog": "1.2.1"
+      },
+      "dependencies": {
+        "are-we-there-yet": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+          "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+          "dev": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "gauge": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+          "dev": true,
+          "requires": {
+            "ansi": "0.3.1",
+            "has-unicode": "2.0.1",
+            "lodash.pad": "4.5.1",
+            "lodash.padend": "4.6.1",
+            "lodash.padstart": "4.6.1"
+          }
+        },
+        "npmlog": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+          "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+          "dev": true,
+          "requires": {
+            "ansi": "0.3.1",
+            "are-we-there-yet": "1.0.6",
+            "gauge": "1.2.7"
+          }
+        }
+      }
+    },
+    "@semantic-release/release-notes-generator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-2.0.0.tgz",
+      "integrity": "sha1-fF2mVolGbVNqU/36n01io70TwW4=",
+      "dev": true,
+      "requires": {
+        "conventional-changelog": "0.0.17",
+        "github-url-from-git": "1.5.0"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -715,6 +789,12 @@
           "optional": true
         }
       }
+    },
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -2196,7 +2276,6 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
       "dev": true,
-      "optional": true,
       "requires": {
         "readable-stream": "2.0.6"
       },
@@ -2205,15 +2284,13 @@
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "readable-stream": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
-          "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -2227,8 +2304,7 @@
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3340,6 +3416,16 @@
         "typedarray": "0.0.6"
       }
     },
+    "config-chain": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
+      }
+    },
     "connect": {
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -4150,7 +4236,6 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
-      "optional": true,
       "requires": {
         "boom": "2.10.1"
       }
@@ -4913,6 +4998,16 @@
       "requires": {
         "address": "1.0.3",
         "debug": "2.6.9"
+      }
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6",
+        "wrappy": "1.0.2"
       }
     },
     "di": {
@@ -6850,6 +6945,12 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
+    "foreachasync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -7688,15 +7789,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-property": "1.0.2"
       }
@@ -7943,6 +8042,15 @@
         "assert-plus": "1.0.0"
       }
     },
+    "git-head": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/git-head/-/git-head-1.14.0.tgz",
+      "integrity": "sha1-vjHBB/uEAgmFYSUO8enYiELDkbg=",
+      "dev": true,
+      "requires": {
+        "git-refs": "1.1.3"
+      }
+    },
     "git-raw-commits": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
@@ -7954,6 +8062,17 @@
         "meow": "4.0.0",
         "split2": "2.2.0",
         "through2": "2.0.3"
+      }
+    },
+    "git-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/git-refs/-/git-refs-1.1.3.tgz",
+      "integrity": "sha1-gwl8s6klhcSkkm7FTiGC354g6J0=",
+      "dev": true,
+      "requires": {
+        "path-object": "2.3.0",
+        "slash": "1.0.0",
+        "walk": "2.3.13"
       }
     },
     "git-remote-origin-url": {
@@ -7991,6 +8110,57 @@
       "dev": true,
       "requires": {
         "ini": "1.3.5"
+      }
+    },
+    "github": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/github/-/github-8.2.1.tgz",
+      "integrity": "sha1-YWsiEfvNHMhjFmmu1nZT5i61OBY=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "0.0.7",
+        "https-proxy-agent": "1.0.0",
+        "mime": "1.6.0",
+        "netrc": "0.1.4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "follow-redirects": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+          "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "stream-consume": "0.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
       }
     },
     "github-slugger": {
@@ -8431,7 +8601,6 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
@@ -9491,15 +9660,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-my-json-valid": {
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
@@ -9612,8 +9779,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -10315,8 +10481,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -10873,6 +11038,402 @@
         }
       }
     },
+    "lerna-semantic-release": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/lerna-semantic-release/-/lerna-semantic-release-9.1.0.tgz",
+      "integrity": "sha1-vJLd04b3mSpOV3UccPqYK9XCxQs=",
+      "dev": true,
+      "requires": {
+        "lerna-semantic-release-io": "7.0.2",
+        "lerna-semantic-release-perform": "4.1.0",
+        "lerna-semantic-release-post": "6.0.0",
+        "lerna-semantic-release-pre": "4.1.1",
+        "lerna-semantic-release-utils": "4.0.15",
+        "meow": "3.7.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        },
+        "meow": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+          "dev": true,
+          "requires": {
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+          "dev": true
+        }
+      }
+    },
+    "lerna-semantic-release-analyze-commits": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lerna-semantic-release-analyze-commits/-/lerna-semantic-release-analyze-commits-4.2.1.tgz",
+      "integrity": "sha1-FjU1Feujq430VOhWLQ0FiVDzzHk=",
+      "dev": true,
+      "requires": {
+        "@semantic-release/commit-analyzer": "2.0.0",
+        "lerna-semantic-release-utils": "4.0.15"
+      }
+    },
+    "lerna-semantic-release-get-last-release": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/lerna-semantic-release-get-last-release/-/lerna-semantic-release-get-last-release-5.0.13.tgz",
+      "integrity": "sha1-AkFuT48RkRw3TrKyZPSKyNWNJFg=",
+      "dev": true,
+      "requires": {
+        "lerna-semantic-release-utils": "4.0.15"
+      }
+    },
+    "lerna-semantic-release-io": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/lerna-semantic-release-io/-/lerna-semantic-release-io-7.0.2.tgz",
+      "integrity": "sha1-71pNTiLnjhzposjZXTMZHk9ZLro=",
+      "dev": true,
+      "requires": {
+        "@semantic-release/last-release-npm": "1.2.1",
+        "git-head": "1.14.0",
+        "lerna-semantic-release-analyze-commits": "4.2.1",
+        "lerna-semantic-release-get-last-release": "5.0.13",
+        "lerna-semantic-release-utils": "4.0.15",
+        "mock-fs": "3.11.0",
+        "mockery": "1.7.0",
+        "semantic-release": "6.3.6",
+        "shelljs": "0.7.0",
+        "simple-git": "1.48.0",
+        "sinon": "1.17.7"
+      },
+      "dependencies": {
+        "sinon": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+          "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+          "dev": true,
+          "requires": {
+            "formatio": "1.1.1",
+            "lolex": "1.3.2",
+            "samsam": "1.1.2",
+            "util": "0.10.3"
+          }
+        }
+      }
+    },
+    "lerna-semantic-release-perform": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lerna-semantic-release-perform/-/lerna-semantic-release-perform-4.1.0.tgz",
+      "integrity": "sha1-OnD/Mo9kSbXYCT1god8+6GGWHr0=",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1",
+        "lerna-semantic-release-io": "7.0.2",
+        "lerna-semantic-release-utils": "4.0.15"
+      }
+    },
+    "lerna-semantic-release-post": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lerna-semantic-release-post/-/lerna-semantic-release-post-6.0.0.tgz",
+      "integrity": "sha1-qkdDci2QRbvAUBeRAFYwsiLIjDs=",
+      "dev": true,
+      "requires": {
+        "conventional-changelog": "1.1.24",
+        "dateformat": "1.0.11",
+        "lerna-semantic-release-analyze-commits": "4.2.1",
+        "lerna-semantic-release-io": "7.0.2",
+        "lerna-semantic-release-utils": "4.0.15"
+      },
+      "dependencies": {
+        "conventional-changelog": {
+          "version": "1.1.24",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
+          "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
+          "dev": true,
+          "requires": {
+            "conventional-changelog-angular": "1.6.6",
+            "conventional-changelog-atom": "0.2.8",
+            "conventional-changelog-codemirror": "0.3.8",
+            "conventional-changelog-core": "2.0.11",
+            "conventional-changelog-ember": "0.3.12",
+            "conventional-changelog-eslint": "1.0.9",
+            "conventional-changelog-express": "0.3.6",
+            "conventional-changelog-jquery": "0.1.0",
+            "conventional-changelog-jscs": "0.1.0",
+            "conventional-changelog-jshint": "0.3.8",
+            "conventional-changelog-preset-loader": "1.1.8"
+          }
+        }
+      }
+    },
+    "lerna-semantic-release-pre": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lerna-semantic-release-pre/-/lerna-semantic-release-pre-4.1.1.tgz",
+      "integrity": "sha1-nOipBxsm8yqmlJhiD+fcNyWNr4Y=",
+      "dev": true,
+      "requires": {
+        "async": "2.0.1",
+        "lerna-semantic-release-io": "6.0.1",
+        "lerna-semantic-release-utils": "4.0.15",
+        "npmconf": "2.1.3",
+        "rc": "1.1.7",
+        "semantic-release": "6.3.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.10"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true
+        },
+        "lerna-semantic-release-io": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/lerna-semantic-release-io/-/lerna-semantic-release-io-6.0.1.tgz",
+          "integrity": "sha1-VjnplXiV6zXf9SKeb8B7kBdazdY=",
+          "dev": true,
+          "requires": {
+            "@semantic-release/last-release-npm": "1.2.1",
+            "git-head": "1.14.0",
+            "lerna-semantic-release-analyze-commits": "4.2.1",
+            "lerna-semantic-release-get-last-release": "5.0.13",
+            "lerna-semantic-release-utils": "4.0.15",
+            "mock-fs": "3.11.0",
+            "mockery": "1.7.0",
+            "semantic-release": "6.3.6",
+            "shelljs": "0.7.0",
+            "simple-git": "1.48.0",
+            "sinon": "1.17.7"
+          }
+        },
+        "rc": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+          "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
+          "dev": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          }
+        },
+        "sinon": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+          "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+          "dev": true,
+          "requires": {
+            "formatio": "1.1.1",
+            "lolex": "1.3.2",
+            "samsam": "1.1.2",
+            "util": "0.10.3"
+          }
+        }
+      }
+    },
+    "lerna-semantic-release-utils": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/lerna-semantic-release-utils/-/lerna-semantic-release-utils-4.0.15.tgz",
+      "integrity": "sha1-V/qbbTDfRB4gsgRTXsgodnlvSGk=",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1",
+        "shelljs": "0.7.0",
+        "winston": "2.4.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "winston": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
+          "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
+          "dev": true,
+          "requires": {
+            "async": "1.0.0",
+            "colors": "1.0.3",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "stack-trace": "0.0.10"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+              "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -11112,6 +11673,17 @@
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "dev": true
     },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
+    },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
@@ -11263,6 +11835,24 @@
       "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
+    "lodash.pad": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+      "dev": true
+    },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+      "dev": true
+    },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
@@ -11273,6 +11863,12 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.5.tgz",
       "integrity": "sha1-lU73UEkmIDjJbR/Jiyj9r58Hcqo=",
+      "dev": true
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.snakecase": {
@@ -12546,6 +13142,30 @@
         }
       }
     },
+    "mock-fs": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-3.11.0.tgz",
+      "integrity": "sha1-CW8h3+mFGJoKbvxLOM60BO6OiRE=",
+      "dev": true,
+      "requires": {
+        "rewire": "2.5.2",
+        "semver": "5.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk=",
+          "dev": true
+        }
+      }
+    },
+    "mockery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8=",
+      "dev": true
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -12645,10 +13265,22 @@
       "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
       "dev": true
     },
+    "nerf-dart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+      "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+      "dev": true
+    },
     "netmask": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+      "dev": true
+    },
+    "netrc": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
+      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
       "dev": true
     },
     "next-tick": {
@@ -13100,6 +13732,34 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-package-arg": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.1.tgz",
+      "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.6.0",
+        "semver": "5.5.0"
+      }
+    },
+    "npm-registry-client": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.5.0.tgz",
+      "integrity": "sha1-D23W5dEUJM+pn85bkw/q8JtPfwQ=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "graceful-fs": "4.1.11",
+        "normalize-package-data": "2.4.0",
+        "npm-package-arg": "4.2.1",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "request": "2.87.0",
+        "retry": "0.10.1",
+        "semver": "5.5.0",
+        "slide": "1.1.6"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -13107,6 +13767,41 @@
       "dev": true,
       "requires": {
         "path-key": "2.0.1"
+      }
+    },
+    "npmconf": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.3.tgz",
+      "integrity": "sha512-iTK+HI68GceCoGOHAQiJ/ik1iDfI7S+cgyG8A+PP18IU3X83kRhQIRhAUNj4Bp2JMx6Zrt5kCiozYa9uGWTjhA==",
+      "dev": true,
+      "requires": {
+        "config-chain": "1.1.11",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.3.3",
+        "osenv": "0.1.5",
+        "safe-buffer": "5.1.2",
+        "semver": "4.3.6",
+        "uid-number": "0.0.5"
+      },
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        }
       }
     },
     "npmlog": {
@@ -16412,6 +17107,16 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -16734,6 +17439,29 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
+    },
+    "path-object": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/path-object/-/path-object-2.3.0.tgz",
+      "integrity": "sha1-A+RmU+XDdcYK8cq92UvGRIpdkRA=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "lodash.assign": "3.2.0"
+      },
+      "dependencies": {
+        "lodash.assign": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+          "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+          "dev": true,
+          "requires": {
+            "lodash._baseassign": "3.2.0",
+            "lodash._createassigner": "3.1.1",
+            "lodash.keys": "3.1.2"
+          }
+        }
+      }
     },
     "path-parse": {
       "version": "1.0.5",
@@ -19764,6 +20492,12 @@
         "object-assign": "4.1.1"
       }
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
@@ -20789,6 +21523,18 @@
         "throttleit": "1.0.0"
       }
     },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      }
+    },
     "request-promise-core": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
@@ -20838,6 +21584,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
     },
     "require-uncached": {
@@ -20954,6 +21706,18 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "dev": true
+    },
+    "rewire": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz",
+      "integrity": "sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=",
+      "dev": true
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -20997,6 +21761,15 @@
         "is-promise": "2.1.0"
       }
     },
+    "run-auto": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/run-auto/-/run-auto-2.0.3.tgz",
+      "integrity": "sha512-kmEkpcJFly4+IWOG9BvwroclzdYUKFSoi92h1FVK41zat+38epu8xjqBDz9eC0sWbPnB3ONYDbtTMnQeNdYhAw==",
+      "dev": true,
+      "requires": {
+        "dezalgo": "1.0.3"
+      }
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -21005,6 +21778,12 @@
       "requires": {
         "aproba": "1.2.0"
       }
+    },
+    "run-series": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
+      "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg==",
+      "dev": true
     },
     "rx": {
       "version": "4.1.0",
@@ -21105,6 +21884,44 @@
       "dev": true,
       "requires": {
         "node-forge": "0.7.5"
+      }
+    },
+    "semantic-release": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-6.3.6.tgz",
+      "integrity": "sha1-Yp0K7JCziilXpXpKnuEhSvUZKMc=",
+      "dev": true,
+      "requires": {
+        "@semantic-release/commit-analyzer": "2.0.0",
+        "@semantic-release/condition-travis": "5.0.2",
+        "@semantic-release/error": "1.0.0",
+        "@semantic-release/last-release-npm": "1.2.1",
+        "@semantic-release/release-notes-generator": "2.0.0",
+        "git-head": "1.14.0",
+        "github": "8.2.1",
+        "lodash": "4.17.10",
+        "nerf-dart": "1.0.0",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npmconf": "2.1.3",
+        "npmlog": "4.1.2",
+        "parse-github-repo-url": "1.4.1",
+        "require-relative": "0.8.7",
+        "run-auto": "2.0.3",
+        "run-series": "1.1.8",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9",
+            "osenv": "0.1.5"
+          }
+        }
       }
     },
     "semver": {
@@ -21285,6 +22102,12 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "simple-git": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.48.0.tgz",
+      "integrity": "sha1-YhmzpupdMOOXIQ9F8moc1OxVt5k=",
+      "dev": true
+    },
     "sinon": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.10.tgz",
@@ -21352,6 +22175,12 @@
           "dev": true
         }
       }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
     },
     "smart-buffer": {
       "version": "1.1.15",
@@ -21487,7 +22316,6 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -21951,6 +22779,12 @@
         "array-back": "1.0.4"
       }
     },
+    "stream-consume": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
+      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+      "dev": true
+    },
     "stream-each": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
@@ -22099,8 +22933,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -23075,6 +23908,169 @@
         }
       }
     },
+    "travis-ci": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/travis-ci/-/travis-ci-2.1.1.tgz",
+      "integrity": "sha1-mGliZa+CeuNXbzGqBth250tLCC4=",
+      "dev": true,
+      "requires": {
+        "github": "0.1.16",
+        "lodash": "1.3.1",
+        "request": "2.74.0",
+        "underscore.string": "2.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "form-data": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+          "dev": true,
+          "requires": {
+            "async": "2.6.1",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "github": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/github/-/github-0.1.16.tgz",
+          "integrity": "sha1-iV0qhbD+t5gNiawM5PRNyqA/F7U=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.17.2",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
+          }
+        },
+        "lodash": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+          "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.74.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.1",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.3",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        }
+      }
+    },
+    "travis-deploy-once": {
+      "version": "1.0.0-node-0.10-support",
+      "resolved": "https://registry.npmjs.org/travis-deploy-once/-/travis-deploy-once-1.0.0-node-0.10-support.tgz",
+      "integrity": "sha1-mOzOfZWy9Lpdze7r9Uud+HcT1eY=",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "6.26.0",
+        "bluebird": "3.5.1",
+        "request": "2.87.0",
+        "request-promise": "4.2.2",
+        "travis-ci": "2.1.1"
+      }
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -23295,6 +24291,12 @@
         }
       }
     },
+    "uid-number": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4=",
+      "dev": true
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -23323,6 +24325,12 @@
           "dev": true
         }
       }
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
     },
     "unherit": {
       "version": "1.1.1",
@@ -24404,6 +25412,15 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "0.1.2"
+      }
+    },
+    "walk": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.13.tgz",
+      "integrity": "sha512-78SMe7To9U7kqVhSoGho3GfspA089ZDBIj2f8jElg2hi6lUCoagtDJ8sSMFNlpAh5Ib8Jt1gQ6Y7gh9mzHtFng==",
+      "dev": true,
+      "requires": {
+        "foreachasync": "3.0.0"
       }
     },
     "walk-back": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rei-cedar",
-  "version": "5.0.0-0",
+  "version": "18.06.1",
   "description": "REI Cedar Style Framework",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "bootstrap": "lerna bootstrap",
     "start": "lerna bootstrap && lerna run build",
     "vue:build": "npm run vue:docs && npm run vue:archive && npm run vue:transfer",
-    "changelog": "standard-changelog"
+    "changelog": "lerna-semantic-release post"
   },
   "devDependencies": {
     "@commitlint/cli": "^6.1.0",
@@ -86,6 +86,7 @@
     "karma-spec-reporter": "^0.0.32",
     "klaw-sync": "^4.0.0",
     "lerna": "^2.10.1",
+    "lerna-semantic-release": "^9.1.0",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",
@@ -125,7 +126,6 @@
     "semver": "^5.5.0",
     "semver-diff": "^2.1.0",
     "sinon": "^5.0.7",
-    "standard-changelog": "^1.0.12",
     "style-loader": "^0.21.0",
     "stylelint": "^9.2.0",
     "stylelint-config-standard": "^18.1.0",

--- a/src/cdr-assets/CHANGELOG.md
+++ b/src/cdr-assets/CHANGELOG.md
@@ -1,0 +1,31 @@
+<a name="0.2.0"></a>
+# 0.2.0 (2018-06-27)
+
+
+### Bug Fixes
+
+* **assets:** fix async race condition in icon asset build ([4934639](https://github.com/rei/rei-cedar/commit/4934639))
+* **grid:** remove margin bottom from row ([0f68118](https://github.com/rei/rei-cedar/commit/0f68118))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **assets:** remove icons from assets ([c402676](https://github.com/rei/rei-cedar/commit/c402676))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **fonts:** remove several font weights and styles ([36f21d8](https://github.com/rei/rei-cedar/commit/36f21d8))
+* **icon:** generate new sprite, externalize icon.json ([f49f828](https://github.com/rei/rei-cedar/commit/f49f828))
+* **tokens:** output token file for cdr-assets ([717836f](https://github.com/rei/rei-cedar/commit/717836f))
+
+
+### BREAKING CHANGES
+
+* **assets:** icon assets are removed from cdr-assets and are now in cdr-icon
+* **grid:** row no longer has a margin-bottom so no styles bleed
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/breadcrumb/CHANGELOG.md
+++ b/src/components/breadcrumb/CHANGELOG.md
@@ -1,0 +1,11 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Features
+
+* **breadcrumb:** breadcrumb component is ready for pr ([984a31c](https://github.com/rei/rei-cedar/commit/984a31c))
+* **breadcrumb:** final cleanup after pr comments ([34467e9](https://github.com/rei/rei-cedar/commit/34467e9))
+
+
+

--- a/src/components/button/CHANGELOG.md
+++ b/src/components/button/CHANGELOG.md
@@ -1,0 +1,31 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **buttons:** Buttons use css modules
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/card/CHANGELOG.md
+++ b/src/components/card/CHANGELOG.md
@@ -1,0 +1,29 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/checkbox/CHANGELOG.md
+++ b/src/components/checkbox/CHANGELOG.md
@@ -1,0 +1,33 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **checkbox:** add custom label class ([7012f33](https://github.com/rei/rei-cedar/commit/7012f33))
+* **checkbox:** add custom label class ([d8882b8](https://github.com/rei/rei-cedar/commit/d8882b8))
+* **checkbox radio:** update checkbox and radio to design spec ([30a5ef0](https://github.com/rei/rei-cedar/commit/30a5ef0))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **checkbox radio:** box model sizing changes
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/cta/CHANGELOG.md
+++ b/src/components/cta/CHANGELOG.md
@@ -1,0 +1,15 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Features
+
+* **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+
+
+### BREAKING CHANGES
+
+* **buttons:** Buttons use css modules
+
+
+

--- a/src/components/grid/CHANGELOG.md
+++ b/src/components/grid/CHANGELOG.md
@@ -1,0 +1,40 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Features
+
+* **grid:** consolidate col's alignSelf props to single alignSelf ([0058ad0](https://github.com/rei/rei-cedar/commit/0058ad0))
+* **grid:** consolidate col's offsetLeft props to just offsetLeft ([ecc3294](https://github.com/rei/rei-cedar/commit/ecc3294))
+* **grid:** consolidate col's offsetRight props to single offsetRight ([b812e99](https://github.com/rei/rei-cedar/commit/b812e99))
+* **grid:** consolidate col's span props to just span ([a3ef361](https://github.com/rei/rei-cedar/commit/a3ef361))
+* **grid:** move col and row to single package ([b0469b6](https://github.com/rei/rei-cedar/commit/b0469b6))
+* **grid:** update align prop to accept responsive values ([1907de8](https://github.com/rei/rei-cedar/commit/1907de8))
+* **grid:** update col and justify props to accept responsive values ([c572a51](https://github.com/rei/rei-cedar/commit/c572a51))
+* **grid:** update gutter prop to accept responsive values ([a3f613f](https://github.com/rei/rei-cedar/commit/a3f613f))
+* **grid:** update row's nowrap prop to accept responsive values ([6dd3514](https://github.com/rei/rei-cedar/commit/6dd3514))
+* **grid:** update vertical prop to be a string and accept responsive values ([008f05b](https://github.com/rei/rei-cedar/commit/008f05b))
+* **grid:** update wrap prop to be a string and accept responsive values ([cfe2d8a](https://github.com/rei/rei-cedar/commit/cfe2d8a))
+
+
+### BREAKING CHANGES
+
+* **grid:** alignSelfSm, alignSelfMd, alignSelfLg consolidated to just alignSelf that accepts responsive
+modifiers
+* **grid:** grid css is no longer in cdr-assets, col and row are no longer their own packages
+* **grid:** offsetLeftSm, offsetLeftMd, offsetLeftLg consolidated to just offsetLeft that accepts responsive
+modifiers
+* **grid:** spanSm, spanMd, spanLg removed and span accepts responsive modifiers
+* **grid:** change row's nowrap prop from boolean to string. Remove nowrapSm, nowrapMd, nowrapLg in favor of
+using nowrap with responsive modifiers
+* **grid:** offsetRightSm, offsetRightMd, offsetRightLg consolidated to just offsetRight that accepts responsive modifiers
+* **grid:** vertical prop is now a string instead of boolean. verticalSm, verticalMd, verticalLg removed and now
+supports responsive modifiers
+* **grid:** gutterSm, gutterMd, gutterLg replaced with just gutter
+* **grid:** alignSm, alignMd, alignLg replaced with just align that accepts responsive values
+* **grid:** colsSm, colsMd, colsLg replaced with just cols prop. justifySm, justifyMd, justifyLg replaced with
+just justify prop
+* **grid:** remove wrapSm, wrapMd, wrapLg in favor of using wrap with responsive modifiers
+
+
+

--- a/src/components/icon/CHANGELOG.md
+++ b/src/components/icon/CHANGELOG.md
@@ -1,0 +1,37 @@
+<a name="0.2.0"></a>
+# 0.2.0 (2018-06-27)
+
+
+### Bug Fixes
+
+* **icon:** prevent flex icon shrinking ([851a078](https://github.com/rei/rei-cedar/commit/851a078))
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **icon:** generate new sprite, externalize icon.json ([f49f828](https://github.com/rei/rei-cedar/commit/f49f828))
+* **icons:** gernerate icon components ([dcefd4e](https://github.com/rei/rei-cedar/commit/dcefd4e))
+* **link-component:** simplifies link component props, adds prop to Icon for fill color inheritance ([9d404f4](https://github.com/rei/rei-cedar/commit/9d404f4))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **icons:** cdr-icon is now used as a lower level component for the icon components. A complete rewrite with no
+backwards compatibility.
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/iconOnlyButton/CHANGELOG.md
+++ b/src/components/iconOnlyButton/CHANGELOG.md
@@ -1,0 +1,15 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Features
+
+* **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+
+
+### BREAKING CHANGES
+
+* **buttons:** Buttons use css modules
+
+
+

--- a/src/components/image/CHANGELOG.md
+++ b/src/components/image/CHANGELOG.md
@@ -1,0 +1,35 @@
+<a name="1.0.0-next.alpha.0"></a>
+# 1.0.0-next.alpha.0 (2018-06-27)
+
+
+### Bug Fixes
+
+* **cdr-img:** the radius validator did not have the correct values, removing them and updating radiu ([c39066d](https://github.com/rei/rei-cedar/commit/c39066d))
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **cdr-image:** these updates bring the cdr-image component inline with the v1 requierments for ima ([c94c636](https://github.com/rei/rei-cedar/commit/c94c636))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/input/CHANGELOG.md
+++ b/src/components/input/CHANGELOG.md
@@ -1,0 +1,31 @@
+<a name="0.1.2"></a>
+## 0.1.2 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **input:** add keydown event ([3c476b3](https://github.com/rei/rei-cedar/commit/3c476b3))
+* **input:** return event along with value in input event ([975fcc4](https://github.com/rei/rei-cedar/commit/975fcc4))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/link/CHANGELOG.md
+++ b/src/components/link/CHANGELOG.md
@@ -1,0 +1,21 @@
+<a name="1.0.0-next.beta.0"></a>
+# 1.0.0-next.beta.0 (2018-06-27)
+
+
+### Features
+
+* **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **link:** use css modules for link ([6b244d2](https://github.com/rei/rei-cedar/commit/6b244d2))
+* **link:** use css modules with link ([bfb98f9](https://github.com/rei/rei-cedar/commit/bfb98f9))
+* **link-component:** simplifies link component props, adds prop to Icon for fill color inheritance ([9d404f4](https://github.com/rei/rei-cedar/commit/9d404f4))
+
+
+### BREAKING CHANGES
+
+* **buttons:** Buttons use css modules
+* **link:** link uses css modules
+* **link:** link now uses css modules
+
+
+

--- a/src/components/list/CHANGELOG.md
+++ b/src/components/list/CHANGELOG.md
@@ -1,0 +1,31 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **component:** cdr-list component updated to match v1 candidate spec ([e5ccef4](https://github.com/rei/rei-cedar/commit/e5ccef4))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **component:** List
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/mediaObject/CHANGELOG.md
+++ b/src/components/mediaObject/CHANGELOG.md
@@ -1,0 +1,30 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **cdr-image:** these updates bring the cdr-image component inline with the v1 requierments for ima ([c94c636](https://github.com/rei/rei-cedar/commit/c94c636))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/quote/CHANGELOG.md
+++ b/src/components/quote/CHANGELOG.md
@@ -1,0 +1,29 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Bug Fixes
+
+* **css:** the token value for the default paragraph where incorrect ([d05e512](https://github.com/rei/rei-cedar/commit/d05e512))
+* **format:** format update ([3c2cc3b](https://github.com/rei/rei-cedar/commit/3c2cc3b))
+* **regression:** the format was incorrect on the backstop file for quote ([b1b8c9d](https://github.com/rei/rei-cedar/commit/b1b8c9d))
+
+
+### Features
+
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+* **component:** adding an additional slot to the quote elemement as it is valid markup to nest bloc ([4155192](https://github.com/rei/rei-cedar/commit/4155192))
+* **component:** the cdr-quote component allows for block and pull quotes. spacing, inset, and break ([2c30b1a](https://github.com/rei/rei-cedar/commit/2c30b1a))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+
+
+### BREAKING CHANGES
+
+* **buttons:** Buttons use css modules
+* **components:** Components are now using css-modules for unique class names tied to the package version
+
+
+

--- a/src/components/radio/CHANGELOG.md
+++ b/src/components/radio/CHANGELOG.md
@@ -1,0 +1,31 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **checkbox radio:** update checkbox and radio to design spec ([30a5ef0](https://github.com/rei/rei-cedar/commit/30a5ef0))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **checkbox radio:** box model sizing changes
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/rating/CHANGELOG.md
+++ b/src/components/rating/CHANGELOG.md
@@ -1,0 +1,34 @@
+<a name="0.1.1"></a>
+## 0.1.1 (2018-06-27)
+
+
+### Bug Fixes
+
+* **rating:** fix rounded rating display ([0e461e4](https://github.com/rei/rei-cedar/commit/0e461e4))
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/select/CHANGELOG.md
+++ b/src/components/select/CHANGELOG.md
@@ -1,0 +1,35 @@
+<a name="0.1.1"></a>
+## 0.1.1 (2018-06-27)
+
+
+### Bug Fixes
+
+* **select:** fix bug with selenium interaction ([18fbab3](https://github.com/rei/rei-cedar/commit/18fbab3))
+* **select:** update variable name ([dbdc0e4](https://github.com/rei/rei-cedar/commit/dbdc0e4))
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/components/text/CHANGELOG.md
+++ b/src/components/text/CHANGELOG.md
@@ -1,0 +1,24 @@
+<a name="1.0.0"></a>
+# 1.0.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **template:** the cdr-text component has been updated with the following two variants:  default pa ([f23e61f](https://github.com/rei/rei-cedar/commit/f23e61f))
+* **text:** add text component ([bb481c5](https://github.com/rei/rei-cedar/commit/bb481c5))
+
+
+### BREAKING CHANGES
+
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+
+
+

--- a/src/compositions/activityCard/CHANGELOG.md
+++ b/src/compositions/activityCard/CHANGELOG.md
@@ -1,0 +1,32 @@
+<a name="0.1.1"></a>
+## 0.1.1 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **activity-card:** publish new plugin build ([2fb19e3](https://github.com/rei/rei-cedar/commit/2fb19e3))
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **docs:** added compositions routes ([a3a0f81](https://github.com/rei/rei-cedar/commit/a3a0f81))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **activity-card:** activity-card no longer is a plugin by default
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+

--- a/src/compositions/caption/CHANGELOG.md
+++ b/src/compositions/caption/CHANGELOG.md
@@ -1,0 +1,30 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **caption:** clean up caption composition ([d88bfa5](https://github.com/rei/rei-cedar/commit/d88bfa5))
+* **component:** the cdr-quote component allows for block and pull quotes. spacing, inset, and break ([2c30b1a](https://github.com/rei/rei-cedar/commit/2c30b1a))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **docs:** added compositions routes ([a3a0f81](https://github.com/rei/rei-cedar/commit/a3a0f81))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **tokens:** consume 0.0.6 tokens and fix issues ([53f4baa](https://github.com/rei/rei-cedar/commit/53f4baa))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+
+
+

--- a/src/compositions/search/CHANGELOG.md
+++ b/src/compositions/search/CHANGELOG.md
@@ -1,0 +1,30 @@
+<a name="0.1.0"></a>
+# 0.1.0 (2018-06-27)
+
+
+### Chores
+
+* **build:** make cdr-* packages externals by default ([e0d9763](https://github.com/rei/rei-cedar/commit/e0d9763))
+
+
+### Features
+
+* **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
+* **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
+* **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **docs:** added compositions routes ([a3a0f81](https://github.com/rei/rei-cedar/commit/a3a0f81))
+* **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+
+
+### BREAKING CHANGES
+
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **release:** packages no longer have plugin as default export
+* **build:** Raw component cdr-* peerdependencies are no longer bundled
+* **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name
+for cdr-column changed to cdr-col
+
+
+


### PR DESCRIPTION
…semantic-release as dev depende

affects: @rei/cdr-assets, @rei/cdr-breadcrumb, @rei/cdr-button, @rei/cdr-card, @rei/cdr-checkbox,
@rei/cdr-cta, @rei/cdr-grid, @rei/cdr-icon, @rei/cdr-icon-only-button, @rei/cdr-img, @rei/cdr-input,
@rei/cdr-link, @rei/cdr-list, @rei/cdr-media-object, @rei/cdr-quote, @rei/cdr-radio,
@rei/cdr-rating, @rei/cdr-select, @rei/cdr-text, @rei/cdr-activity-card, @rei/cdr-caption,
@rei/cdr-search