### PR TITLE
docs(changelog): updating changlogs against latest tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,85 @@
+<a name="18.8.1"></a>
+## [18.8.1](https://github.com/rei/rei-cedar/compare/v5.0.0-alpha.1...v18.8.1) (2018-08-01)
+
+
+### Bug Fixes
+
+* **accordion:** add dynamic class to change cdr-accordion-item z-index on focus/blur ([b701ab7](https://github.com/rei/rei-cedar/commit/b701ab7))
+* **accordion:** fix css bugs ([d19278c](https://github.com/rei/rei-cedar/commit/d19278c))
+* **accordion:** set visibility hidden on cdr-accordion-item slot contents when closed ([81a5a0d](https://github.com/rei/rei-cedar/commit/81a5a0d))
+* **activity card:** correct border-radius on image to match card ([5a48d79](https://github.com/rei/rei-cedar/commit/5a48d79))
+* **button:** bump version to match alpha ([3439b98](https://github.com/rei/rei-cedar/commit/3439b98))
+* **button cta:** import cdr-icon css for components packaged with an icon ([6bb2233](https://github.com/rei/rei-cedar/commit/6bb2233))
+* **cdr-img:** add radius to cropped/ratio images ([ceefec6](https://github.com/rei/rei-cedar/commit/ceefec6))
+* **cdr-img:** the radius validator did not have the correct values, removing them and updating radiu ([c39066d](https://github.com/rei/rei-cedar/commit/c39066d))
+* **cta:** fix box shadow on --light --elevated ([341f2de](https://github.com/rei/rei-cedar/commit/341f2de))
+* **select:** fix bug with selenium interaction ([18fbab3](https://github.com/rei/rei-cedar/commit/18fbab3))
+* **select:** update variable name ([dbdc0e4](https://github.com/rei/rei-cedar/commit/dbdc0e4))
+* **test:** added breadcrumb and input page links ([eebb259](https://github.com/rei/rei-cedar/commit/eebb259))
+
+
+### Features
+
+* **accordion button cta:** bump versions to match alpha release ([c7f21bb](https://github.com/rei/rei-cedar/commit/c7f21bb))
+* **breadcrumb:** breadcrumb component is ready for pr ([984a31c](https://github.com/rei/rei-cedar/commit/984a31c))
+* **breadcrumb:** final cleanup after pr comments ([34467e9](https://github.com/rei/rei-cedar/commit/34467e9))
+* **breadcrumb:** update version ([fa16f95](https://github.com/rei/rei-cedar/commit/fa16f95))
+* **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+* **cdr-image v1 release:** moving the package.json to v1 for the cdr-image component ([6fa1cc7](https://github.com/rei/rei-cedar/commit/6fa1cc7))
+* **cdr-list release:** moving cdr-list to V1 and updating its readme ([451d3ae](https://github.com/rei/rei-cedar/commit/451d3ae))
+* **cdr-radio release:** updates to the cdr-radio readme API and moving the package.json to v1 ([13b35c4](https://github.com/rei/rei-cedar/commit/13b35c4))
+* **cedar proving grounds:** loops through all the routes, which have been moved to routes.js, and e ([7cda2b3](https://github.com/rei/rei-cedar/commit/7cda2b3))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **crd-checkbox release:** updates to the cdr-checkbox API readme and bumping the package to v1 ([0066831](https://github.com/rei/rei-cedar/commit/0066831))
+* **cta:** update readme, bump version ([4f87071](https://github.com/rei/rei-cedar/commit/4f87071))
+* **grid:** consolidate col's alignSelf props to single alignSelf ([0058ad0](https://github.com/rei/rei-cedar/commit/0058ad0))
+* **grid:** consolidate col's offsetLeft props to just offsetLeft ([ecc3294](https://github.com/rei/rei-cedar/commit/ecc3294))
+* **grid:** consolidate col's offsetRight props to single offsetRight ([b812e99](https://github.com/rei/rei-cedar/commit/b812e99))
+* **grid:** consolidate col's span props to just span ([a3ef361](https://github.com/rei/rei-cedar/commit/a3ef361))
+* **grid:** move col and row to single package ([b0469b6](https://github.com/rei/rei-cedar/commit/b0469b6))
+* **grid:** release 0.2.0 ([accc22b](https://github.com/rei/rei-cedar/commit/accc22b))
+* **grid:** update align prop to accept responsive values ([1907de8](https://github.com/rei/rei-cedar/commit/1907de8))
+* **grid:** update col and justify props to accept responsive values ([c572a51](https://github.com/rei/rei-cedar/commit/c572a51))
+* **grid:** update gutter prop to accept responsive values ([a3f613f](https://github.com/rei/rei-cedar/commit/a3f613f))
+* **grid:** update row's nowrap prop to accept responsive values ([6dd3514](https://github.com/rei/rei-cedar/commit/6dd3514))
+* **grid:** update vertical prop to be a string and accept responsive values ([008f05b](https://github.com/rei/rei-cedar/commit/008f05b))
+* **grid:** update wrap prop to be a string and accept responsive values ([cfe2d8a](https://github.com/rei/rei-cedar/commit/cfe2d8a))
+* **icon:** add a slot to all components ([5bd063f](https://github.com/rei/rei-cedar/commit/5bd063f))
+* **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **link:** use css modules for link ([6b244d2](https://github.com/rei/rei-cedar/commit/6b244d2))
+* **link:** use css modules with link ([bfb98f9](https://github.com/rei/rei-cedar/commit/bfb98f9))
+* **proving grounds:** removes cruft ([ae8c943](https://github.com/rei/rei-cedar/commit/ae8c943))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
+* **release:** cedar Alpha release ([883ff94](https://github.com/rei/rei-cedar/commit/883ff94))
+* **tokens:** consume [@rei](https://github.com/rei)/cdr-tokens package ([f094978](https://github.com/rei/rei-cedar/commit/f094978))
+
+
+### BREAKING CHANGES
+
+* **release:** CdrLink and CdrText are moving to V1
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **grid:** offsetRightSm, offsetRightMd, offsetRightLg consolidated to just offsetRight that accepts responsive modifiers
+* **grid:** offsetLeftSm, offsetLeftMd, offsetLeftLg consolidated to just offsetLeft that accepts responsive
+modifiers
+* **grid:** spanSm, spanMd, spanLg removed and span accepts responsive modifiers
+* **grid:** change row's nowrap prop from boolean to string. Remove nowrapSm, nowrapMd, nowrapLg in favor of
+using nowrap with responsive modifiers
+* **grid:** remove wrapSm, wrapMd, wrapLg in favor of using wrap with responsive modifiers
+* **grid:** vertical prop is now a string instead of boolean. verticalSm, verticalMd, verticalLg removed and now
+supports responsive modifiers
+* **grid:** alignSelfSm, alignSelfMd, alignSelfLg consolidated to just alignSelf that accepts responsive
+modifiers
+* **grid:** alignSm, alignMd, alignLg replaced with just align that accepts responsive values
+* **grid:** colsSm, colsMd, colsLg replaced with just cols prop. justifySm, justifyMd, justifyLg replaced with
+just justify prop
+* **buttons:** Buttons use css modules
+* **grid:** grid css is no longer in cdr-assets, col and row are no longer their own packages
+* **link:** link uses css modules
+* **link:** link now uses css modules
+* **grid:** gutterSm, gutterMd, gutterLg replaced with just gutter
+
+
+
 <a name="18.7.2"></a>
 ## [18.7.2](https://github.com/rei/rei-cedar/compare/v5.0.0-alpha.1...v18.7.2) (2018-07-25)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rei-cedar",
-  "version": "18.07.2",
+  "version": "18.08.1",
   "description": "REI Cedar Style Framework",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/cdr-assets/CHANGELOG.md
+++ b/src/cdr-assets/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.2.0"></a>
-# 0.2.0 (2018-07-25)
+# 0.2.0 (2018-08-01)
 
 
 ### Bug Fixes
@@ -18,6 +18,7 @@
 * **fonts:** remove several font weights and styles ([36f21d8](https://github.com/rei/rei-cedar/commit/36f21d8))
 * **icon:** generate new sprite, externalize icon.json ([f49f828](https://github.com/rei/rei-cedar/commit/f49f828))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 * **tokens:** output token file for cdr-assets ([717836f](https://github.com/rei/rei-cedar/commit/717836f))
 
 

--- a/src/components/accordion/CHANGELOG.md
+++ b/src/components/accordion/CHANGELOG.md
@@ -1,15 +1,19 @@
-<a name="0.1.0-alpha.2"></a>
-# 0.1.0-alpha.2 (2018-07-25)
+<a name="1.0.0"></a>
+# 1.0.0 (2018-08-01)
 
 
 ### Bug Fixes
 
+* **accordion:** add dynamic class to change cdr-accordion-item z-index on focus/blur ([b701ab7](https://github.com/rei/rei-cedar/commit/b701ab7))
+* **accordion:** fix css bugs ([d19278c](https://github.com/rei/rei-cedar/commit/d19278c))
+* **accordion:** set visibility hidden on cdr-accordion-item slot contents when closed ([81a5a0d](https://github.com/rei/rei-cedar/commit/81a5a0d))
 * **button:** bump version to match alpha ([3439b98](https://github.com/rei/rei-cedar/commit/3439b98))
 
 
 ### Features
 
 * **accordion button cta:** bump versions to match alpha release ([c7f21bb](https://github.com/rei/rei-cedar/commit/c7f21bb))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 

--- a/src/components/breadcrumb/CHANGELOG.md
+++ b/src/components/breadcrumb/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="1.0.0"></a>
-# 1.0.0 (2018-07-25)
+# 1.0.0 (2018-08-01)
 
 
 ### Features
@@ -7,6 +7,7 @@
 * **breadcrumb:** breadcrumb component is ready for pr ([984a31c](https://github.com/rei/rei-cedar/commit/984a31c))
 * **breadcrumb:** final cleanup after pr comments ([34467e9](https://github.com/rei/rei-cedar/commit/34467e9))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 

--- a/src/components/button/CHANGELOG.md
+++ b/src/components/button/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="1.0.0"></a>
-# 1.0.0 (2018-07-25)
+# 1.0.0 (2018-08-01)
 
 
 ### Bug Fixes
@@ -24,6 +24,7 @@
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/card/CHANGELOG.md
+++ b/src/components/card/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.2.0"></a>
-# 0.2.0 (2018-07-25)
+# 0.2.0 (2018-08-01)
 
 
 ### Chores
@@ -16,6 +16,7 @@
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/checkbox/CHANGELOG.md
+++ b/src/components/checkbox/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0-alpha.0"></a>
-# 1.0.0-alpha.0 (2018-07-25)
+<a name="1.0.0"></a>
+# 1.0.0 (2018-08-01)
 
 
 ### Chores
@@ -11,14 +11,17 @@
 
 * **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
 * **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **cdr-radio release:** updates to the cdr-radio readme API and moving the package.json to v1 ([13b35c4](https://github.com/rei/rei-cedar/commit/13b35c4))
 * **checkbox:** add custom label class ([7012f33](https://github.com/rei/rei-cedar/commit/7012f33))
 * **checkbox:** add custom label class ([d8882b8](https://github.com/rei/rei-cedar/commit/d8882b8))
 * **checkbox radio:** update checkbox and radio to design spec ([30a5ef0](https://github.com/rei/rei-cedar/commit/30a5ef0))
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **crd-checkbox release:** updates to the cdr-checkbox API readme and bumping the package to v1 ([0066831](https://github.com/rei/rei-cedar/commit/0066831))
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/cta/CHANGELOG.md
+++ b/src/components/cta/CHANGELOG.md
@@ -1,18 +1,21 @@
-<a name="0.1.0-alpha.1"></a>
-# 0.1.0-alpha.1 (2018-07-25)
+<a name="1.0.0"></a>
+# 1.0.0 (2018-08-01)
 
 
 ### Bug Fixes
 
 * **button:** bump version to match alpha ([3439b98](https://github.com/rei/rei-cedar/commit/3439b98))
 * **button cta:** import cdr-icon css for components packaged with an icon ([6bb2233](https://github.com/rei/rei-cedar/commit/6bb2233))
+* **cta:** fix box shadow on --light --elevated ([341f2de](https://github.com/rei/rei-cedar/commit/341f2de))
 
 
 ### Features
 
 * **accordion button cta:** bump versions to match alpha release ([c7f21bb](https://github.com/rei/rei-cedar/commit/c7f21bb))
 * **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+* **cta:** update readme, bump version ([4f87071](https://github.com/rei/rei-cedar/commit/4f87071))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/grid/CHANGELOG.md
+++ b/src/components/grid/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="1.0.0"></a>
-# 1.0.0 (2018-07-25)
+# 1.0.0 (2018-08-01)
 
 
 ### Features
@@ -17,6 +17,7 @@
 * **grid:** update vertical prop to be a string and accept responsive values ([008f05b](https://github.com/rei/rei-cedar/commit/008f05b))
 * **grid:** update wrap prop to be a string and accept responsive values ([cfe2d8a](https://github.com/rei/rei-cedar/commit/cfe2d8a))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/icon/CHANGELOG.md
+++ b/src/components/icon/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="1.0.0-next.beta.1"></a>
-# 1.0.0-next.beta.1 (2018-07-25)
+# 1.0.0-next.beta.1 (2018-08-01)
 
 
 ### Bug Fixes
@@ -24,6 +24,7 @@
 * **icons:** gernerate icon components ([dcefd4e](https://github.com/rei/rei-cedar/commit/dcefd4e))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **link-component:** simplifies link component props, adds prop to Icon for fill color inheritance ([9d404f4](https://github.com/rei/rei-cedar/commit/9d404f4))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/image/CHANGELOG.md
+++ b/src/components/image/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0-next.alpha.1"></a>
-# 1.0.0-next.alpha.1 (2018-07-25)
+<a name="1.0.0"></a>
+# 1.0.0 (2018-08-01)
 
 
 ### Bug Fixes
@@ -18,11 +18,13 @@
 * **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
 * **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
 * **cdr-image:** these updates bring the cdr-image component inline with the v1 requierments for ima ([c94c636](https://github.com/rei/rei-cedar/commit/c94c636))
+* **cdr-image v1 release:** moving the package.json to v1 for the cdr-image component ([6fa1cc7](https://github.com/rei/rei-cedar/commit/6fa1cc7))
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/input/CHANGELOG.md
+++ b/src/components/input/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.1.2"></a>
-## 0.1.2 (2018-07-25)
+## 0.1.2 (2018-08-01)
 
 
 ### Chores
@@ -18,6 +18,7 @@
 * **input:** return event along with value in input event ([975fcc4](https://github.com/rei/rei-cedar/commit/975fcc4))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/link/CHANGELOG.md
+++ b/src/components/link/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="1.0.0"></a>
-# 1.0.0 (2018-07-25)
+# 1.0.0 (2018-08-01)
 
 
 ### Features
@@ -10,6 +10,7 @@
 * **link:** use css modules for link ([6b244d2](https://github.com/rei/rei-cedar/commit/6b244d2))
 * **link:** use css modules with link ([bfb98f9](https://github.com/rei/rei-cedar/commit/bfb98f9))
 * **link-component:** simplifies link component props, adds prop to Icon for fill color inheritance ([9d404f4](https://github.com/rei/rei-cedar/commit/9d404f4))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 * **release:** cedar Alpha release ([883ff94](https://github.com/rei/rei-cedar/commit/883ff94))
 
 

--- a/src/components/list/CHANGELOG.md
+++ b/src/components/list/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="1.0.0"></a>
-# 1.0.0 (2018-07-25)
+# 1.0.0 (2018-08-01)
 
 
 ### Chores
@@ -18,6 +18,7 @@
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/mediaObject/CHANGELOG.md
+++ b/src/components/mediaObject/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.1.1"></a>
-## 0.1.1 (2018-07-25)
+## 0.1.1 (2018-08-01)
 
 
 ### Chores
@@ -17,6 +17,7 @@
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/quote/CHANGELOG.md
+++ b/src/components/quote/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.1.0"></a>
-# 0.1.0 (2018-07-25)
+# 0.1.0 (2018-08-01)
 
 
 ### Bug Fixes
@@ -19,6 +19,7 @@
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/radio/CHANGELOG.md
+++ b/src/components/radio/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0-alpha.0"></a>
-# 1.0.0-alpha.0 (2018-07-25)
+<a name="1.0.0"></a>
+# 1.0.0 (2018-08-01)
 
 
 ### Chores
@@ -11,12 +11,14 @@
 
 * **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
 * **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **cdr-radio release:** updates to the cdr-radio readme API and moving the package.json to v1 ([13b35c4](https://github.com/rei/rei-cedar/commit/13b35c4))
 * **checkbox radio:** update checkbox and radio to design spec ([30a5ef0](https://github.com/rei/rei-cedar/commit/30a5ef0))
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/rating/CHANGELOG.md
+++ b/src/components/rating/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.1.1"></a>
-## 0.1.1 (2018-07-25)
+## 0.1.1 (2018-08-01)
 
 
 ### Bug Fixes
@@ -21,6 +21,7 @@
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/select/CHANGELOG.md
+++ b/src/components/select/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.1.1"></a>
-## 0.1.1 (2018-07-25)
+## 0.1.1 (2018-08-01)
 
 
 ### Bug Fixes
@@ -22,6 +22,7 @@
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/components/text/CHANGELOG.md
+++ b/src/components/text/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="1.0.0"></a>
-# 1.0.0 (2018-07-25)
+# 1.0.0 (2018-08-01)
 
 
 ### Chores
@@ -13,6 +13,7 @@
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 * **release:** cedar Alpha release ([883ff94](https://github.com/rei/rei-cedar/commit/883ff94))
 * **template:** the cdr-text component has been updated with the following two variants:  default pa ([f23e61f](https://github.com/rei/rei-cedar/commit/f23e61f))
 * **text:** add text component ([bb481c5](https://github.com/rei/rei-cedar/commit/bb481c5))

--- a/src/compositions/activityCard/CHANGELOG.md
+++ b/src/compositions/activityCard/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.1.1"></a>
-## 0.1.1 (2018-07-25)
+## 0.1.1 (2018-08-01)
 
 
 ### Bug Fixes
@@ -23,6 +23,7 @@
 * **docs:** added compositions routes ([a3a0f81](https://github.com/rei/rei-cedar/commit/a3a0f81))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES

--- a/src/compositions/caption/CHANGELOG.md
+++ b/src/compositions/caption/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.1.0"></a>
-# 0.1.0 (2018-07-25)
+# 0.1.0 (2018-08-01)
 
 
 ### Chores
@@ -18,6 +18,7 @@
 * **docs:** added compositions routes ([a3a0f81](https://github.com/rei/rei-cedar/commit/a3a0f81))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 * **tokens:** consume 0.0.6 tokens and fix issues ([53f4baa](https://github.com/rei/rei-cedar/commit/53f4baa))
 
 

--- a/src/compositions/search/CHANGELOG.md
+++ b/src/compositions/search/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="0.1.0"></a>
-# 0.1.0 (2018-07-25)
+# 0.1.0 (2018-08-01)
 
 
 ### Bug Fixes
@@ -22,6 +22,7 @@
 * **docs:** added compositions routes ([a3a0f81](https://github.com/rei/rei-cedar/commit/a3a0f81))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES


### PR DESCRIPTION
affects: @rei/cdr-assets, @rei/cdr-accordion, @rei/cdr-breadcrumb, @rei/cdr-button, @rei/cdr-card,
@rei/cdr-checkbox, @rei/cdr-cta, @rei/cdr-grid, @rei/cdr-icon, @rei/cdr-img, @rei/cdr-input,
@rei/cdr-link, @rei/cdr-list, @rei/cdr-media-object, @rei/cdr-quote, @rei/cdr-radio,
@rei/cdr-rating, @rei/cdr-select, @rei/cdr-text, @rei/cdr-activity-card, @rei/cdr-caption,
@rei/cdr-search
