### PR TITLE
Update resets, fix backstop errors

### DIFF
--- a/backstop.js
+++ b/backstop.js
@@ -20,8 +20,8 @@ function createScenario(def) {
 
 function splitScenario(def, type = '', selectorsArr, extraOptions = {}) {
   const scenario = Object.assign({}, extraOptions, def);
-  scenario.label = `${def.label} ${type}`;
-  selectorsArr.forEach((s) => {
+  selectorsArr.forEach((s, idx) => {
+    scenario.label = `${def.label} ${type}${idx}`;
     scenario[`${type}Selector`] = true;
     scenario.selectors = [s];
     createScenario(scenario);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2024,22 +2024,12 @@
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
-    "backstop-twentytwenty": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/backstop-twentytwenty/-/backstop-twentytwenty-1.0.4.tgz",
-      "integrity": "sha512-sENfpossNAbVKZjTzBU6bkbR1vIb7t6brjqH9ZMEIYh/RyCIGFM3BSgERzh+tdwpAVXHSbIV1gQRrtzBYzUrjw==",
-      "dev": true,
-      "requires": {
-        "react": "^15.6.2"
-      }
-    },
     "backstopjs": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-3.2.16.tgz",
-      "integrity": "sha512-VPzXZ72lnnug5PcG6W97tShEw32+TrCJiWdM00PZw0IXZ/hYRjQ1LFwVx6qDi1hZEZBIRbT2GQfBbytvtsEfVg==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-3.5.5.tgz",
+      "integrity": "sha512-BnHnf0mQuZtmkuHdU+xV898XzVNouSJq4oh1DlOyiRMyNDNWdTjETDHfSlZRZK4MGF1DIZbJvYQx1K4McRvSFg==",
       "dev": true,
       "requires": {
-        "backstop-twentytwenty": "^1.0.4",
         "casperjs": "^1.1.0-beta5",
         "chalk": "^1.1.3",
         "chromy": "0.5.11",
@@ -2050,24 +2040,13 @@
         "minimist": "^1.2.0",
         "node-resemble-js": "^0.2.0",
         "object-hash": "1.1.5",
-        "open": "0.0.5",
+        "opn": "^5.3.0",
         "os": "^0.1.1",
         "p-map": "^1.1.1",
         "path": "^0.12.7",
         "phantomjs-prebuilt": "^2.1.7",
         "puppeteer": "^1.2.0-next.1523485686787",
-        "react": "^15.6.1",
-        "react-dom": "^15.6.1",
-        "react-modal": "^3.0.3",
-        "react-redux": "^5.0.6",
-        "react-sticky": "^6.0.1",
-        "react-toggle-button": "^2.1.0",
-        "redux": "^3.7.2",
-        "sinon": "^1.17.7",
-        "styled-components": "^2.1.2",
-        "temp": "^0.8.3",
-        "webpack": "^3.5.6",
-        "webpack-dev-server": "^2.7.1"
+        "temp": "^0.8.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2100,18 +2079,6 @@
             "klaw": "^1.0.0",
             "path-is-absolute": "^1.0.0",
             "rimraf": "^2.2.8"
-          }
-        },
-        "sinon": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-          "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-          "dev": true,
-          "requires": {
-            "formatio": "1.1.1",
-            "lolex": "1.3.2",
-            "samsam": "1.1.2",
-            "util": ">=0.10.3 <1"
           }
         },
         "supports-color": {
@@ -2566,16 +2533,6 @@
         }
       }
     },
-    "buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
-      }
-    },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
@@ -2947,9 +2904,9 @@
       }
     },
     "chrome-remote-interface": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.25.6.tgz",
-      "integrity": "sha512-YNkw2FqKqb99p7nyxrx0cphAHzjyukd6NwnOuk1bI0KV5lrQ6A7DA8HZAWjhy5qbbetpGky2AKENnkTsFrYw3w==",
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz",
+      "integrity": "sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==",
       "dev": true,
       "requires": {
         "commander": "2.11.x",
@@ -4184,17 +4141,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
-    },
     "cross-env": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.6.tgz",
@@ -4258,12 +4204,6 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
-    },
-    "css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
-      "dev": true
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -4395,17 +4335,6 @@
             "regjsparser": "^0.1.4"
           }
         }
-      }
-    },
-    "css-to-react-native": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.0.tgz",
-      "integrity": "sha512-SWG8+tsVRBHpxn1cSDmx7B95DJCiKwUecBbboGpm2znDCnJDMGkcoYR73w1p2IZMab6iNqVms8VC+4TrSqoFeQ==",
-      "dev": true,
-      "requires": {
-        "css-color-keywords": "^1.0.0",
-        "fbjs": "^0.8.5",
-        "postcss-value-parser": "^3.3.0"
       }
     },
     "css-unit-converter": {
@@ -6161,12 +6090,6 @@
         "clone-regexp": "^1.0.0"
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=",
-      "dev": true
-    },
     "exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -6916,12 +6839,12 @@
       }
     },
     "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "requires": {
-        "is-function": "~1.0.0"
+        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -8637,12 +8560,6 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
-    },
-    "hoist-non-react-statics": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-      "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w==",
       "dev": true
     },
     "home-or-tmp": {
@@ -11488,16 +11405,16 @@
       "dev": true
     },
     "load-bmfont": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.3.0.tgz",
-      "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.3.1.tgz",
+      "integrity": "sha512-lQkEawgez06lM2iw1vQEEOtVLJXyMzFcUqbwWMrB0g6zwhdUs/+e0KNd1zEJ7OFBbMVz0tbzQyjgjtTB47+PBg==",
       "dev": true,
       "requires": {
         "buffer-equal": "0.0.1",
         "mime": "^1.3.4",
         "parse-bmfont-ascii": "^1.0.3",
         "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.0",
+        "parse-bmfont-xml": "^1.1.4",
         "xhr": "^2.0.1",
         "xtend": "^4.0.0"
       }
@@ -11596,12 +11513,6 @@
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
-    },
-    "lodash-es": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg==",
       "dev": true
     },
     "lodash._arraycopy": {
@@ -16946,12 +16857,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "open": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
-      "dev": true
-    },
     "opener": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
@@ -17245,9 +17150,9 @@
       "dev": true
     },
     "parse-bmfont-xml": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
-      "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
+      "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
       "dev": true,
       "requires": {
         "xml-parse-from-string": "^1.0.0",
@@ -20581,19 +20486,19 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.4.0.tgz",
-      "integrity": "sha512-WDnC1FSHTedvRSS8BZB73tPAx2svUCWFdcxVjrybw8pbKOAB1v5S/pW0EamkqQoL1mXiBc+v8lyYjhhzMHIk1Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.7.0.tgz",
+      "integrity": "sha512-f+1DxKHPqce6CXUBz2eVO2WcATeVeQSOPG9GYaGObEZDCiCEUwG+gogjMsrvn7he2wHTqNVb5p6RUrwmr8XFBA==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
-        "extract-zip": "^1.6.5",
-        "https-proxy-agent": "^2.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
         "mime": "^2.0.3",
         "progress": "^2.0.0",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
-        "ws": "^3.0.0"
+        "ws": "^5.1.1"
       },
       "dependencies": {
         "debug": {
@@ -20616,6 +20521,15 @@
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
           "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
           "dev": true
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },
@@ -20681,15 +20595,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
-    },
-    "raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
     },
     "ramda": {
       "version": "0.25.0",
@@ -20801,19 +20706,6 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
-      }
-    },
-    "react": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
-      "dev": true,
-      "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
       }
     },
     "react-codemirror2": {
@@ -20969,18 +20861,6 @@
         }
       }
     },
-    "react-dom": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
-      }
-    },
     "react-error-overlay": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
@@ -21009,77 +20889,6 @@
       "dev": true,
       "requires": {
         "react-icon-base": "2.1.0"
-      }
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
-    },
-    "react-modal": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.4.tgz",
-      "integrity": "sha512-5VYNvy301Z0xxGBQhPmDdzOcyEkUG8sU7bpRsAPI4OHgEUkbBFrpjzs/ocNI0m824/lOqTxddXzwgmDJXx3s3Q==",
-      "dev": true,
-      "requires": {
-        "exenv": "^1.2.0",
-        "prop-types": "^15.5.10",
-        "react-lifecycles-compat": "^3.0.0",
-        "warning": "^3.0.0"
-      }
-    },
-    "react-motion": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
-      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^0.2.0",
-        "prop-types": "^15.5.8",
-        "raf": "^3.1.0"
-      },
-      "dependencies": {
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true
-        }
-      }
-    },
-    "react-redux": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
-      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
-      "dev": true,
-      "requires": {
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.0.0",
-        "lodash": "^4.17.5",
-        "lodash-es": "^4.17.5",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.0"
-      }
-    },
-    "react-sticky": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.2.tgz",
-      "integrity": "sha512-eXsij6ifE2k1d6eCwQzil0JRS3VLP6BYfiF7qEbVPL3GLqciedGJfbavpXx5T95x5HvhuAA4FChYEDv83r1NyQ==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.8",
-        "raf": "^3.3.0"
-      }
-    },
-    "react-toggle-button": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-toggle-button/-/react-toggle-button-2.2.0.tgz",
-      "integrity": "sha1-obkhQ6oN9BRkL8sUHwh59UW8Wok=",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.6.0",
-        "react-motion": "^0.5.2"
       }
     },
     "read-cache": {
@@ -21287,18 +21096,6 @@
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
-      }
-    },
-    "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
       }
     },
     "regenerate": {
@@ -22979,45 +22776,6 @@
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
     },
-    "styled-components": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.4.0.tgz",
-      "integrity": "sha512-bLW0/lQxTgJ0y+TEllctly+/B0Hz2N82e5AhubP+FIVPSisyOzyFnZzWdqRml7RDwRCsT+EGNN8YYa0VFutT+w==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.0.3",
-        "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.9",
-        "hoist-non-react-statics": "^1.2.0",
-        "is-plain-object": "^2.0.1",
-        "prop-types": "^15.5.4",
-        "stylis": "^3.4.0",
-        "supports-color": "^3.2.3"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
-      }
-    },
     "stylelint": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.2.1.tgz",
@@ -23345,12 +23103,6 @@
         "object-assign": "^4.1.0",
         "ramda": "^0.25.0"
       }
-    },
-    "stylis": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
-      "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==",
-      "dev": true
     },
     "sugarss": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-preset-env": "^1.6.0",
     "babel-preset-stage-2": "^6.22.0",
     "babel-register": "^6.22.0",
-    "backstopjs": "^3.1.19",
+    "backstopjs": "^3.5.5",
     "chalk": "^2.3.1",
     "chromedriver": "^2.35.0",
     "clean-webpack-plugin": "^0.1.16",

--- a/src/components/accordion/examples/Accordion.vue
+++ b/src/components/accordion/examples/Accordion.vue
@@ -43,6 +43,7 @@
       <cdr-accordion-item
         id="compact"
         label="Compact"
+        data-backstop="accordion-compact"
       >
         <ul>
           <li>

--- a/src/components/button/examples/demo/Default.vue
+++ b/src/components/button/examples/demo/Default.vue
@@ -32,7 +32,7 @@
         tag="a"
         href="https://rei.com"
         size="large"
-        data-backstop="cdr-button--large anchor">
+        data-backstop="cdr-button--anchor">
         Link
       </cdr-button>
     </div>

--- a/src/components/cta/CdrCta.backstop.js
+++ b/src/components/cta/CdrCta.backstop.js
@@ -9,7 +9,7 @@ module.exports = [{
     '[data-backstop="cdr-cta--light"]',
     '[data-backstop="cdr-cta--sale"]',
     '[data-backstop="cdr-cta--full-width"]',
-    '[data-backstop="cdr-cta--elevated]',
+    '[data-backstop="cdr-cta--elevated"]',
   ],
   hoverSelectors: [
     '[data-backstop="cdr-cta--brand"]',
@@ -17,6 +17,6 @@ module.exports = [{
     '[data-backstop="cdr-cta--light"]',
     '[data-backstop="cdr-cta--sale"]',
     '[data-backstop="cdr-cta--full-width"]',
-    '[data-backstop="cdr-cta--elevated]',
+    '[data-backstop="cdr-cta--elevated"]',
   ],
 }];

--- a/src/css/generic/reset.pcss
+++ b/src/css/generic/reset.pcss
@@ -29,12 +29,11 @@ html {
 }
 
 body {
+  @include redwood-body-20;
+
+  line-height: 1;
   margin: 0;
-  font-family: $font-family-sans-serif;
-  font-size: 1.6rem;
-  font-weight: normal;
-  line-height: 1.5;
-  color: #292b2c;
+  color: $text-color-primary-on-light;
   background-color: #fff;
 }
 
@@ -102,7 +101,7 @@ dd {
 }
 
 blockquote {
-  margin: 0 0 1rem;
+  margin: 0;
 }
 
 dfn {
@@ -135,14 +134,15 @@ sup {
 }
 
 a {
-  color: #0275d8;
+  color: $link-color;
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects;
 }
 
-a:hover {
-  color: #014c8c;
+a:hover,
+a:active {
+  color: $link-color;
   text-decoration: underline;
 }
 
@@ -176,7 +176,7 @@ pre {
 }
 
 figure {
-  margin: 0 0 1rem;
+  margin: 0;
 }
 
 img {
@@ -208,7 +208,7 @@ table {
 caption {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  color: #636c72;
+  color: inherit;
   text-align: left;
   caption-side: bottom;
 }
@@ -219,11 +219,10 @@ th {
 
 label {
   display: inline-block;
-  margin-bottom: 0.5rem;
+  margin: 0;
 }
 
 button:focus {
-  outline: 0.1rem dotted;
   outline: 0.5rem auto -webkit-focus-ring-color;
 }
 


### PR DESCRIPTION
I started out going a lot more heavy handed with these changes to try and make more of the default selectors look like ours by default. This was causing a lot of component specific updates to maintain their styles. I decided instead to cut all of that out and kept to the purpose of resets and just tried to remove some of the unwanted side-effects here while changing colors/fonts to use our tokens.

cdr-assets will need to be updated to 0.4.0 to publish these out.

I was using backstop A TON and got sick of seeing a couple errors in there every time I ran instead of all green so I fixed those too while I was in here.