### PR TITLE
accordion hide content fix

### DIFF
--- a/src/components/accordion/CdrAccordionItem.vue
+++ b/src/components/accordion/CdrAccordionItem.vue
@@ -7,7 +7,7 @@
     <button
       :class="$style['cdr-accordion-item__button']"
       :id="id"
-      @click="toggle"
+      @click="toggle($event)"
       @focus="focused = true"
       @blur="focused = false"
       :aria-expanded="`${isOpen}`"
@@ -113,7 +113,7 @@ export default {
       return this.focused ? this.modifyClassName(this.baseClass, 'focused') : null;
     },
     isOpenClass() {
-      return this.isOpen ? 'open' : null;
+      return this.isOpen ? 'open' : 'closed';
     },
   },
   mounted() {
@@ -122,8 +122,9 @@ export default {
     }
   },
   methods: {
-    toggle() {
+    toggle(event) {
       this.isOpen = !this.isOpen;
+      this.$parent.$emit('accordion-item-toggle', this.isOpen, event);
       const ref = `accordion-${this.$props.id}`;
       this.maxHeight = `${this.$refs[ref].childNodes[2].childNodes[0].clientHeight}px`;
       const timeout = this.isOpen ? 300 : 50;

--- a/src/components/accordion/README.md
+++ b/src/components/accordion/README.md
@@ -40,17 +40,25 @@ Accordions are built from two components, `cdr-accordion` and `cdr-accordion-ite
 
 ## Slots
 
-#### cdr-accordion
+### cdr-accordion
 | name                                            |
 | :---------------------------------------------- |
 | Default                                         |
 | Default slot for cdr-accordion-item(s) |
 
-#### cdr-accordion-item
+### cdr-accordion-item
 | name                                            |
 | :---------------------------------------------- |
 | Default                                         |
 | Default slot for cdr-accordion-item content |
+
+## Events
+
+### cdr-accordion-item
+| name                                            |
+| :---------------------------------------------- |
+| accordion-item-toggle                                         |
+| $emit event fired on cdr-accordion-item toggle
 
 ## Installation
 

--- a/src/components/accordion/README.md
+++ b/src/components/accordion/README.md
@@ -9,34 +9,40 @@ Accordions are built from two components, `cdr-accordion` and `cdr-accordion-ite
 | name | type | Default |
 | :--- | :--- | :--- |
 | compact | boolean | false |
-| Set compact style of cdr-accordion-item child components
+
+Set compact style of cdr-accordion-item child components
 
 | name | type | Default |
 | :--- | :--- | :--- |
 | borderAligned | boolean | false |
-| Set border-aligned style of cdr-accordion-item child components |
+
+Set border-aligned style of cdr-accordion-item child components
 
 | name | type | Default |
 | :--- | :--- | :--- |
 | showAll | boolean | false |
-| Set all child cdr-accordion-item components to display open by default |
+
+Set all child cdr-accordion-item components to display open by default
 
 ### cdr-accordion-item
 
 | name | type | Default |
 | :--- | :--- | :--- |
 | id | string | n/a |
-| Required id for component reference. Id must e unique |
+
+Required id for component reference. Id must e unique
 
 | name | type | Default |
 | :--- | :--- | :--- |
 | label | string | n/a |
-| Set the readable text on the cdr-accordion-item button or trigger. Required |
+
+Set the readable text on the cdr-accordion-item button or trigger. Required |
 
 | name | type | Default |
 | :--- | :--- | :--- |
 | show | boolean | false |
-| Set a single cdr-accordion-item to display open by default. Prop showAll will take precedence, if true. |
+
+Set a single cdr-accordion-item to display open by default. Prop showAll will take precedence, if true. |
 
 ## Slots
 
@@ -44,21 +50,24 @@ Accordions are built from two components, `cdr-accordion` and `cdr-accordion-ite
 | name                                            |
 | :---------------------------------------------- |
 | Default                                         |
-| Default slot for cdr-accordion-item(s) |
+
+Default slot for cdr-accordion-item(s)
 
 ### cdr-accordion-item
 | name                                            |
 | :---------------------------------------------- |
 | Default                                         |
-| Default slot for cdr-accordion-item content |
+
+Default slot for cdr-accordion-item content
 
 ## Events
 
 ### cdr-accordion-item
 | name                                            |
 | :---------------------------------------------- |
-| accordion-item-toggle                                         |
-| $emit event fired on cdr-accordion-item toggle
+| accordion-item-toggle
+
+$emit event fired on cdr-accordion-item toggle
 
 ## Installation
 

--- a/src/components/accordion/__tests__/CdrAccordionItem.spec.js
+++ b/src/components/accordion/__tests__/CdrAccordionItem.spec.js
@@ -43,6 +43,13 @@ describe('CdrAccordionItem', () => {
           default: 'This is some slot text.'
         },
       });
+
+      /* Dupe call to parent $emit because using shallowMount */
+      wrapper.vm.$parent = {
+        $emit: function() {
+          return true;
+        }
+      };
   
       expect(wrapper.vm.maxHeight).toBe(0);
       wrapper.vm.toggle();
@@ -51,23 +58,6 @@ describe('CdrAccordionItem', () => {
       setTimeout(() => {
         expect(wrapper.vm.maxHeight).toBe('none');
       }, 300);
-    });
-
-    it('style class checks provided values', () => {
-      const wrapper = shallowMount(CdrAccordionItem, {
-        propsData: propsData,
-        provide: {
-          showAll: false,
-          borderAligned: true,
-          compact: true,
-        },
-        slots: {
-          default: 'This is some slot text.'
-        },
-      });
-
-      expect(wrapper.classes()).toContain('cdr-accordion-item--compact');
-      expect(wrapper.classes()).toContain('cdr-accordion-item--border-aligned');
     });
 
     it('toggles when isOpen', () => {
@@ -83,6 +73,12 @@ describe('CdrAccordionItem', () => {
         },
       });
 
+      wrapper.vm.$parent = {
+        $emit: function() {
+          return true;
+        }
+      };
+
       expect(wrapper.vm.maxHeight).toBe('none');
       wrapper.vm.toggle();
       expect(wrapper.vm.isOpen).toBe(false);
@@ -90,5 +86,38 @@ describe('CdrAccordionItem', () => {
         expect(wrapper.vm.maxHeight).toBe(0);
       }, 500);
     });
+  });
+
+  it('focused style', () => {
+    const wrapper = shallowMount(CdrAccordionItem, {
+      propsData: propsData,
+      provide: {
+        showAll: false,
+        borderAligned: true,
+        compact: true,
+      },
+      slots: {
+        default: 'This is some slot text.'
+      },
+    });
+    wrapper.setData({ focused: true });
+    expect(wrapper.classes()).toContain('cdr-accordion-item--focused');
+  });
+
+  it('style class checks provided values', () => {
+    const wrapper = shallowMount(CdrAccordionItem, {
+      propsData: propsData,
+      provide: {
+        showAll: false,
+        borderAligned: true,
+        compact: true,
+      },
+      slots: {
+        default: 'This is some slot text.'
+      },
+    });
+
+    expect(wrapper.classes()).toContain('cdr-accordion-item--compact');
+    expect(wrapper.classes()).toContain('cdr-accordion-item--border-aligned');
   });
 });

--- a/src/components/accordion/examples/Accordion.vue
+++ b/src/components/accordion/examples/Accordion.vue
@@ -40,32 +40,45 @@
     </div>
     <div class="accordion-group">
       <h3>Compact</h3>
-      <cdr-accordion
-        :compact="true"
-        data-backstop="accordion-compact"
+      <cdr-accordion-item
+        id="compact"
+        label="Compact"
       >
-        <cdr-accordion-item
-          id="compact"
-          label="Compact"
-        >
-          <cdr-text
-            tag="p"
-          >
-            It helps to see at least two accordions together.
-          </cdr-text>
-        </cdr-accordion-item>
-        <cdr-accordion-item
-          id="compact-2"
-          label="Label with multiple words, so many words in fact that
-          this content may wrap to several lines"
-        >
-          <cdr-list tag="ol">
-            <li>Item one</li>
-            <li>Item two</li>
-            <li>Hopefully right font size</li>
-          </cdr-list>
-        </cdr-accordion-item>
-      </cdr-accordion>
+        <ul>
+          <li>
+            <a
+              href="https://www.rei.com/"
+            >
+              REI.com
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.rei.com/h/adventure-projects"
+            >
+              adventure projects
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.rei.com/stewardship"
+            >
+              stewardship
+            </a>
+          </li>
+        </ul>
+      </cdr-accordion-item>
+      <cdr-accordion-item
+        id="compact-2"
+        label="Label with multiple words, so many words in fact that
+        this content may wrap to several lines"
+      >
+        <cdr-list tag="ol">
+          <li>Item one</li>
+          <li>Item two</li>
+          <li>Hopefully right font size</li>
+        </cdr-list>
+      </cdr-accordion-item>
     </div>
     <div class="accordion-group">
       <h3>Border-Aligned</h3>
@@ -97,6 +110,18 @@ import Components from 'componentsdir/_index';
 export default {
   name: 'Accordion',
   components: Components,
+  data() {
+    return {
+      tabindex: -1,
+    };
+  },
+  provide() {
+    return {
+      compact: true,
+      borderAligned: false,
+      showAll: false,
+    };
+  },
 };
 </script>
 

--- a/src/components/accordion/package.json
+++ b/src/components/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-accordion",
-  "version": "0.1.0-alpha.3",
+  "version": "1.0.0",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Accordion",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-accordion",

--- a/src/components/accordion/styles/CdrAccordionItem.pcss
+++ b/src/components/accordion/styles/CdrAccordionItem.pcss
@@ -89,6 +89,10 @@
     &:global(.open) {
       opacity: 1;
     }
+
+    &:global(.closed) {
+      visibility: hidden;
+    }
   }
 
   /* Style variants


### PR DESCRIPTION
This fix hides the contents of a closed cdr-accordion-item so that the contents are not tabbable without breaking the animation.

fix(accordion): set visibility hidden on cdr-accordion-item slot contents when closed

affects: @rei/cdr-accordion