### PR TITLE
feat(18.9.1 release): release adds support for cdr-icon and updates t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,118 @@
 <a name="18.8.1"></a>
+## [18.8.1](https://github.com/rei/rei-cedar/compare/v5.0.0-alpha.1...v18.8.1) (2018-09-13)
+
+
+### Bug Fixes
+
+* **accordion:** add dynamic class to change cdr-accordion-item z-index on focus/blur ([b701ab7](https://github.com/rei/rei-cedar/commit/b701ab7))
+* **accordion:** fix css bugs ([d19278c](https://github.com/rei/rei-cedar/commit/d19278c))
+* **accordion:** set visibility hidden on cdr-accordion-item slot contents when closed ([81a5a0d](https://github.com/rei/rei-cedar/commit/81a5a0d))
+* **activity card:** correct border-radius on image to match card ([5a48d79](https://github.com/rei/rei-cedar/commit/5a48d79))
+* **breadcrumb:** fixed console error where element was not available in resize event ([dea6b8b](https://github.com/rei/rei-cedar/commit/dea6b8b))
+* **button:** bump version to match alpha ([3439b98](https://github.com/rei/rei-cedar/commit/3439b98))
+* **button cta:** import cdr-icon css for components packaged with an icon ([6bb2233](https://github.com/rei/rei-cedar/commit/6bb2233))
+* **cdr-img:** add radius to cropped/ratio images ([ceefec6](https://github.com/rei/rei-cedar/commit/ceefec6))
+* **cdr-img:** the radius validator did not have the correct values, removing them and updating radiu ([c39066d](https://github.com/rei/rei-cedar/commit/c39066d))
+* **cta:** fix box shadow on --light --elevated ([341f2de](https://github.com/rei/rei-cedar/commit/341f2de))
+* **icons:** flip incorrect pin-fill and pin-stroke icons ([4a3ce56](https://github.com/rei/rei-cedar/commit/4a3ce56))
+* **select:** fix bug with selenium interaction ([18fbab3](https://github.com/rei/rei-cedar/commit/18fbab3))
+* **select:** update variable name ([dbdc0e4](https://github.com/rei/rei-cedar/commit/dbdc0e4))
+* **test:** added breadcrumb and input page links ([eebb259](https://github.com/rei/rei-cedar/commit/eebb259))
+
+
+### Features
+
+* **accordion:** update dependencies ([d45808f](https://github.com/rei/rei-cedar/commit/d45808f))
+* **accordion button cta:** bump versions to match alpha release ([c7f21bb](https://github.com/rei/rei-cedar/commit/c7f21bb))
+* **activity-card:** update dependencies ([efcc917](https://github.com/rei/rei-cedar/commit/efcc917))
+* **breadcrumb:** breadcrumb component is ready for pr ([984a31c](https://github.com/rei/rei-cedar/commit/984a31c))
+* **breadcrumb:** final cleanup after pr comments ([34467e9](https://github.com/rei/rei-cedar/commit/34467e9))
+* **breadcrumb:** update dependencies ([9cf4192](https://github.com/rei/rei-cedar/commit/9cf4192))
+* **breadcrumb:** update version ([fa16f95](https://github.com/rei/rei-cedar/commit/fa16f95))
+* **button:** update dependencies ([9f2c00d](https://github.com/rei/rei-cedar/commit/9f2c00d))
+* **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+* **caption:** update dependencies ([daee967](https://github.com/rei/rei-cedar/commit/daee967))
+* **card:** update dependencies ([0ef7910](https://github.com/rei/rei-cedar/commit/0ef7910))
+* **cdr-image v1 release:** moving the package.json to v1 for the cdr-image component ([6fa1cc7](https://github.com/rei/rei-cedar/commit/6fa1cc7))
+* **cdr-list release:** moving cdr-list to V1 and updating its readme ([451d3ae](https://github.com/rei/rei-cedar/commit/451d3ae))
+* **cdr-radio release:** updates to the cdr-radio readme API and moving the package.json to v1 ([13b35c4](https://github.com/rei/rei-cedar/commit/13b35c4))
+* **cedar proving grounds:** loops through all the routes, which have been moved to routes.js, and e ([7cda2b3](https://github.com/rei/rei-cedar/commit/7cda2b3))
+* **checkbox:** update dependencies ([ea5d4fa](https://github.com/rei/rei-cedar/commit/ea5d4fa))
+* **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
+* **crd-checkbox release:** updates to the cdr-checkbox API readme and bumping the package to v1 ([0066831](https://github.com/rei/rei-cedar/commit/0066831))
+* **cta:** update dependencies ([6467ba2](https://github.com/rei/rei-cedar/commit/6467ba2))
+* **cta:** update readme, bump version ([4f87071](https://github.com/rei/rei-cedar/commit/4f87071))
+* **grid:** consolidate col's alignSelf props to single alignSelf ([0058ad0](https://github.com/rei/rei-cedar/commit/0058ad0))
+* **grid:** consolidate col's offsetLeft props to just offsetLeft ([ecc3294](https://github.com/rei/rei-cedar/commit/ecc3294))
+* **grid:** consolidate col's offsetRight props to single offsetRight ([b812e99](https://github.com/rei/rei-cedar/commit/b812e99))
+* **grid:** consolidate col's span props to just span ([a3ef361](https://github.com/rei/rei-cedar/commit/a3ef361))
+* **grid:** move col and row to single package ([b0469b6](https://github.com/rei/rei-cedar/commit/b0469b6))
+* **grid:** release 0.2.0 ([accc22b](https://github.com/rei/rei-cedar/commit/accc22b))
+* **grid:** update align prop to accept responsive values ([1907de8](https://github.com/rei/rei-cedar/commit/1907de8))
+* **grid:** update col and justify props to accept responsive values ([c572a51](https://github.com/rei/rei-cedar/commit/c572a51))
+* **grid:** update dependencies ([4c320d1](https://github.com/rei/rei-cedar/commit/4c320d1))
+* **grid:** update gutter prop to accept responsive values ([a3f613f](https://github.com/rei/rei-cedar/commit/a3f613f))
+* **grid:** update row's nowrap prop to accept responsive values ([6dd3514](https://github.com/rei/rei-cedar/commit/6dd3514))
+* **grid:** update vertical prop to be a string and accept responsive values ([008f05b](https://github.com/rei/rei-cedar/commit/008f05b))
+* **grid:** update wrap prop to be a string and accept responsive values ([cfe2d8a](https://github.com/rei/rei-cedar/commit/cfe2d8a))
+* **icon:** add a slot to all components ([5bd063f](https://github.com/rei/rei-cedar/commit/5bd063f))
+* **icon:** add grid-view, list-view, and scan-barcode icons ([918f782](https://github.com/rei/rei-cedar/commit/918f782))
+* **icon:** update dependencies ([6b6c0fe](https://github.com/rei/rei-cedar/commit/6b6c0fe))
+* **image:** update dependencies ([d1adf01](https://github.com/rei/rei-cedar/commit/d1adf01))
+* **input:** update dependencies ([e6b43fa](https://github.com/rei/rei-cedar/commit/e6b43fa))
+* **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **link:** update dependencies ([bf6b68e](https://github.com/rei/rei-cedar/commit/bf6b68e))
+* **link:** use css modules for link ([6b244d2](https://github.com/rei/rei-cedar/commit/6b244d2))
+* **link:** use css modules with link ([bfb98f9](https://github.com/rei/rei-cedar/commit/bfb98f9))
+* **list:** update dependencies ([1d78423](https://github.com/rei/rei-cedar/commit/1d78423))
+* **media-object:** update dependencies ([ec035df](https://github.com/rei/rei-cedar/commit/ec035df))
+* **proving grounds:** removes cruft ([ae8c943](https://github.com/rei/rei-cedar/commit/ae8c943))
+* **quote:** update dependencies ([6d0149e](https://github.com/rei/rei-cedar/commit/6d0149e))
+* **quote:** update to the quote component merging block into the base class for cdr-quote. This ena ([f53e0b7](https://github.com/rei/rei-cedar/commit/f53e0b7))
+* **radio:** update dependencies ([d2786a5](https://github.com/rei/rei-cedar/commit/d2786a5))
+* **rating:** new icons, color adjustments, add ability to make the component a link ([302f30c](https://github.com/rei/rei-cedar/commit/302f30c))
+* **rating:** update dependencies ([98f8250](https://github.com/rei/rei-cedar/commit/98f8250))
+* **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
+* **release:** cedar Alpha release ([883ff94](https://github.com/rei/rei-cedar/commit/883ff94))
+* **resets:** normalize resets to use tokens ([5a705e3](https://github.com/rei/rei-cedar/commit/5a705e3))
+* **search:** update dependencies ([f8d98b6](https://github.com/rei/rei-cedar/commit/f8d98b6))
+* **select:** update dependencies ([cd60f29](https://github.com/rei/rei-cedar/commit/cd60f29))
+* **text:** update dependencies ([506d029](https://github.com/rei/rei-cedar/commit/506d029))
+* **tokens:** consume [@rei](https://github.com/rei)/cdr-tokens package ([f094978](https://github.com/rei/rei-cedar/commit/f094978))
+
+
+### BREAKING CHANGES
+
+* **icons:** pin-fill and pin-stroke have been reversed to correct a naming error
+* **components:** Components are now using css-modules for unique class names tied to the package version
+* **icon:** Replace star icons with new ones
+* **rating:** Sizes have changed -- small: 16px, medium(default): 24px, large: 32px
+* **release:** CdrLink and CdrText are moving to V1
+* **grid:** alignSelfSm, alignSelfMd, alignSelfLg consolidated to just alignSelf that accepts responsive
+modifiers
+* **grid:** offsetRightSm, offsetRightMd, offsetRightLg consolidated to just offsetRight that accepts responsive modifiers
+* **grid:** offsetLeftSm, offsetLeftMd, offsetLeftLg consolidated to just offsetLeft that accepts responsive
+modifiers
+* **grid:** spanSm, spanMd, spanLg removed and span accepts responsive modifiers
+* **grid:** change row's nowrap prop from boolean to string. Remove nowrapSm, nowrapMd, nowrapLg in favor of
+using nowrap with responsive modifiers
+* **resets:** Default line height changed from 1.15 to 1 | Remove default margin on blockquote, figure, and label
+elements
+* **grid:** vertical prop is now a string instead of boolean. verticalSm, verticalMd, verticalLg removed and now
+supports responsive modifiers
+* **grid:** gutterSm, gutterMd, gutterLg replaced with just gutter
+* **grid:** alignSm, alignMd, alignLg replaced with just align that accepts responsive values
+* **grid:** colsSm, colsMd, colsLg replaced with just cols prop. justifySm, justifyMd, justifyLg replaced with
+just justify prop
+* **buttons:** Buttons use css modules
+* **grid:** grid css is no longer in cdr-assets, col and row are no longer their own packages
+* **link:** link uses css modules
+* **link:** link now uses css modules
+* **grid:** remove wrapSm, wrapMd, wrapLg in favor of using wrap with responsive modifiers
+
+
+
+<a name="18.8.1"></a>
 ## [18.8.1](https://github.com/rei/rei-cedar/compare/v5.0.0-alpha.1...v18.8.1) (2018-08-01)
 
 

--- a/src/cdr-assets/CHANGELOG.md
+++ b/src/cdr-assets/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.2.0"></a>
-# 0.2.0 (2018-08-01)
+<a name="0.3.0"></a>
+# 0.3.0 (2018-09-13)
 
 
 ### Bug Fixes
@@ -19,11 +19,14 @@
 * **icon:** generate new sprite, externalize icon.json ([f49f828](https://github.com/rei/rei-cedar/commit/f49f828))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
+* **resets:** normalize resets to use tokens ([5a705e3](https://github.com/rei/rei-cedar/commit/5a705e3))
 * **tokens:** output token file for cdr-assets ([717836f](https://github.com/rei/rei-cedar/commit/717836f))
 
 
 ### BREAKING CHANGES
 
+* **resets:** Default line height changed from 1.15 to 1 | Remove default margin on blockquote, figure, and label
+elements
 * **assets:** icon assets are removed from cdr-assets and are now in cdr-icon
 * **grid:** row no longer has a margin-bottom so no styles bleed
 * **all components:** Change all package names to cdr- prefix. Package name for cdr-image changed to cdr-img. Package name

--- a/src/components/accordion/CHANGELOG.md
+++ b/src/components/accordion/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Bug Fixes
@@ -12,6 +12,7 @@
 
 ### Features
 
+* **accordion:** update dependencies ([d45808f](https://github.com/rei/rei-cedar/commit/d45808f))
 * **accordion button cta:** bump versions to match alpha release ([c7f21bb](https://github.com/rei/rei-cedar/commit/c7f21bb))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 

--- a/src/components/accordion/package.json
+++ b/src/components/accordion/package.json
@@ -27,12 +27,12 @@
   },
   "peerDependencies": {
     "@rei/cdr-assets": "^0.3.0",
-    "@rei/cdr-icon": "^0.2.0",
+    "@rei/cdr-icon": "^1.0.0",
     "vue": "^2.5.13"
   },
   "devDependencies": {
     "@rei/cdr-assets": "^0.3.0",
-    "@rei/cdr-icon": "^0.2.0",
+    "@rei/cdr-icon": "^1.0.0",
     "pkg-ok": "^2.1.0"
   }
 }

--- a/src/components/breadcrumb/CHANGELOG.md
+++ b/src/components/breadcrumb/CHANGELOG.md
@@ -1,11 +1,17 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
+
+
+### Bug Fixes
+
+* **breadcrumb:** fixed console error where element was not available in resize event ([dea6b8b](https://github.com/rei/rei-cedar/commit/dea6b8b))
 
 
 ### Features
 
 * **breadcrumb:** breadcrumb component is ready for pr ([984a31c](https://github.com/rei/rei-cedar/commit/984a31c))
 * **breadcrumb:** final cleanup after pr comments ([34467e9](https://github.com/rei/rei-cedar/commit/34467e9))
+* **breadcrumb:** update dependencies ([9cf4192](https://github.com/rei/rei-cedar/commit/9cf4192))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 

--- a/src/components/button/CHANGELOG.md
+++ b/src/components/button/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1-alpha.1"></a>
+## 1.0.1-alpha.1 (2018-09-13)
 
 
 ### Bug Fixes
@@ -18,6 +18,7 @@
 * **accordion button cta:** bump versions to match alpha release ([c7f21bb](https://github.com/rei/rei-cedar/commit/c7f21bb))
 * **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
 * **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **button:** update dependencies ([9f2c00d](https://github.com/rei/rei-cedar/commit/9f2c00d))
 * **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))

--- a/src/components/button/package.json
+++ b/src/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-button",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.2",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Button",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-button",
@@ -28,12 +28,12 @@
   },
   "peerDependencies": {
     "@rei/cdr-assets": "^0.3.0",
-    "@rei/cdr-icon": "^0.2.0",
+    "@rei/cdr-icon": "^1.0.0",
     "vue": "^2.5.13"
   },
   "devDependencies": {
     "@rei/cdr-assets": "^0.3.0",
-    "@rei/cdr-icon": "^0.2.0",
+    "@rei/cdr-icon": "^1.0.0",
     "pkg-ok": "^1.1.0"
   }
 }

--- a/src/components/card/CHANGELOG.md
+++ b/src/components/card/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.2.0"></a>
-# 0.2.0 (2018-08-01)
+<a name="0.2.1"></a>
+## 0.2.1 (2018-09-13)
 
 
 ### Chores
@@ -11,6 +11,7 @@
 
 * **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
 * **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
+* **card:** update dependencies ([0ef7910](https://github.com/rei/rei-cedar/commit/0ef7910))
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))

--- a/src/components/card/package.json
+++ b/src/components/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-card",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Card",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-card",

--- a/src/components/checkbox/CHANGELOG.md
+++ b/src/components/checkbox/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Chores
@@ -12,8 +12,9 @@
 * **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
 * **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
 * **cdr-radio release:** updates to the cdr-radio readme API and moving the package.json to v1 ([13b35c4](https://github.com/rei/rei-cedar/commit/13b35c4))
-* **checkbox:** add custom label class ([7012f33](https://github.com/rei/rei-cedar/commit/7012f33))
 * **checkbox:** add custom label class ([d8882b8](https://github.com/rei/rei-cedar/commit/d8882b8))
+* **checkbox:** add custom label class ([7012f33](https://github.com/rei/rei-cedar/commit/7012f33))
+* **checkbox:** update dependencies ([ea5d4fa](https://github.com/rei/rei-cedar/commit/ea5d4fa))
 * **checkbox radio:** update checkbox and radio to design spec ([30a5ef0](https://github.com/rei/rei-cedar/commit/30a5ef0))
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
 * **crd-checkbox release:** updates to the cdr-checkbox API readme and bumping the package to v1 ([0066831](https://github.com/rei/rei-cedar/commit/0066831))

--- a/src/components/cta/CHANGELOG.md
+++ b/src/components/cta/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Bug Fixes
@@ -13,6 +13,7 @@
 
 * **accordion button cta:** bump versions to match alpha release ([c7f21bb](https://github.com/rei/rei-cedar/commit/c7f21bb))
 * **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
+* **cta:** update dependencies ([6467ba2](https://github.com/rei/rei-cedar/commit/6467ba2))
 * **cta:** update readme, bump version ([4f87071](https://github.com/rei/rei-cedar/commit/4f87071))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))

--- a/src/components/cta/package.json
+++ b/src/components/cta/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@rei/cdr-assets": "^0.3.0",
-    "@rei/cdr-icon": "^0.2.0",
+    "@rei/cdr-icon": "^1.0.0",
     "vue": "^2.5.13"
   },
   "devDependencies": {

--- a/src/components/cta/package.json
+++ b/src/components/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-cta",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Cta",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-cta",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@rei/cdr-assets": "^0.3.0",
-    "@rei/cdr-icon": "^0.2.0",
+    "@rei/cdr-icon": "^1.0.0",
     "pkg-ok": "^2.1.0"
   }
 }

--- a/src/components/grid/CHANGELOG.md
+++ b/src/components/grid/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Features
@@ -12,6 +12,7 @@
 * **grid:** release 0.2.0 ([accc22b](https://github.com/rei/rei-cedar/commit/accc22b))
 * **grid:** update align prop to accept responsive values ([1907de8](https://github.com/rei/rei-cedar/commit/1907de8))
 * **grid:** update col and justify props to accept responsive values ([c572a51](https://github.com/rei/rei-cedar/commit/c572a51))
+* **grid:** update dependencies ([4c320d1](https://github.com/rei/rei-cedar/commit/4c320d1))
 * **grid:** update gutter prop to accept responsive values ([a3f613f](https://github.com/rei/rei-cedar/commit/a3f613f))
 * **grid:** update row's nowrap prop to accept responsive values ([6dd3514](https://github.com/rei/rei-cedar/commit/6dd3514))
 * **grid:** update vertical prop to be a string and accept responsive values ([008f05b](https://github.com/rei/rei-cedar/commit/008f05b))

--- a/src/components/icon/CHANGELOG.md
+++ b/src/components/icon/CHANGELOG.md
@@ -1,10 +1,11 @@
-<a name="1.0.0-next.beta.1"></a>
-# 1.0.0-next.beta.1 (2018-08-01)
+<a name="1.0.0-next.beta.4"></a>
+# 1.0.0-next.beta.4 (2018-09-13)
 
 
 ### Bug Fixes
 
 * **icon:** prevent flex icon shrinking ([851a078](https://github.com/rei/rei-cedar/commit/851a078))
+* **icons:** flip incorrect pin-fill and pin-stroke icons ([4a3ce56](https://github.com/rei/rei-cedar/commit/4a3ce56))
 
 
 ### Chores
@@ -20,7 +21,9 @@
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **icon:** add a slot to all components ([5bd063f](https://github.com/rei/rei-cedar/commit/5bd063f))
+* **icon:** add grid-view, list-view, and scan-barcode icons ([918f782](https://github.com/rei/rei-cedar/commit/918f782))
 * **icon:** generate new sprite, externalize icon.json ([f49f828](https://github.com/rei/rei-cedar/commit/f49f828))
+* **icon:** update dependencies ([6b6c0fe](https://github.com/rei/rei-cedar/commit/6b6c0fe))
 * **icons:** gernerate icon components ([dcefd4e](https://github.com/rei/rei-cedar/commit/dcefd4e))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **link-component:** simplifies link component props, adds prop to Icon for fill color inheritance ([9d404f4](https://github.com/rei/rei-cedar/commit/9d404f4))
@@ -29,6 +32,8 @@
 
 ### BREAKING CHANGES
 
+* **icons:** pin-fill and pin-stroke have been reversed to correct a naming error
+* **icon:** Replace star icons with new ones
 * **components:** Components are now using css-modules for unique class names tied to the package version
 * **icons:** cdr-icon is now used as a lower level component for the icon components. A complete rewrite with no
 backwards compatibility.

--- a/src/components/icon/package.json
+++ b/src/components/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-icon",
-  "version": "1.0.0-next.beta.4",
+  "version": "1.0.0",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Icon",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-icon",

--- a/src/components/image/CHANGELOG.md
+++ b/src/components/image/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Bug Fixes
@@ -22,6 +22,7 @@
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
+* **image:** update dependencies ([d1adf01](https://github.com/rei/rei-cedar/commit/d1adf01))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))

--- a/src/components/input/CHANGELOG.md
+++ b/src/components/input/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.1.2"></a>
-## 0.1.2 (2018-08-01)
+<a name="0.1.3"></a>
+## 0.1.3 (2018-09-13)
 
 
 ### Chores
@@ -16,6 +16,7 @@
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **input:** add keydown event ([3c476b3](https://github.com/rei/rei-cedar/commit/3c476b3))
 * **input:** return event along with value in input event ([975fcc4](https://github.com/rei/rei-cedar/commit/975fcc4))
+* **input:** update dependencies ([e6b43fa](https://github.com/rei/rei-cedar/commit/e6b43fa))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))

--- a/src/components/link/CHANGELOG.md
+++ b/src/components/link/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Features
@@ -7,6 +7,7 @@
 * **buttons:** update to use css modules ([a5e5fda](https://github.com/rei/rei-cedar/commit/a5e5fda))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **link:** update dependencies ([bf6b68e](https://github.com/rei/rei-cedar/commit/bf6b68e))
 * **link:** use css modules for link ([6b244d2](https://github.com/rei/rei-cedar/commit/6b244d2))
 * **link:** use css modules with link ([bfb98f9](https://github.com/rei/rei-cedar/commit/bfb98f9))
 * **link-component:** simplifies link component props, adds prop to Icon for fill color inheritance ([9d404f4](https://github.com/rei/rei-cedar/commit/9d404f4))

--- a/src/components/link/package.json
+++ b/src/components/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-link",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Link",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-link",
@@ -27,7 +27,7 @@
     "build:docs": "node build/docs-build.js"
   },
   "dependencies": {
-    "@rei/cdr-icon": "^0.1.0"
+    "@rei/cdr-icon": "^1.0.0"
   },
   "peerDependencies": {
     "@rei/cdr-assets": "^0.3.0",

--- a/src/components/list/CHANGELOG.md
+++ b/src/components/list/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Chores
@@ -17,6 +17,7 @@
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **list:** update dependencies ([1d78423](https://github.com/rei/rei-cedar/commit/1d78423))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 

--- a/src/components/mediaObject/CHANGELOG.md
+++ b/src/components/mediaObject/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.1.1"></a>
-## 0.1.1 (2018-08-01)
+<a name="0.1.2"></a>
+## 0.1.2 (2018-09-13)
 
 
 ### Chores
@@ -16,6 +16,7 @@
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **media-object:** update dependencies ([ec035df](https://github.com/rei/rei-cedar/commit/ec035df))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 

--- a/src/components/mediaObject/package.json
+++ b/src/components/mediaObject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-media-object",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Media Object",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-media-object",
@@ -29,15 +29,15 @@
   "peerDependencies": {
     "@rei/cdr-assets": "^0.3.0",
     "@rei/cdr-link": "^1.0.0",
-    "@rei/cdr-icon": "^0.2.0",
-    "@rei/cdr-img": "^1.0.0-alpha.1",
+    "@rei/cdr-icon": "^1.0.0",
+    "@rei/cdr-img": "^1.0.0",
     "vue": "^2.5.13"
   },
   "devDependencies": {
     "@rei/cdr-link": "^1.0.0",
     "@rei/cdr-assets": "^0.3.0",
-    "@rei/cdr-icon": "^0.2.0",
-    "@rei/cdr-img": "^1.0.0-alpha.1",
+    "@rei/cdr-icon": "^1.0.0",
+    "@rei/cdr-img": "^1.0.0",
     "pkg-ok": "^1.1.0"
   }
 }

--- a/src/components/quote/CHANGELOG.md
+++ b/src/components/quote/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.1.0"></a>
-# 0.1.0 (2018-08-01)
+<a name="0.1.1"></a>
+## 0.1.1 (2018-09-13)
 
 
 ### Bug Fixes
@@ -19,6 +19,8 @@
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **quote:** update dependencies ([6d0149e](https://github.com/rei/rei-cedar/commit/6d0149e))
+* **quote:** update to the quote component merging block into the base class for cdr-quote. This ena ([f53e0b7](https://github.com/rei/rei-cedar/commit/f53e0b7))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 

--- a/src/components/radio/CHANGELOG.md
+++ b/src/components/radio/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Chores
@@ -17,6 +17,7 @@
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **radio:** update dependencies ([d2786a5](https://github.com/rei/rei-cedar/commit/d2786a5))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 

--- a/src/components/rating/CHANGELOG.md
+++ b/src/components/rating/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.1.1"></a>
-## 0.1.1 (2018-08-01)
+<a name="1.0.0-alpha.2"></a>
+# 1.0.0-alpha.2 (2018-09-13)
 
 
 ### Bug Fixes
@@ -20,12 +20,15 @@
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))
 * **docs:** added all component's routes to rei-cedar project, and a couple compositions as a POC ([29fdf72](https://github.com/rei/rei-cedar/commit/29fdf72))
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
+* **rating:** new icons, color adjustments, add ability to make the component a link ([302f30c](https://github.com/rei/rei-cedar/commit/302f30c))
+* **rating:** update dependencies ([98f8250](https://github.com/rei/rei-cedar/commit/98f8250))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
 
 
 ### BREAKING CHANGES
 
+* **rating:** Sizes have changed -- small: 16px, medium(default): 24px, large: 32px
 * **components:** Components are now using css-modules for unique class names tied to the package version
 * **release:** packages no longer have plugin as default export
 * **build:** Raw component cdr-* peerdependencies are no longer bundled

--- a/src/components/select/CHANGELOG.md
+++ b/src/components/select/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.1.1"></a>
-## 0.1.1 (2018-08-01)
+<a name="0.1.2"></a>
+## 0.1.2 (2018-09-13)
 
 
 ### Bug Fixes
@@ -23,6 +23,7 @@
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
+* **select:** update dependencies ([cd60f29](https://github.com/rei/rei-cedar/commit/cd60f29))
 
 
 ### BREAKING CHANGES

--- a/src/components/text/CHANGELOG.md
+++ b/src/components/text/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-08-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-09-13)
 
 
 ### Chores
@@ -17,6 +17,7 @@
 * **release:** cedar Alpha release ([883ff94](https://github.com/rei/rei-cedar/commit/883ff94))
 * **template:** the cdr-text component has been updated with the following two variants:  default pa ([f23e61f](https://github.com/rei/rei-cedar/commit/f23e61f))
 * **text:** add text component ([bb481c5](https://github.com/rei/rei-cedar/commit/bb481c5))
+* **text:** update dependencies ([506d029](https://github.com/rei/rei-cedar/commit/506d029))
 
 
 ### BREAKING CHANGES

--- a/src/compositions/activityCard/CHANGELOG.md
+++ b/src/compositions/activityCard/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.1.1"></a>
-## 0.1.1 (2018-08-01)
+<a name="0.1.2"></a>
+## 0.1.2 (2018-09-13)
 
 
 ### Bug Fixes
@@ -15,6 +15,7 @@
 ### Features
 
 * **activity-card:** publish new plugin build ([2fb19e3](https://github.com/rei/rei-cedar/commit/2fb19e3))
+* **activity-card:** update dependencies ([efcc917](https://github.com/rei/rei-cedar/commit/efcc917))
 * **all components:** change package name prefixes from cedar-* to cdr-* ([dad0dfb](https://github.com/rei/rei-cedar/commit/dad0dfb)), closes [#354](https://github.com/rei/rei-cedar/issues/354)
 * **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))

--- a/src/compositions/activityCard/package.json
+++ b/src/compositions/activityCard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-activity-card",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Activity Card",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-card-activity",
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@rei/cdr-assets": "^0.3.0",
     "@rei/cdr-card": "^0.2.0",
-    "@rei/cdr-icon": "^0.1.0",
+    "@rei/cdr-icon": "^1.0.0",
     "@rei/cdr-img": "^1.0.0",
     "@rei/cdr-list": "^1.0.0",
     "@rei/cdr-media-object": "^0.1.0",
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@rei/cdr-assets": "^0.3.0",
     "@rei/cdr-card": "^0.2.0",
-    "@rei/cdr-icon": "^0.1.0",
+    "@rei/cdr-icon": "^1.0.0",
     "@rei/cdr-img": "^1.0.0",
     "@rei/cdr-list": "^1.0.0",
     "@rei/cdr-media-object": "^0.1.0",

--- a/src/compositions/caption/CHANGELOG.md
+++ b/src/compositions/caption/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.1.0"></a>
-# 0.1.0 (2018-08-01)
+<a name="0.1.1"></a>
+## 0.1.1 (2018-09-13)
 
 
 ### Chores
@@ -11,6 +11,7 @@
 
 * **assets:** bump to 0.2.0 with removal of icon assets ([2e57098](https://github.com/rei/rei-cedar/commit/2e57098))
 * **caption:** clean up caption composition ([d88bfa5](https://github.com/rei/rei-cedar/commit/d88bfa5))
+* **caption:** update dependencies ([daee967](https://github.com/rei/rei-cedar/commit/daee967))
 * **component:** the cdr-quote component allows for block and pull quotes. spacing, inset, and break ([2c30b1a](https://github.com/rei/rei-cedar/commit/2c30b1a))
 * **components:** update components to use css-modules ([ec1321c](https://github.com/rei/rei-cedar/commit/ec1321c))
 * **deps:** update icon and assets for publishing ([48f2c67](https://github.com/rei/rei-cedar/commit/48f2c67))

--- a/src/compositions/search/CHANGELOG.md
+++ b/src/compositions/search/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="0.1.0"></a>
-# 0.1.0 (2018-08-01)
+<a name="0.1.1"></a>
+## 0.1.1 (2018-09-13)
 
 
 ### Bug Fixes
@@ -23,6 +23,7 @@
 * **lerna-semantic-release:** replaced standard changelog with lerna-semantic-release as dev depende ([5084037](https://github.com/rei/rei-cedar/commit/5084037))
 * **release:** bump all to 0.1.0 and remove base-components ([f5c335e](https://github.com/rei/rei-cedar/commit/f5c335e))
 * **release:** button, breadcrumb, grid, and list are released to v1 ([d6973b7](https://github.com/rei/rei-cedar/commit/d6973b7))
+* **search:** update dependencies ([f8d98b6](https://github.com/rei/rei-cedar/commit/f8d98b6))
 
 
 ### BREAKING CHANGES

--- a/src/compositions/search/package.json
+++ b/src/compositions/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-search",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Search",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-search",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "@rei/cdr-assets": "^0.3.0",
     "@rei/cdr-button": "^1.0.0",
-    "@rei/cdr-icon": "^0.2.0",
+    "@rei/cdr-icon": "^1.0.0",
     "@rei/cdr-input": "^0.1.0",
     "vue": "^2.5.13"
   },
   "devDependencies": {
     "@rei/cdr-assets": "^0.3.0",
     "@rei/cdr-button": "^1.0.0",
-    "@rei/cdr-icon": "^0.2.0",
+    "@rei/cdr-icon": "^1.0.0",
     "@rei/cdr-input": "^0.1.0",
     "pkg-ok": "^1.1.0"
   }


### PR DESCRIPTION
…he peer-dependancies of compone

affects: @rei/cdr-assets, @rei/cdr-accordion, @rei/cdr-breadcrumb, @rei/cdr-button, @rei/cdr-card,
@rei/cdr-checkbox, @rei/cdr-cta, @rei/cdr-grid, @rei/cdr-icon, @rei/cdr-img, @rei/cdr-input,
@rei/cdr-link, @rei/cdr-list, @rei/cdr-media-object, @rei/cdr-quote, @rei/cdr-radio,
@rei/cdr-rating, @rei/cdr-select, @rei/cdr-text, @rei/cdr-activity-card, @rei/cdr-caption,
@rei/cdr-search