### PR TITLE
Fix button, cta component css that use cdr-icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rei-cedar",
-  "version": "18.06.1",
+  "version": "18.07.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/accordion/package-lock.json
+++ b/src/components/accordion/package-lock.json
@@ -1,14 +1,11 @@
 {
-	"name": "@rei/cdr-accordion",
-	"version": "0.1.0",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@rei/cdr-assets": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@rei/cdr-assets/-/cdr-assets-0.1.0.tgz",
-			"integrity": "sha512-tQCfpIvtKINFkGTymEn7Jd75uW+Xo9bAUQ+LhKu9bNjDnB2gEqtKmmcRrk/EESwHEXrPnNHh3mHVe/J8I4PUVA==",
-			"dev": true
+			"integrity": "sha512-tQCfpIvtKINFkGTymEn7Jd75uW+Xo9bAUQ+LhKu9bNjDnB2gEqtKmmcRrk/EESwHEXrPnNHh3mHVe/J8I4PUVA=="
 		},
 		"@rei/cdr-icon": {
 			"version": "0.2.1",
@@ -18,14 +15,12 @@
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-			"dev": true
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "1.9.1"
 			}
@@ -33,14 +28,12 @@
 		"camelcase": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-			"dev": true
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 		},
 		"chalk": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "3.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -51,7 +44,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-			"dev": true,
 			"requires": {
 				"string-width": "2.1.1",
 				"strip-ansi": "4.0.0",
@@ -61,14 +53,12 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -76,8 +66,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"core-js": {
 			"version": "2.5.7",
@@ -88,7 +77,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.3",
 				"shebang-command": "1.2.0",
@@ -98,20 +86,17 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"execa": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"get-stream": "3.0.0",
@@ -126,7 +111,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "2.0.0"
 			}
@@ -134,50 +118,42 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-			"dev": true
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -186,7 +162,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -196,7 +171,6 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -206,7 +180,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -214,20 +187,17 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"normalize-newline": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-newline/-/normalize-newline-3.0.0.tgz",
-			"integrity": "sha1-HL6oBKukNgAfg5OKsh7AOdaa6dM=",
-			"dev": true
+			"integrity": "sha1-HL6oBKukNgAfg5OKsh7AOdaa6dM="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "2.0.1"
 			}
@@ -235,14 +205,12 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-			"dev": true,
 			"requires": {
 				"execa": "0.7.0",
 				"lcid": "1.0.0",
@@ -252,14 +220,12 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-			"dev": true,
 			"requires": {
 				"p-try": "1.0.0"
 			}
@@ -268,7 +234,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "1.2.0"
 			}
@@ -276,26 +241,22 @@
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"pkg-ok": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-ok/-/pkg-ok-2.2.0.tgz",
 			"integrity": "sha512-kigi0o1NP/mw+AVt/hicm3plnZkMLhXFXYE7Q6yRXq2cu5N517WvXeZ1pQXVWvslZ3cSlEqyR+0neOxSJDq3Sg==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
 				"normalize-newline": "3.0.0",
@@ -305,32 +266,27 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -338,20 +294,17 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -361,7 +314,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "3.0.0"
 			}
@@ -369,14 +321,12 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"supports-color": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-			"dev": true,
 			"requires": {
 				"has-flag": "3.0.0"
 			}
@@ -385,7 +335,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -393,14 +342,12 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -409,14 +356,12 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -425,7 +370,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -436,7 +380,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -446,20 +389,17 @@
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
 			"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-			"dev": true,
 			"requires": {
 				"cliui": "4.1.0",
 				"decamelize": "1.2.0",
@@ -479,7 +419,6 @@
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0"
 			}

--- a/src/components/button/comps/CdrCloseButton.vue
+++ b/src/components/button/comps/CdrCloseButton.vue
@@ -11,6 +11,7 @@
 
 <script>
 import { IconXLg } from '@rei/cdr-icon';
+import '@rei/cdr-icon/dist/cdr-icon.css';
 import CdrButton from 'componentsdir/button/CdrButton';
 
 export default {

--- a/src/components/button/comps/CdrPlayButton.vue
+++ b/src/components/button/comps/CdrPlayButton.vue
@@ -11,6 +11,7 @@
 
 <script>
 import { IconPlay } from '@rei/cdr-icon';
+import '@rei/cdr-icon/dist/cdr-icon.css';
 import CdrButton from 'componentsdir/button/CdrButton';
 
 export default {

--- a/src/components/button/package-lock.json
+++ b/src/components/button/package-lock.json
@@ -7,10 +7,10 @@
 			"resolved": "https://registry.npmjs.org/@rei/cdr-assets/-/cdr-assets-0.1.0.tgz",
 			"integrity": "sha512-tQCfpIvtKINFkGTymEn7Jd75uW+Xo9bAUQ+LhKu9bNjDnB2gEqtKmmcRrk/EESwHEXrPnNHh3mHVe/J8I4PUVA=="
 		},
-		"@rei/cdr-button": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@rei/cdr-button/-/cdr-button-0.1.0.tgz",
-			"integrity": "sha512-7+j3PRgE1+RCYQlAQ5n4r07ynB2biawe1z9XukxXGKnEYdxDISDL9rCyIt8NmicQqL5c5laK/aNj2CzBgxuv0Q=="
+		"@rei/cdr-icon": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@rei/cdr-icon/-/cdr-icon-0.2.1.tgz",
+			"integrity": "sha512-KA3Kq5tT7wEpJgbdqjhrdM29jDfQF1WvzOPSmIzFMyOavGlyqubbx8XV1pH8rLECUPz8+YGDZXWbKYn/c2l8xg=="
 		},
 		"pkg-ok": {
 			"version": "1.1.0",

--- a/src/components/button/package.json
+++ b/src/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-button",
-  "version": "0.1.0-alpha.0",
+  "version": "0.2.0-alpha.0",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Button",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-button",

--- a/src/components/button/package.json
+++ b/src/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-button",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0-alpha.1",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Button",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-button",

--- a/src/components/cta/CdrCta.vue
+++ b/src/components/cta/CdrCta.vue
@@ -28,7 +28,7 @@ export default {
       */
     ctaStyle: {
       type: String,
-      default: 'brand',
+      default: 'dark',
       validator: value => (['brand', 'dark', 'light', 'sale'].indexOf(value) >= 0) || false,
     },
     /**

--- a/src/components/cta/CdrCta.vue
+++ b/src/components/cta/CdrCta.vue
@@ -14,6 +14,7 @@
 <script>
 import modifier from 'mixinsdir/modifier';
 import { IconCaretRight } from '@rei/cdr-icon';
+import '@rei/cdr-icon/dist/cdr-icon.css';
 
 export default {
   name: 'CdrCta',

--- a/src/components/cta/examples/Cta.vue
+++ b/src/components/cta/examples/Cta.vue
@@ -3,14 +3,14 @@
     <h2>CTA</h2>
     <div class="button-example">
       <cdr-cta
-        data-backstop="cdr-cta--brand">
-        Default (brand)
+        data-backstop="cdr-cta--dark">
+        Default (dark)
       </cdr-cta>
       <cdr-cta
         href="https://rei.com"
-        cta-style="dark"
-        data-backstop="cdr-cta--dark"
-      >Dark</cdr-cta
+        cta-style="brand"
+        data-backstop="cdr-cta--brand"
+      >Brand</cdr-cta
       >
       <cdr-cta
         href="https://rei.com"

--- a/src/components/cta/package-lock.json
+++ b/src/components/cta/package-lock.json
@@ -7,6 +7,11 @@
 			"resolved": "https://registry.npmjs.org/@rei/cdr-assets/-/cdr-assets-0.1.0.tgz",
 			"integrity": "sha512-tQCfpIvtKINFkGTymEn7Jd75uW+Xo9bAUQ+LhKu9bNjDnB2gEqtKmmcRrk/EESwHEXrPnNHh3mHVe/J8I4PUVA=="
 		},
+		"@rei/cdr-icon": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@rei/cdr-icon/-/cdr-icon-0.2.1.tgz",
+			"integrity": "sha512-KA3Kq5tT7wEpJgbdqjhrdM29jDfQF1WvzOPSmIzFMyOavGlyqubbx8XV1pH8rLECUPz8+YGDZXWbKYn/c2l8xg=="
+		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",

--- a/src/components/cta/package.json
+++ b/src/components/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-cta",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Cta",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-cta",
@@ -22,15 +22,14 @@
     "prepublishOnly": "npm run build && pkg-ok",
     "build": "node build/build.js"
   },
-  "dependencies": {
-    "@rei/cdr-icon": "^0.2.0"
-  },
   "peerDependencies": {
     "@rei/cdr-assets": "^0.1.0",
+    "@rei/cdr-icon": "^0.2.0",
     "vue": "^2.5.13"
   },
   "devDependencies": {
     "@rei/cdr-assets": "^0.1.0",
+    "@rei/cdr-icon": "^0.2.0",
     "pkg-ok": "^2.1.0"
   }
 }


### PR DESCRIPTION
cdr-icon.css is imported for cdr-cta, cdr-play-button, cdr-close-button. also updates cdr-cta to use 'dark' as the default style instead of 'brand'.

After this gets merged I'll kick related alpha builds.