### PR TITLE
WIP(cta): render CTA only as anchor

### DIFF
--- a/src/components/cta/CdrCta.vue
+++ b/src/components/cta/CdrCta.vue
@@ -1,17 +1,17 @@
 <template>
-  <component
-    :is="tag"
+  <a
     :class="[modifierClass, ctaClass, fullWidthClass]"
-    :type="tag === 'button' ? type : null"
-    :tabindex="tag === 'button' ? null: 0"
-    @click="onClick">
+    :target="target"
+    :rel="computedRel"
+    :href="href"
+  >
+    <!-- @slot innerHTML on the inside of the cta component -->
     <slot />
     <icon-caret-right :class="$style[`cdr-cta__icon`]" />
-  </component>
+  </a>
 </template>
 
 <script>
-import buttonBase from 'mixinsdir/buttonBase';
 import modifier from 'mixinsdir/modifier';
 import { IconCaretRight } from '@rei/cdr-icon';
 
@@ -20,16 +20,8 @@ export default {
   components: {
     IconCaretRight,
   },
-  mixins: [buttonBase, modifier],
+  mixins: [modifier],
   props: {
-    /**
-      * Render cdr-cta as an <a> or <button> element.
-      */
-    tag: {
-      type: String,
-      default: 'a',
-      validator: value => (['button', 'a'].indexOf(value) >= 0) || false,
-    },
     /**
       * Change the color of the cdr-cta button match different themes.
       */
@@ -38,6 +30,22 @@ export default {
       default: 'brand',
       validator: value => (['brand', 'dark', 'light', 'sale'].indexOf(value) >= 0) || false,
     },
+    /**
+     * Sets width to be 100%.
+    */
+    fullWidth: {
+      type: Boolean,
+      default: false,
+      validator: value => typeof value === 'boolean',
+    },
+    href: {
+      type: String,
+      default: '#',
+    },
+    /** @ignore */
+    target: String,
+    /** @ignore */
+    rel: String,
   },
   computed: {
     baseClass() {
@@ -45,6 +53,16 @@ export default {
     },
     ctaClass() {
       return this.modifyClassName(this.baseClass, this.ctaStyle);
+    },
+    fullWidthClass() {
+      return this.fullWidth && !this.iconOnly ?
+        this.modifyClassName(this.baseClass, 'full-width') : null;
+    },
+    computedRel() {
+      if (this.target === '_blank') {
+        return this.rel || 'noopener noreferrer';
+      }
+      return this.rel;
     },
   },
 };

--- a/src/components/cta/__tests__/CdrCta.spec.js
+++ b/src/components/cta/__tests__/CdrCta.spec.js
@@ -9,14 +9,6 @@ describe('CdrCta.vue', () => {
     expect(ctaStyle.validator('dark')).toBe(true);
   });
 
-  it('validates tag prop', () => {
-    const wrapper = shallowMount(CdrCta);
-    const tag = wrapper.vm.$options.props.tag;
-    expect(tag.validator('input')).toBe(false);
-    expect(tag.validator('a')).toBe(true);
-    expect(tag.validator('button')).toBe(true);
-  });
-
   it('adds classes from ctaStyle prop', () => {
     const wrapper = shallowMount(CdrCta, {
       propsData: {
@@ -29,8 +21,7 @@ describe('CdrCta.vue', () => {
     expect(wrapper.classes()).toContain('cdr-cta--sale');
   });
 
-  // this is actually testing the full-width prop in the buttonBase mixin
-  it('adds full width class from mixin', () => {
+  it('adds full width class', () => {
     const wrapper = shallowMount(CdrCta, {
       propsData: {
         fullWidth: true,
@@ -38,5 +29,37 @@ describe('CdrCta.vue', () => {
     });
 
     expect(wrapper.classes()).toContain('cdr-cta--full-width');
+  });
+
+  it('sets target attr correctly', () => {
+    const wrapper = shallowMount(CdrCta, {
+      propsData: {
+        target: '_self',
+      },
+    });
+    expect(wrapper.attributes().target).toBe('_self');
+  });
+
+  it('sets a default href', () => {
+    const wrapper = shallowMount(CdrCta);
+    expect(wrapper.attributes().href).toBe('#');
+  });
+
+  it('sets rel attr correctly', () => {
+    const wrapper = shallowMount(CdrCta, {
+      propsData: {
+        rel: 'nofollow',
+      },
+    });
+    expect(wrapper.attributes().rel).toBe('nofollow');
+  });
+
+  it('computes target="_blank" rel attr correctly', () => {
+    const wrapper = shallowMount(CdrCta, {
+      propsData: {
+        target: '_blank',
+      },
+    });
+    expect(wrapper.attributes().rel).toBe('noopener noreferrer');
   });
 });

--- a/src/components/cta/examples/Cta.vue
+++ b/src/components/cta/examples/Cta.vue
@@ -25,13 +25,6 @@
         modifier="elevated"
       >Sale (elevated)</cdr-cta
       >
-      <cdr-cta
-        tag="button"
-        cta-style="sale"
-        data-backstop="cdr-cta--sale anchor"
-        modifier="elevated"
-      >Button (elevated)</cdr-cta
-      >
     </div>
     <div class="button-example">
       <cdr-cta


### PR DESCRIPTION
Remove ability to render CTA as a button because it should not be a button. Props more closely match cdr-link.
affects: @rei/cdr-cta