### PR TITLE
Spacing utility classes

### DIFF
--- a/src/css/README.md
+++ b/src/css/README.md
@@ -77,15 +77,16 @@ Intended to be used for adding margin to the right of an element.
 
 #### Variants
 
-| Class            | property     | value     |
-|------------------|--------------|-----------|
-| .cdr-inline--xxs | margin-right | 2px       |
-| .cdr-inline--xs  | margin-right | 4px       |
-| .cdr-inline--sm  | margin-right | 8px       |
-| .cdr-inline      | margin-right | 16px      |
-| .cdr-inline--lg  | margin-right | 32px      |
-| .cdr-inline--xl  | margin-right | 64px      |
-| .cdr-inline--xxl | margin-right | 128px     |
+| Class                   | property     | value     |
+|-------------------------|--------------|-----------|
+| .inline-eighth-x        | margin-right | 2px       |
+| .inline-quarter-x       | margin-right | 4px       |
+| .inline-half-x          | margin-right | 8px       |
+| .inline-three-quarter-x | margin-right | 12px      |
+| .inline-1-x             | margin-right | 16px      |
+| .inline-1-and-a-half-x  | margin-right | 24px      |
+| .inline-2-x             | margin-right | 32px      |
+| .inline-4-x             | margin-right | 64px      |
 
 ### Insets:
 Used to add padding to all of our elements, it is important to be sure that elements use these variables rather than the generic space values for their internal spacing.
@@ -94,42 +95,45 @@ Used to add padding to all of our elements, it is important to be sure that elem
 
 | Class                              | property       | value     |
 |------------------------------------|----------------|-----------|
-| .cdr-inset--xxs                    | padding        | 2px       |
-| .cdr-inset--xxs.cdr-inset--squish  | padding        | 0 2px     |
-| .cdr-inset--xxs.cdr-inset--stretch | padding        | 4px 2px   |
-| .cdr-inset--xs                     | padding        | 4px       |
-| .cdr-inset--xs.cdr-inset--squish   | padding        | 2px 4px   |
-| .cdr-inset--xs.cdr-inset--stretch  | padding        | 6px 4px   |
-| .cdr-inset--sm                     | padding        | 8px       |
-| .cdr-inset--sm.cdr-inset--squish   | padding        | 4px 8px   |
-| .cdr-inset--sm.cdr-inset--stretch  | padding        | 12px 8px  |
-| .cdr-inset                         | padding        | 16px      |
-| .cdr-inset--squish                 | padding        | 8px 16px  |
-| .cdr-inset--stretch                | padding        | 24px 16px |
-| .cdr-inset--lg                     | padding        | 32px      |
-| .cdr-inset--lg.cdr-inset--squish   | padding        | 16px 32px |
-| .cdr-inset--lg.cdr-inset--stretch  | padding        | 48px 32px |
-| .cdr-inset--xl                     | padding        | 64px      |
-| .cdr-inset--xl.cdr-inset--squish   | padding        | 32px 64px |
-| .cdr-inset--xl.cdr-inset--stretch  | padding        | 96px 64px |
-| .cdr-inset--remove-all             | padding        | 0         |
-| .cdr-inset--remove-top             | padding-top    | 0         |
-| .cdr-inset--remove-right           | padding-right  | 0         |
-| .cdr-inset--remove-bottom          | padding-bottom | 0         |
-| .cdr-inset--remove-left            | padding-left   | 0         |
+| .inset-eighth-x                    | padding        | 2px       |
+| .inset-eighth-x-squish             | padding        | 0 2px     |
+| .inset-eighth-x-stretch            | padding        | 4px 2px   |
+| .inset-quarter-x                   | padding        | 4px       |
+| .inset-quarter-x-squish            | padding        | 2px 4px   |
+| .inset-quarter-x-stretch           | padding        | 6px 4px   |
+| .inset-half-x                      | padding        | 8px       |
+| .inset-half-x-squish               | padding        | 4px 8px   |
+| .inset-half-x-stretch              | padding        | 12px 8px  |
+| .inset-three-quarter-x             | padding        | 12px      |
+| .inset-three-quarter-x-squish      | padding        | 6px 12px  |
+| .inset-three-quarter-x-stretch     | padding        | 18px 12px |
+| .inset-1-x                         | padding        | 16px      |
+| .inset-1-x-squish                  | padding        | 8px 16px  |
+| .inset-1-x-stretch                 | padding        | 24px 16px |
+| .inset-1-and-a-half-x              | padding        | 24px      |
+| .inset-1-and-a-half-x-squish       | padding        | 12px 24px |
+| .inset-1-and-a-half-x-stretch      | padding        | 36px 24px |
+| .inset-2-x                         | padding        | 32px      |
+| .inset-2-x-squish                  | padding        | 16px 32px |
+| .inset-2-x-stretch                 | padding        | 48px 32px |
+| .inset-4-x                         | padding        | 64px      |
+| .inset-4-x-squish                  | padding        | 32px 64px |
+| .inset-4-x-stretch                 | padding        | 96px 64px |
+
 
 ### Stack
 Intended to be used to add margin to the bottom of an element.
 
 #### Variants 
 
-| Class           | property      | value     |
-|-----------------|---------------|-----------|
-| .cdr-stack--xxs | margin-bottom | 2px       |
-| .cdr-stack--xs  | margin-bottom | 4px       |
-| .cdr-stack--sm  | margin-bottom | 8px       |
-| .cdr-stack      | margin-bottom | 16px      |
-| .cdr-stack--lg  | margin-bottom | 32px      |
-| .cdr-stack--xl  | margin-bottom | 64px      |
-| .cdr-stack--xxl | margin-bottom | 128px     |
+| Class                   | property      | value     |
+|-------------------------|---------------|-----------|
+| .stack-eighth-x         | margin-bottom | 2px       |
+| .stack-quarter-x        | margin-bottom | 4px       |
+| .stack-half-x           | margin-bottom | 8px       |
+| .stack-three-quarter-x  | margin-bottom | 12px      |
+| .stack-1-x              | margin-bottom | 16px      |
+| .stack-1-and-a-half-x   | margin-bottom | 24px      |
+| .stack-2-x              | margin-bottom | 32px      |
+| .stack-4-x              | margin-bottom | 64px      |
 

--- a/src/css/main.postcss
+++ b/src/css/main.postcss
@@ -15,3 +15,4 @@
 @import './utility/visibility.pcss';
 @import './utility/a11y.pcss';
 @import './utility/align.pcss';
+@import './utility/spacing.pcss';

--- a/src/css/utility/spacing.pcss
+++ b/src/css/utility/spacing.pcss
@@ -37,34 +37,38 @@
         :inline
 ========================================================================== */
 
-/* 
-  inset values 
+/*
+  inset values
   these reference specific tokens because they exist
 */
 .inset-eighth-x {
   padding: $inset-eighth-x;
 }
+
 .inset-quarter-x {
   padding: $inset-quarter-x;
 }
+
 .inset-half-x {
   padding: $inset-half-x;
 }
-.inset-half-x {
-  padding: $inset-half-x;
-}
+
 .inset-three-quarter-x {
   padding: $inset-three-quarter-x;
 }
+
 .inset-1-x {
   padding: $inset-1-x;
 }
+
 .inset-1-and-a-half-x {
   padding: $inset-1-and-a-half-x;
 }
+
 .inset-2-x {
   padding: $inset-2-x;
 }
+
 .inset-4-x {
   padding: $inset-4-x;
 }
@@ -73,27 +77,31 @@
 .inset-eighth-x-squish {
   padding: $inset-eighth-x-squish;
 }
+
 .inset-quarter-x-squish {
   padding: $inset-quarter-x-squish;
 }
+
 .inset-half-x-squish {
   padding: $inset-half-x-squish;
 }
-.inset-half-x-squish {
-  padding: $inset-half-x-squish;
-}
+
 .inset-three-quarter-x-squish {
   padding: $inset-three-quarter-x-squish;
 }
+
 .inset-1-x-squish {
   padding: $inset-1-x-squish;
 }
+
 .inset-1-and-a-half-x-squish {
   padding: $inset-1-and-a-half-x-squish;
 }
+
 .inset-2-x-squish {
   padding: $inset-2-x-squish;
 }
+
 .inset-4-x-squish {
   padding: $inset-4-x-squish;
 }
@@ -102,27 +110,31 @@
 .inset-eighth-x-stretch {
   padding: $inset-eighth-x-stretch;
 }
+
 .inset-quarter-x-stretch {
   padding: $inset-quarter-x-stretch;
 }
+
 .inset-half-x-stretch {
   padding: $inset-half-x-stretch;
 }
-.inset-half-x-stretch {
-  padding: $inset-half-x-stretch;
-}
+
 .inset-three-quarter-x-stretch {
   padding: $inset-three-quarter-x-stretch;
 }
+
 .inset-1-x-stretch {
   padding: $inset-1-x-stretch;
 }
+
 .inset-1-and-a-half-x-stretch {
   padding: $inset-1-and-a-half-x-stretch;
 }
+
 .inset-2-x-stretch {
   padding: $inset-2-x-stretch;
 }
+
 .inset-4-x-stretch {
   padding: $inset-4-x-stretch;
 }
@@ -131,27 +143,31 @@
 .stack-eighth-x {
   margin-bottom: $space-eighth-x;
 }
+
 .stack-quarter-x {
   margin-bottom: $space-quarter-x;
 }
+
 .stack-half-x {
   margin-bottom: $space-half-x;
 }
-.stack-half-x {
-  margin-bottom: $space-half-x;
-}
+
 .stack-three-quarter-x {
   margin-bottom: $space-three-quarter-x;
 }
+
 .stack-1-x {
   margin-bottom: $space-1-x;
 }
+
 .stack-1-and-a-half-x {
   margin-bottom: $space-1-and-a-half-x;
 }
+
 .stack-2-x {
   margin-bottom: $space-2-x;
 }
+
 .stack-4-x {
   margin-bottom: $space-4-x;
 }
@@ -160,31 +176,34 @@
 .inline-eighth-x {
   margin-right: $space-eighth-x;
 }
+
 .inline-quarter-x {
   margin-right: $space-quarter-x;
 }
+
 .inline-half-x {
   margin-right: $space-half-x;
 }
-.inline-half-x {
-  margin-right: $space-half-x;
-}
+
 .inline-three-quarter-x {
   margin-right: $space-three-quarter-x;
 }
+
 .inline-1-x {
   margin-right: $space-1-x;
 }
+
 .inline-1-and-a-half-x {
   margin-right: $space-1-and-a-half-x;
 }
+
 .inline-2-x {
   margin-right: $space-2-x;
 }
+
 .inline-4-x {
   margin-right: $space-4-x;
 }
-
 
 /* @xs
   0px - 767px
@@ -194,27 +213,31 @@
   .inset-eighth-x\@xs {
     padding: $inset-eighth-x;
   }
+
   .inset-quarter-x\@xs {
     padding: $inset-quarter-x;
   }
+
   .inset-half-x\@xs {
     padding: $inset-half-x;
   }
-  .inset-half-x\@xs {
-    padding: $inset-half-x;
-  }
+
   .inset-three-quarter-x\@xs {
     padding: $inset-three-quarter-x;
   }
+
   .inset-1-x\@xs {
     padding: $inset-1-x;
   }
+
   .inset-1-and-a-half-x\@xs {
     padding: $inset-1-and-a-half-x;
   }
+
   .inset-2-x\@xs {
     padding: $inset-2-x;
   }
+
   .inset-4-x\@xs {
     padding: $inset-4-x;
   }
@@ -223,27 +246,31 @@
   .inset-eighth-x-squish\@xs {
     padding: $inset-eighth-x-squish;
   }
+
   .inset-quarter-x-squish\@xs {
     padding: $inset-quarter-x-squish;
   }
+
   .inset-half-x-squish\@xs {
     padding: $inset-half-x-squish;
   }
-  .inset-half-x-squish\@xs {
-    padding: $inset-half-x-squish;
-  }
+
   .inset-three-quarter-x-squish\@xs {
     padding: $inset-three-quarter-x-squish;
   }
+
   .inset-1-x-squish\@xs {
     padding: $inset-1-x-squish;
   }
+
   .inset-1-and-a-half-x-squish\@xs {
     padding: $inset-1-and-a-half-x-squish;
   }
+
   .inset-2-x-squish\@xs {
     padding: $inset-2-x-squish;
   }
+
   .inset-4-x-squish\@xs {
     padding: $inset-4-x-squish;
   }
@@ -252,27 +279,31 @@
   .inset-eighth-x-stretch\@xs {
     padding: $inset-eighth-x-stretch;
   }
+
   .inset-quarter-x-stretch\@xs {
     padding: $inset-quarter-x-stretch;
   }
+
   .inset-half-x-stretch\@xs {
     padding: $inset-half-x-stretch;
   }
-  .inset-half-x-stretch\@xs {
-    padding: $inset-half-x-stretch;
-  }
+
   .inset-three-quarter-x-stretch\@xs {
     padding: $inset-three-quarter-x-stretch;
   }
+
   .inset-1-x-stretch\@xs {
     padding: $inset-1-x-stretch;
   }
+
   .inset-1-and-a-half-x-stretch\@xs {
     padding: $inset-1-and-a-half-x-stretch;
   }
+
   .inset-2-x-stretch\@xs {
     padding: $inset-2-x-stretch;
   }
+
   .inset-4-x-stretch\@xs {
     padding: $inset-4-x-stretch;
   }
@@ -281,27 +312,31 @@
   .stack-eighth-x\@xs {
     margin-bottom: $space-eighth-x;
   }
+
   .stack-quarter-x\@xs {
     margin-bottom: $space-quarter-x;
   }
+
   .stack-half-x\@xs {
     margin-bottom: $space-half-x;
   }
-  .stack-half-x\@xs {
-    margin-bottom: $space-half-x;
-  }
+
   .stack-three-quarter-x\@xs {
     margin-bottom: $space-three-quarter-x;
   }
+
   .stack-1-x\@xs {
     margin-bottom: $space-1-x;
   }
+
   .stack-1-and-a-half-x\@xs {
     margin-bottom: $space-1-and-a-half-x;
   }
+
   .stack-2-x\@xs {
     margin-bottom: $space-2-x;
   }
+
   .stack-4-x\@xs {
     margin-bottom: $space-4-x;
   }
@@ -310,27 +345,31 @@
   .inline-eighth-x\@xs {
     margin-right: $space-eighth-x;
   }
+
   .inline-quarter-x\@xs {
     margin-right: $space-quarter-x;
   }
+
   .inline-half-x\@xs {
     margin-right: $space-half-x;
   }
-  .inline-half-x\@xs {
-    margin-right: $space-half-x;
-  }
+
   .inline-three-quarter-x\@xs {
     margin-right: $space-three-quarter-x;
   }
+
   .inline-1-x\@xs {
     margin-right: $space-1-x;
   }
+
   .inline-1-and-a-half-x\@xs {
     margin-right: $space-1-and-a-half-x;
   }
+
   .inline-2-x\@xs {
     margin-right: $space-2-x;
   }
+
   .inline-4-x\@xs {
     margin-right: $space-4-x;
   }
@@ -343,27 +382,31 @@
   .inset-eighth-x\@sm {
     padding: $inset-eighth-x;
   }
+
   .inset-quarter-x\@sm {
     padding: $inset-quarter-x;
   }
+
   .inset-half-x\@sm {
     padding: $inset-half-x;
   }
-  .inset-half-x\@sm {
-    padding: $inset-half-x;
-  }
+
   .inset-three-quarter-x\@sm {
     padding: $inset-three-quarter-x;
   }
+
   .inset-1-x\@sm {
     padding: $inset-1-x;
   }
+
   .inset-1-and-a-half-x\@sm {
     padding: $inset-1-and-a-half-x;
   }
+
   .inset-2-x\@sm {
     padding: $inset-2-x;
   }
+  
   .inset-4-x\@sm {
     padding: $inset-4-x;
   }
@@ -372,27 +415,31 @@
   .inset-eighth-x-squish\@sm {
     padding: $inset-eighth-x-squish;
   }
+
   .inset-quarter-x-squish\@sm {
     padding: $inset-quarter-x-squish;
   }
+
   .inset-half-x-squish\@sm {
     padding: $inset-half-x-squish;
   }
-  .inset-half-x-squish\@sm {
-    padding: $inset-half-x-squish;
-  }
+
   .inset-three-quarter-x-squish\@sm {
     padding: $inset-three-quarter-x-squish;
   }
+
   .inset-1-x-squish\@sm {
     padding: $inset-1-x-squish;
   }
+
   .inset-1-and-a-half-x-squish\@sm {
     padding: $inset-1-and-a-half-x-squish;
   }
+
   .inset-2-x-squish\@sm {
     padding: $inset-2-x-squish;
   }
+
   .inset-4-x-squish\@sm {
     padding: $inset-4-x-squish;
   }
@@ -401,27 +448,31 @@
   .inset-eighth-x-stretch\@sm {
     padding: $inset-eighth-x-stretch;
   }
+
   .inset-quarter-x-stretch\@sm {
     padding: $inset-quarter-x-stretch;
   }
+
   .inset-half-x-stretch\@sm {
     padding: $inset-half-x-stretch;
   }
-  .inset-half-x-stretch\@sm {
-    padding: $inset-half-x-stretch;
-  }
+
   .inset-three-quarter-x-stretch\@sm {
     padding: $inset-three-quarter-x-stretch;
   }
+
   .inset-1-x-stretch\@sm {
     padding: $inset-1-x-stretch;
   }
+
   .inset-1-and-a-half-x-stretch\@sm {
     padding: $inset-1-and-a-half-x-stretch;
   }
+
   .inset-2-x-stretch\@sm {
     padding: $inset-2-x-stretch;
   }
+
   .inset-4-x-stretch\@sm {
     padding: $inset-4-x-stretch;
   }
@@ -430,27 +481,31 @@
   .stack-eighth-x\@sm {
     margin-bottom: $space-eighth-x;
   }
+
   .stack-quarter-x\@sm {
     margin-bottom: $space-quarter-x;
   }
+
   .stack-half-x\@sm {
     margin-bottom: $space-half-x;
   }
-  .stack-half-x\@sm {
-    margin-bottom: $space-half-x;
-  }
+
   .stack-three-quarter-x\@sm {
     margin-bottom: $space-three-quarter-x;
   }
+
   .stack-1-x\@sm {
     margin-bottom: $space-1-x;
   }
+
   .stack-1-and-a-half-x\@sm {
     margin-bottom: $space-1-and-a-half-x;
   }
+
   .stack-2-x\@sm {
     margin-bottom: $space-2-x;
   }
+
   .stack-4-x\@sm {
     margin-bottom: $space-4-x;
   }
@@ -459,27 +514,31 @@
   .inline-eighth-x\@sm {
     margin-right: $space-eighth-x;
   }
+
   .inline-quarter-x\@sm {
     margin-right: $space-quarter-x;
   }
+
   .inline-half-x\@sm {
     margin-right: $space-half-x;
   }
-  .inline-half-x\@sm {
-    margin-right: $space-half-x;
-  }
+
   .inline-three-quarter-x\@sm {
     margin-right: $space-three-quarter-x;
   }
+
   .inline-1-x\@sm {
     margin-right: $space-1-x;
   }
+
   .inline-1-and-a-half-x\@sm {
     margin-right: $space-1-and-a-half-x;
   }
+
   .inline-2-x\@sm {
     margin-right: $space-2-x;
   }
+
   .inline-4-x\@sm {
     margin-right: $space-4-x;
   }
@@ -492,27 +551,31 @@
   .inset-eighth-x\@md {
     padding: $inset-eighth-x;
   }
+
   .inset-quarter-x\@md {
     padding: $inset-quarter-x;
   }
+
   .inset-half-x\@md {
     padding: $inset-half-x;
   }
-  .inset-half-x\@md {
-    padding: $inset-half-x;
-  }
+
   .inset-three-quarter-x\@md {
     padding: $inset-three-quarter-x;
   }
+
   .inset-1-x\@md {
     padding: $inset-1-x;
   }
+
   .inset-1-and-a-half-x\@md {
     padding: $inset-1-and-a-half-x;
   }
+
   .inset-2-x\@md {
     padding: $inset-2-x;
   }
+
   .inset-4-x\@md {
     padding: $inset-4-x;
   }
@@ -521,27 +584,31 @@
   .inset-eighth-x-squish\@md {
     padding: $inset-eighth-x-squish;
   }
+
   .inset-quarter-x-squish\@md {
     padding: $inset-quarter-x-squish;
   }
+
   .inset-half-x-squish\@md {
     padding: $inset-half-x-squish;
   }
-  .inset-half-x-squish\@md {
-    padding: $inset-half-x-squish;
-  }
+
   .inset-three-quarter-x-squish\@md {
     padding: $inset-three-quarter-x-squish;
   }
+
   .inset-1-x-squish\@md {
     padding: $inset-1-x-squish;
   }
+
   .inset-1-and-a-half-x-squish\@md {
     padding: $inset-1-and-a-half-x-squish;
   }
+
   .inset-2-x-squish\@md {
     padding: $inset-2-x-squish;
   }
+
   .inset-4-x-squish\@md {
     padding: $inset-4-x-squish;
   }
@@ -550,27 +617,31 @@
   .inset-eighth-x-stretch\@md {
     padding: $inset-eighth-x-stretch;
   }
+
   .inset-quarter-x-stretch\@md {
     padding: $inset-quarter-x-stretch;
   }
+
   .inset-half-x-stretch\@md {
     padding: $inset-half-x-stretch;
   }
-  .inset-half-x-stretch\@md {
-    padding: $inset-half-x-stretch;
-  }
+
   .inset-three-quarter-x-stretch\@md {
     padding: $inset-three-quarter-x-stretch;
   }
+
   .inset-1-x-stretch\@md {
     padding: $inset-1-x-stretch;
   }
+
   .inset-1-and-a-half-x-stretch\@md {
     padding: $inset-1-and-a-half-x-stretch;
   }
+
   .inset-2-x-stretch\@md {
     padding: $inset-2-x-stretch;
   }
+
   .inset-4-x-stretch\@md {
     padding: $inset-4-x-stretch;
   }
@@ -579,27 +650,31 @@
   .stack-eighth-x\@md {
     margin-bottom: $space-eighth-x;
   }
+
   .stack-quarter-x\@md {
     margin-bottom: $space-quarter-x;
   }
+
   .stack-half-x\@md {
     margin-bottom: $space-half-x;
   }
-  .stack-half-x\@md {
-    margin-bottom: $space-half-x;
-  }
+
   .stack-three-quarter-x\@md {
     margin-bottom: $space-three-quarter-x;
   }
+
   .stack-1-x\@md {
     margin-bottom: $space-1-x;
   }
+
   .stack-1-and-a-half-x\@md {
     margin-bottom: $space-1-and-a-half-x;
   }
+
   .stack-2-x\@md {
     margin-bottom: $space-2-x;
   }
+
   .stack-4-x\@md {
     margin-bottom: $space-4-x;
   }
@@ -608,27 +683,31 @@
   .inline-eighth-x\@md {
     margin-right: $space-eighth-x;
   }
+
   .inline-quarter-x\@md {
     margin-right: $space-quarter-x;
   }
+
   .inline-half-x\@md {
     margin-right: $space-half-x;
   }
-  .inline-half-x\@md {
-    margin-right: $space-half-x;
-  }
+
   .inline-three-quarter-x\@md {
     margin-right: $space-three-quarter-x;
   }
+
   .inline-1-x\@md {
     margin-right: $space-1-x;
   }
+
   .inline-1-and-a-half-x\@md {
     margin-right: $space-1-and-a-half-x;
   }
+
   .inline-2-x\@md {
     margin-right: $space-2-x;
   }
+
   .inline-4-x\@md {
     margin-right: $space-4-x;
   }
@@ -642,27 +721,31 @@
   .inset-eighth-x\@lg {
     padding: $inset-eighth-x;
   }
+
   .inset-quarter-x\@lg {
     padding: $inset-quarter-x;
   }
+
   .inset-half-x\@lg {
     padding: $inset-half-x;
   }
-  .inset-half-x\@lg {
-    padding: $inset-half-x;
-  }
+
   .inset-three-quarter-x\@lg {
     padding: $inset-three-quarter-x;
   }
+
   .inset-1-x\@lg {
     padding: $inset-1-x;
   }
+
   .inset-1-and-a-half-x\@lg {
     padding: $inset-1-and-a-half-x;
   }
+  
   .inset-2-x\@lg {
     padding: $inset-2-x;
   }
+
   .inset-4-x\@lg {
     padding: $inset-4-x;
   }
@@ -671,27 +754,31 @@
   .inset-eighth-x-squish\@lg {
     padding: $inset-eighth-x-squish;
   }
+
   .inset-quarter-x-squish\@lg {
     padding: $inset-quarter-x-squish;
   }
+
   .inset-half-x-squish\@lg {
     padding: $inset-half-x-squish;
   }
-  .inset-half-x-squish\@lg {
-    padding: $inset-half-x-squish;
-  }
+
   .inset-three-quarter-x-squish\@lg {
     padding: $inset-three-quarter-x-squish;
   }
+
   .inset-1-x-squish\@lg {
     padding: $inset-1-x-squish;
   }
+
   .inset-1-and-a-half-x-squish\@lg {
     padding: $inset-1-and-a-half-x-squish;
   }
+
   .inset-2-x-squish\@lg {
     padding: $inset-2-x-squish;
   }
+
   .inset-4-x-squish\@lg {
     padding: $inset-4-x-squish;
   }
@@ -700,27 +787,31 @@
   .inset-eighth-x-stretch\@lg {
     padding: $inset-eighth-x-stretch;
   }
+
   .inset-quarter-x-stretch\@lg {
     padding: $inset-quarter-x-stretch;
   }
+
   .inset-half-x-stretch\@lg {
     padding: $inset-half-x-stretch;
   }
-  .inset-half-x-stretch\@lg {
-    padding: $inset-half-x-stretch;
-  }
+
   .inset-three-quarter-x-stretch\@lg {
     padding: $inset-three-quarter-x-stretch;
   }
+
   .inset-1-x-stretch\@lg {
     padding: $inset-1-x-stretch;
   }
+
   .inset-1-and-a-half-x-stretch\@lg {
     padding: $inset-1-and-a-half-x-stretch;
   }
+
   .inset-2-x-stretch\@lg {
     padding: $inset-2-x-stretch;
   }
+
   .inset-4-x-stretch\@lg {
     padding: $inset-4-x-stretch;
   }
@@ -729,27 +820,31 @@
   .stack-eighth-x\@lg {
     margin-bottom: $space-eighth-x;
   }
+
   .stack-quarter-x\@lg {
     margin-bottom: $space-quarter-x;
   }
+
   .stack-half-x\@lg {
     margin-bottom: $space-half-x;
   }
-  .stack-half-x\@lg {
-    margin-bottom: $space-half-x;
-  }
+
   .stack-three-quarter-x\@lg {
     margin-bottom: $space-three-quarter-x;
   }
+
   .stack-1-x\@lg {
     margin-bottom: $space-1-x;
   }
+
   .stack-1-and-a-half-x\@lg {
     margin-bottom: $space-1-and-a-half-x;
   }
+
   .stack-2-x\@lg {
     margin-bottom: $space-2-x;
   }
+
   .stack-4-x\@lg {
     margin-bottom: $space-4-x;
   }
@@ -758,27 +853,31 @@
   .inline-eighth-x\@lg {
     margin-right: $space-eighth-x;
   }
+
   .inline-quarter-x\@lg {
     margin-right: $space-quarter-x;
   }
+
   .inline-half-x\@lg {
     margin-right: $space-half-x;
   }
-  .inline-half-x\@lg {
-    margin-right: $space-half-x;
-  }
+
   .inline-three-quarter-x\@lg {
     margin-right: $space-three-quarter-x;
   }
+
   .inline-1-x\@lg {
     margin-right: $space-1-x;
   }
+
   .inline-1-and-a-half-x\@lg {
     margin-right: $space-1-and-a-half-x;
   }
+
   .inline-2-x\@lg {
     margin-right: $space-2-x;
   }
+
   .inline-4-x\@lg {
     margin-right: $space-4-x;
   }

--- a/src/css/utility/spacing.pcss
+++ b/src/css/utility/spacing.pcss
@@ -1,0 +1,785 @@
+/* ==========================================================================
+  # spacing
+  
+  Utility classes spacing
+
+  TOC:
+
+    :inset
+    :inset-squish
+    :inset-stretch
+    :stack
+    :inline
+    :responsive
+      :xs
+        :inset
+        :inset-squish
+        :inset-stretch
+        :stack
+        :inline
+      :sm
+        :inset
+        :inset-squish
+        :inset-stretch
+        :stack
+        :inline
+      :md
+        :inset
+        :inset-squish
+        :inset-stretch
+        :stack
+        :inline
+      :lg
+        :inset
+        :inset-squish
+        :inset-stretch
+        :stack
+        :inline
+========================================================================== */
+
+/* 
+  inset values 
+  these reference specific tokens because they exist
+*/
+.inset-eighth-x {
+  padding: $inset-eighth-x;
+}
+.inset-quarter-x {
+  padding: $inset-quarter-x;
+}
+.inset-half-x {
+  padding: $inset-half-x;
+}
+.inset-half-x {
+  padding: $inset-half-x;
+}
+.inset-three-quarter-x {
+  padding: $inset-three-quarter-x;
+}
+.inset-1-x {
+  padding: $inset-1-x;
+}
+.inset-1-and-a-half-x {
+  padding: $inset-1-and-a-half-x;
+}
+.inset-2-x {
+  padding: $inset-2-x;
+}
+.inset-4-x {
+  padding: $inset-4-x;
+}
+
+/* inset-squish */
+.inset-eighth-x-squish {
+  padding: $inset-eighth-x-squish;
+}
+.inset-quarter-x-squish {
+  padding: $inset-quarter-x-squish;
+}
+.inset-half-x-squish {
+  padding: $inset-half-x-squish;
+}
+.inset-half-x-squish {
+  padding: $inset-half-x-squish;
+}
+.inset-three-quarter-x-squish {
+  padding: $inset-three-quarter-x-squish;
+}
+.inset-1-x-squish {
+  padding: $inset-1-x-squish;
+}
+.inset-1-and-a-half-x-squish {
+  padding: $inset-1-and-a-half-x-squish;
+}
+.inset-2-x-squish {
+  padding: $inset-2-x-squish;
+}
+.inset-4-x-squish {
+  padding: $inset-4-x-squish;
+}
+
+/* inset-stretch */
+.inset-eighth-x-stretch {
+  padding: $inset-eighth-x-stretch;
+}
+.inset-quarter-x-stretch {
+  padding: $inset-quarter-x-stretch;
+}
+.inset-half-x-stretch {
+  padding: $inset-half-x-stretch;
+}
+.inset-half-x-stretch {
+  padding: $inset-half-x-stretch;
+}
+.inset-three-quarter-x-stretch {
+  padding: $inset-three-quarter-x-stretch;
+}
+.inset-1-x-stretch {
+  padding: $inset-1-x-stretch;
+}
+.inset-1-and-a-half-x-stretch {
+  padding: $inset-1-and-a-half-x-stretch;
+}
+.inset-2-x-stretch {
+  padding: $inset-2-x-stretch;
+}
+.inset-4-x-stretch {
+  padding: $inset-4-x-stretch;
+}
+
+/* stack values */
+.stack-eighth-x {
+  margin-bottom: $space-eighth-x;
+}
+.stack-quarter-x {
+  margin-bottom: $space-quarter-x;
+}
+.stack-half-x {
+  margin-bottom: $space-half-x;
+}
+.stack-half-x {
+  margin-bottom: $space-half-x;
+}
+.stack-three-quarter-x {
+  margin-bottom: $space-three-quarter-x;
+}
+.stack-1-x {
+  margin-bottom: $space-1-x;
+}
+.stack-1-and-a-half-x {
+  margin-bottom: $space-1-and-a-half-x;
+}
+.stack-2-x {
+  margin-bottom: $space-2-x;
+}
+.stack-4-x {
+  margin-bottom: $space-4-x;
+}
+
+/* inline values */
+.inline-eighth-x {
+  margin-right: $space-eighth-x;
+}
+.inline-quarter-x {
+  margin-right: $space-quarter-x;
+}
+.inline-half-x {
+  margin-right: $space-half-x;
+}
+.inline-half-x {
+  margin-right: $space-half-x;
+}
+.inline-three-quarter-x {
+  margin-right: $space-three-quarter-x;
+}
+.inline-1-x {
+  margin-right: $space-1-x;
+}
+.inline-1-and-a-half-x {
+  margin-right: $space-1-and-a-half-x;
+}
+.inline-2-x {
+  margin-right: $space-2-x;
+}
+.inline-4-x {
+  margin-right: $space-4-x;
+}
+
+
+/* @xs
+  0px - 767px
+  ========== */
+
+@media (--xs-mq-only) {
+  .inset-eighth-x\@xs {
+    padding: $inset-eighth-x;
+  }
+  .inset-quarter-x\@xs {
+    padding: $inset-quarter-x;
+  }
+  .inset-half-x\@xs {
+    padding: $inset-half-x;
+  }
+  .inset-half-x\@xs {
+    padding: $inset-half-x;
+  }
+  .inset-three-quarter-x\@xs {
+    padding: $inset-three-quarter-x;
+  }
+  .inset-1-x\@xs {
+    padding: $inset-1-x;
+  }
+  .inset-1-and-a-half-x\@xs {
+    padding: $inset-1-and-a-half-x;
+  }
+  .inset-2-x\@xs {
+    padding: $inset-2-x;
+  }
+  .inset-4-x\@xs {
+    padding: $inset-4-x;
+  }
+
+  /* inset-squish */
+  .inset-eighth-x-squish\@xs {
+    padding: $inset-eighth-x-squish;
+  }
+  .inset-quarter-x-squish\@xs {
+    padding: $inset-quarter-x-squish;
+  }
+  .inset-half-x-squish\@xs {
+    padding: $inset-half-x-squish;
+  }
+  .inset-half-x-squish\@xs {
+    padding: $inset-half-x-squish;
+  }
+  .inset-three-quarter-x-squish\@xs {
+    padding: $inset-three-quarter-x-squish;
+  }
+  .inset-1-x-squish\@xs {
+    padding: $inset-1-x-squish;
+  }
+  .inset-1-and-a-half-x-squish\@xs {
+    padding: $inset-1-and-a-half-x-squish;
+  }
+  .inset-2-x-squish\@xs {
+    padding: $inset-2-x-squish;
+  }
+  .inset-4-x-squish\@xs {
+    padding: $inset-4-x-squish;
+  }
+
+  /* inset-stretch */
+  .inset-eighth-x-stretch\@xs {
+    padding: $inset-eighth-x-stretch;
+  }
+  .inset-quarter-x-stretch\@xs {
+    padding: $inset-quarter-x-stretch;
+  }
+  .inset-half-x-stretch\@xs {
+    padding: $inset-half-x-stretch;
+  }
+  .inset-half-x-stretch\@xs {
+    padding: $inset-half-x-stretch;
+  }
+  .inset-three-quarter-x-stretch\@xs {
+    padding: $inset-three-quarter-x-stretch;
+  }
+  .inset-1-x-stretch\@xs {
+    padding: $inset-1-x-stretch;
+  }
+  .inset-1-and-a-half-x-stretch\@xs {
+    padding: $inset-1-and-a-half-x-stretch;
+  }
+  .inset-2-x-stretch\@xs {
+    padding: $inset-2-x-stretch;
+  }
+  .inset-4-x-stretch\@xs {
+    padding: $inset-4-x-stretch;
+  }
+
+  /* stack values */
+  .stack-eighth-x\@xs {
+    margin-bottom: $space-eighth-x;
+  }
+  .stack-quarter-x\@xs {
+    margin-bottom: $space-quarter-x;
+  }
+  .stack-half-x\@xs {
+    margin-bottom: $space-half-x;
+  }
+  .stack-half-x\@xs {
+    margin-bottom: $space-half-x;
+  }
+  .stack-three-quarter-x\@xs {
+    margin-bottom: $space-three-quarter-x;
+  }
+  .stack-1-x\@xs {
+    margin-bottom: $space-1-x;
+  }
+  .stack-1-and-a-half-x\@xs {
+    margin-bottom: $space-1-and-a-half-x;
+  }
+  .stack-2-x\@xs {
+    margin-bottom: $space-2-x;
+  }
+  .stack-4-x\@xs {
+    margin-bottom: $space-4-x;
+  }
+
+  /* inline values */
+  .inline-eighth-x\@xs {
+    margin-right: $space-eighth-x;
+  }
+  .inline-quarter-x\@xs {
+    margin-right: $space-quarter-x;
+  }
+  .inline-half-x\@xs {
+    margin-right: $space-half-x;
+  }
+  .inline-half-x\@xs {
+    margin-right: $space-half-x;
+  }
+  .inline-three-quarter-x\@xs {
+    margin-right: $space-three-quarter-x;
+  }
+  .inline-1-x\@xs {
+    margin-right: $space-1-x;
+  }
+  .inline-1-and-a-half-x\@xs {
+    margin-right: $space-1-and-a-half-x;
+  }
+  .inline-2-x\@xs {
+    margin-right: $space-2-x;
+  }
+  .inline-4-x\@xs {
+    margin-right: $space-4-x;
+  }
+}
+
+/* @sm
+  768px - 991px
+  ========== */
+@media (--sm-mq-only) {
+  .inset-eighth-x\@sm {
+    padding: $inset-eighth-x;
+  }
+  .inset-quarter-x\@sm {
+    padding: $inset-quarter-x;
+  }
+  .inset-half-x\@sm {
+    padding: $inset-half-x;
+  }
+  .inset-half-x\@sm {
+    padding: $inset-half-x;
+  }
+  .inset-three-quarter-x\@sm {
+    padding: $inset-three-quarter-x;
+  }
+  .inset-1-x\@sm {
+    padding: $inset-1-x;
+  }
+  .inset-1-and-a-half-x\@sm {
+    padding: $inset-1-and-a-half-x;
+  }
+  .inset-2-x\@sm {
+    padding: $inset-2-x;
+  }
+  .inset-4-x\@sm {
+    padding: $inset-4-x;
+  }
+
+  /* inset-squish */
+  .inset-eighth-x-squish\@sm {
+    padding: $inset-eighth-x-squish;
+  }
+  .inset-quarter-x-squish\@sm {
+    padding: $inset-quarter-x-squish;
+  }
+  .inset-half-x-squish\@sm {
+    padding: $inset-half-x-squish;
+  }
+  .inset-half-x-squish\@sm {
+    padding: $inset-half-x-squish;
+  }
+  .inset-three-quarter-x-squish\@sm {
+    padding: $inset-three-quarter-x-squish;
+  }
+  .inset-1-x-squish\@sm {
+    padding: $inset-1-x-squish;
+  }
+  .inset-1-and-a-half-x-squish\@sm {
+    padding: $inset-1-and-a-half-x-squish;
+  }
+  .inset-2-x-squish\@sm {
+    padding: $inset-2-x-squish;
+  }
+  .inset-4-x-squish\@sm {
+    padding: $inset-4-x-squish;
+  }
+
+  /* inset-stretch */
+  .inset-eighth-x-stretch\@sm {
+    padding: $inset-eighth-x-stretch;
+  }
+  .inset-quarter-x-stretch\@sm {
+    padding: $inset-quarter-x-stretch;
+  }
+  .inset-half-x-stretch\@sm {
+    padding: $inset-half-x-stretch;
+  }
+  .inset-half-x-stretch\@sm {
+    padding: $inset-half-x-stretch;
+  }
+  .inset-three-quarter-x-stretch\@sm {
+    padding: $inset-three-quarter-x-stretch;
+  }
+  .inset-1-x-stretch\@sm {
+    padding: $inset-1-x-stretch;
+  }
+  .inset-1-and-a-half-x-stretch\@sm {
+    padding: $inset-1-and-a-half-x-stretch;
+  }
+  .inset-2-x-stretch\@sm {
+    padding: $inset-2-x-stretch;
+  }
+  .inset-4-x-stretch\@sm {
+    padding: $inset-4-x-stretch;
+  }
+
+  /* stack values */
+  .stack-eighth-x\@sm {
+    margin-bottom: $space-eighth-x;
+  }
+  .stack-quarter-x\@sm {
+    margin-bottom: $space-quarter-x;
+  }
+  .stack-half-x\@sm {
+    margin-bottom: $space-half-x;
+  }
+  .stack-half-x\@sm {
+    margin-bottom: $space-half-x;
+  }
+  .stack-three-quarter-x\@sm {
+    margin-bottom: $space-three-quarter-x;
+  }
+  .stack-1-x\@sm {
+    margin-bottom: $space-1-x;
+  }
+  .stack-1-and-a-half-x\@sm {
+    margin-bottom: $space-1-and-a-half-x;
+  }
+  .stack-2-x\@sm {
+    margin-bottom: $space-2-x;
+  }
+  .stack-4-x\@sm {
+    margin-bottom: $space-4-x;
+  }
+
+  /* inline values */
+  .inline-eighth-x\@sm {
+    margin-right: $space-eighth-x;
+  }
+  .inline-quarter-x\@sm {
+    margin-right: $space-quarter-x;
+  }
+  .inline-half-x\@sm {
+    margin-right: $space-half-x;
+  }
+  .inline-half-x\@sm {
+    margin-right: $space-half-x;
+  }
+  .inline-three-quarter-x\@sm {
+    margin-right: $space-three-quarter-x;
+  }
+  .inline-1-x\@sm {
+    margin-right: $space-1-x;
+  }
+  .inline-1-and-a-half-x\@sm {
+    margin-right: $space-1-and-a-half-x;
+  }
+  .inline-2-x\@sm {
+    margin-right: $space-2-x;
+  }
+  .inline-4-x\@sm {
+    margin-right: $space-4-x;
+  }
+}
+
+/* @md
+  992px - 1199px
+  ========== */
+@media (--md-mq-only) {
+  .inset-eighth-x\@md {
+    padding: $inset-eighth-x;
+  }
+  .inset-quarter-x\@md {
+    padding: $inset-quarter-x;
+  }
+  .inset-half-x\@md {
+    padding: $inset-half-x;
+  }
+  .inset-half-x\@md {
+    padding: $inset-half-x;
+  }
+  .inset-three-quarter-x\@md {
+    padding: $inset-three-quarter-x;
+  }
+  .inset-1-x\@md {
+    padding: $inset-1-x;
+  }
+  .inset-1-and-a-half-x\@md {
+    padding: $inset-1-and-a-half-x;
+  }
+  .inset-2-x\@md {
+    padding: $inset-2-x;
+  }
+  .inset-4-x\@md {
+    padding: $inset-4-x;
+  }
+
+  /* inset-squish */
+  .inset-eighth-x-squish\@md {
+    padding: $inset-eighth-x-squish;
+  }
+  .inset-quarter-x-squish\@md {
+    padding: $inset-quarter-x-squish;
+  }
+  .inset-half-x-squish\@md {
+    padding: $inset-half-x-squish;
+  }
+  .inset-half-x-squish\@md {
+    padding: $inset-half-x-squish;
+  }
+  .inset-three-quarter-x-squish\@md {
+    padding: $inset-three-quarter-x-squish;
+  }
+  .inset-1-x-squish\@md {
+    padding: $inset-1-x-squish;
+  }
+  .inset-1-and-a-half-x-squish\@md {
+    padding: $inset-1-and-a-half-x-squish;
+  }
+  .inset-2-x-squish\@md {
+    padding: $inset-2-x-squish;
+  }
+  .inset-4-x-squish\@md {
+    padding: $inset-4-x-squish;
+  }
+
+  /* inset-stretch */
+  .inset-eighth-x-stretch\@md {
+    padding: $inset-eighth-x-stretch;
+  }
+  .inset-quarter-x-stretch\@md {
+    padding: $inset-quarter-x-stretch;
+  }
+  .inset-half-x-stretch\@md {
+    padding: $inset-half-x-stretch;
+  }
+  .inset-half-x-stretch\@md {
+    padding: $inset-half-x-stretch;
+  }
+  .inset-three-quarter-x-stretch\@md {
+    padding: $inset-three-quarter-x-stretch;
+  }
+  .inset-1-x-stretch\@md {
+    padding: $inset-1-x-stretch;
+  }
+  .inset-1-and-a-half-x-stretch\@md {
+    padding: $inset-1-and-a-half-x-stretch;
+  }
+  .inset-2-x-stretch\@md {
+    padding: $inset-2-x-stretch;
+  }
+  .inset-4-x-stretch\@md {
+    padding: $inset-4-x-stretch;
+  }
+
+  /* stack values */
+  .stack-eighth-x\@md {
+    margin-bottom: $space-eighth-x;
+  }
+  .stack-quarter-x\@md {
+    margin-bottom: $space-quarter-x;
+  }
+  .stack-half-x\@md {
+    margin-bottom: $space-half-x;
+  }
+  .stack-half-x\@md {
+    margin-bottom: $space-half-x;
+  }
+  .stack-three-quarter-x\@md {
+    margin-bottom: $space-three-quarter-x;
+  }
+  .stack-1-x\@md {
+    margin-bottom: $space-1-x;
+  }
+  .stack-1-and-a-half-x\@md {
+    margin-bottom: $space-1-and-a-half-x;
+  }
+  .stack-2-x\@md {
+    margin-bottom: $space-2-x;
+  }
+  .stack-4-x\@md {
+    margin-bottom: $space-4-x;
+  }
+
+  /* inline values */
+  .inline-eighth-x\@md {
+    margin-right: $space-eighth-x;
+  }
+  .inline-quarter-x\@md {
+    margin-right: $space-quarter-x;
+  }
+  .inline-half-x\@md {
+    margin-right: $space-half-x;
+  }
+  .inline-half-x\@md {
+    margin-right: $space-half-x;
+  }
+  .inline-three-quarter-x\@md {
+    margin-right: $space-three-quarter-x;
+  }
+  .inline-1-x\@md {
+    margin-right: $space-1-x;
+  }
+  .inline-1-and-a-half-x\@md {
+    margin-right: $space-1-and-a-half-x;
+  }
+  .inline-2-x\@md {
+    margin-right: $space-2-x;
+  }
+  .inline-4-x\@md {
+    margin-right: $space-4-x;
+  }
+}
+
+/* @lg
+  1200px and up
+  ========== */
+
+@media (--lg-mq-only) {
+  .inset-eighth-x\@lg {
+    padding: $inset-eighth-x;
+  }
+  .inset-quarter-x\@lg {
+    padding: $inset-quarter-x;
+  }
+  .inset-half-x\@lg {
+    padding: $inset-half-x;
+  }
+  .inset-half-x\@lg {
+    padding: $inset-half-x;
+  }
+  .inset-three-quarter-x\@lg {
+    padding: $inset-three-quarter-x;
+  }
+  .inset-1-x\@lg {
+    padding: $inset-1-x;
+  }
+  .inset-1-and-a-half-x\@lg {
+    padding: $inset-1-and-a-half-x;
+  }
+  .inset-2-x\@lg {
+    padding: $inset-2-x;
+  }
+  .inset-4-x\@lg {
+    padding: $inset-4-x;
+  }
+
+  /* inset-squish */
+  .inset-eighth-x-squish\@lg {
+    padding: $inset-eighth-x-squish;
+  }
+  .inset-quarter-x-squish\@lg {
+    padding: $inset-quarter-x-squish;
+  }
+  .inset-half-x-squish\@lg {
+    padding: $inset-half-x-squish;
+  }
+  .inset-half-x-squish\@lg {
+    padding: $inset-half-x-squish;
+  }
+  .inset-three-quarter-x-squish\@lg {
+    padding: $inset-three-quarter-x-squish;
+  }
+  .inset-1-x-squish\@lg {
+    padding: $inset-1-x-squish;
+  }
+  .inset-1-and-a-half-x-squish\@lg {
+    padding: $inset-1-and-a-half-x-squish;
+  }
+  .inset-2-x-squish\@lg {
+    padding: $inset-2-x-squish;
+  }
+  .inset-4-x-squish\@lg {
+    padding: $inset-4-x-squish;
+  }
+
+  /* inset-stretch */
+  .inset-eighth-x-stretch\@lg {
+    padding: $inset-eighth-x-stretch;
+  }
+  .inset-quarter-x-stretch\@lg {
+    padding: $inset-quarter-x-stretch;
+  }
+  .inset-half-x-stretch\@lg {
+    padding: $inset-half-x-stretch;
+  }
+  .inset-half-x-stretch\@lg {
+    padding: $inset-half-x-stretch;
+  }
+  .inset-three-quarter-x-stretch\@lg {
+    padding: $inset-three-quarter-x-stretch;
+  }
+  .inset-1-x-stretch\@lg {
+    padding: $inset-1-x-stretch;
+  }
+  .inset-1-and-a-half-x-stretch\@lg {
+    padding: $inset-1-and-a-half-x-stretch;
+  }
+  .inset-2-x-stretch\@lg {
+    padding: $inset-2-x-stretch;
+  }
+  .inset-4-x-stretch\@lg {
+    padding: $inset-4-x-stretch;
+  }
+
+  /* stack values */
+  .stack-eighth-x\@lg {
+    margin-bottom: $space-eighth-x;
+  }
+  .stack-quarter-x\@lg {
+    margin-bottom: $space-quarter-x;
+  }
+  .stack-half-x\@lg {
+    margin-bottom: $space-half-x;
+  }
+  .stack-half-x\@lg {
+    margin-bottom: $space-half-x;
+  }
+  .stack-three-quarter-x\@lg {
+    margin-bottom: $space-three-quarter-x;
+  }
+  .stack-1-x\@lg {
+    margin-bottom: $space-1-x;
+  }
+  .stack-1-and-a-half-x\@lg {
+    margin-bottom: $space-1-and-a-half-x;
+  }
+  .stack-2-x\@lg {
+    margin-bottom: $space-2-x;
+  }
+  .stack-4-x\@lg {
+    margin-bottom: $space-4-x;
+  }
+
+  /* inline values */
+  .inline-eighth-x\@lg {
+    margin-right: $space-eighth-x;
+  }
+  .inline-quarter-x\@lg {
+    margin-right: $space-quarter-x;
+  }
+  .inline-half-x\@lg {
+    margin-right: $space-half-x;
+  }
+  .inline-half-x\@lg {
+    margin-right: $space-half-x;
+  }
+  .inline-three-quarter-x\@lg {
+    margin-right: $space-three-quarter-x;
+  }
+  .inline-1-x\@lg {
+    margin-right: $space-1-x;
+  }
+  .inline-1-and-a-half-x\@lg {
+    margin-right: $space-1-and-a-half-x;
+  }
+  .inline-2-x\@lg {
+    margin-right: $space-2-x;
+  }
+  .inline-4-x\@lg {
+    margin-right: $space-4-x;
+  }
+}

--- a/src/css/utility/spacing.pcss
+++ b/src/css/utility/spacing.pcss
@@ -41,167 +41,167 @@
   inset values
   these reference specific tokens because they exist
 */
-.inset-eighth-x {
+.cdr-inset-eighth-x {
   padding: $inset-eighth-x;
 }
 
-.inset-quarter-x {
+.cdr-inset-quarter-x {
   padding: $inset-quarter-x;
 }
 
-.inset-half-x {
+.cdr-inset-half-x {
   padding: $inset-half-x;
 }
 
-.inset-three-quarter-x {
+.cdr-cdr-inset-three-quarter-x {
   padding: $inset-three-quarter-x;
 }
 
-.inset-1-x {
+.cdr-cdr-inset-1-x {
   padding: $inset-1-x;
 }
 
-.inset-1-and-a-half-x {
+.cdr-cdr-inset-1-and-a-half-x {
   padding: $inset-1-and-a-half-x;
 }
 
-.inset-2-x {
+.cdr-cdr-inset-2-x {
   padding: $inset-2-x;
 }
 
-.inset-4-x {
+.cdr-cdr-inset-4-x {
   padding: $inset-4-x;
 }
 
 /* inset-squish */
-.inset-eighth-x-squish {
+.cdr-cdr-inset-eighth-x-squish {
   padding: $inset-eighth-x-squish;
 }
 
-.inset-quarter-x-squish {
+.cdr-cdr-inset-quarter-x-squish {
   padding: $inset-quarter-x-squish;
 }
 
-.inset-half-x-squish {
+.cdr-cdr-inset-half-x-squish {
   padding: $inset-half-x-squish;
 }
 
-.inset-three-quarter-x-squish {
+.cdr-cdr-inset-three-quarter-x-squish {
   padding: $inset-three-quarter-x-squish;
 }
 
-.inset-1-x-squish {
+.cdr-cdr-inset-1-x-squish {
   padding: $inset-1-x-squish;
 }
 
-.inset-1-and-a-half-x-squish {
+.cdr-cdr-inset-1-and-a-half-x-squish {
   padding: $inset-1-and-a-half-x-squish;
 }
 
-.inset-2-x-squish {
+.cdr-cdr-inset-2-x-squish {
   padding: $inset-2-x-squish;
 }
 
-.inset-4-x-squish {
+.cdr-cdr-inset-4-x-squish {
   padding: $inset-4-x-squish;
 }
 
 /* inset-stretch */
-.inset-eighth-x-stretch {
+.cdr-cdr-inset-eighth-x-stretch {
   padding: $inset-eighth-x-stretch;
 }
 
-.inset-quarter-x-stretch {
+.cdr-cdr-inset-quarter-x-stretch {
   padding: $inset-quarter-x-stretch;
 }
 
-.inset-half-x-stretch {
+.cdr-cdr-inset-half-x-stretch {
   padding: $inset-half-x-stretch;
 }
 
-.inset-three-quarter-x-stretch {
+.cdr-cdr-inset-three-quarter-x-stretch {
   padding: $inset-three-quarter-x-stretch;
 }
 
-.inset-1-x-stretch {
+.cdr-cdr-inset-1-x-stretch {
   padding: $inset-1-x-stretch;
 }
 
-.inset-1-and-a-half-x-stretch {
+.cdr-cdr-inset-1-and-a-half-x-stretch {
   padding: $inset-1-and-a-half-x-stretch;
 }
 
-.inset-2-x-stretch {
+.cdr-cdr-inset-2-x-stretch {
   padding: $inset-2-x-stretch;
 }
 
-.inset-4-x-stretch {
+.cdr-cdr-inset-4-x-stretch {
   padding: $inset-4-x-stretch;
 }
 
 /* stack values */
-.stack-eighth-x {
+.cdr-cdr-stack-eighth-x {
   margin-bottom: $space-eighth-x;
 }
 
-.stack-quarter-x {
+.cdr-cdr-stack-quarter-x {
   margin-bottom: $space-quarter-x;
 }
 
-.stack-half-x {
+.cdr-cdr-stack-half-x {
   margin-bottom: $space-half-x;
 }
 
-.stack-three-quarter-x {
+.cdr-cdr-stack-three-quarter-x {
   margin-bottom: $space-three-quarter-x;
 }
 
-.stack-1-x {
+.cdr-cdr-stack-1-x {
   margin-bottom: $space-1-x;
 }
 
-.stack-1-and-a-half-x {
+.cdr-cdr-stack-1-and-a-half-x {
   margin-bottom: $space-1-and-a-half-x;
 }
 
-.stack-2-x {
+.cdr-cdr-stack-2-x {
   margin-bottom: $space-2-x;
 }
 
-.stack-4-x {
+.cdr-cdr-stack-4-x {
   margin-bottom: $space-4-x;
 }
 
 /* inline values */
-.inline-eighth-x {
+.cdr-cdr-inline-eighth-x {
   margin-right: $space-eighth-x;
 }
 
-.inline-quarter-x {
+.cdr-cdr-inline-quarter-x {
   margin-right: $space-quarter-x;
 }
 
-.inline-half-x {
+.cdr-cdr-inline-half-x {
   margin-right: $space-half-x;
 }
 
-.inline-three-quarter-x {
+.cdr-cdr-inline-three-quarter-x {
   margin-right: $space-three-quarter-x;
 }
 
-.inline-1-x {
+.cdr-cdr-inline-1-x {
   margin-right: $space-1-x;
 }
 
-.inline-1-and-a-half-x {
+.cdr-cdr-inline-1-and-a-half-x {
   margin-right: $space-1-and-a-half-x;
 }
 
-.inline-2-x {
+.cdr-cdr-inline-2-x {
   margin-right: $space-2-x;
 }
 
-.inline-4-x {
+.cdr-cdr-inline-4-x {
   margin-right: $space-4-x;
 }
 
@@ -210,167 +210,167 @@
   ========== */
 
 @media (--xs-mq-only) {
-  .inset-eighth-x\@xs {
+  .cdr-cdr-inset-eighth-x\@xs {
     padding: $inset-eighth-x;
   }
 
-  .inset-quarter-x\@xs {
+  .cdr-cdr-inset-quarter-x\@xs {
     padding: $inset-quarter-x;
   }
 
-  .inset-half-x\@xs {
+  .cdr-inset-half-x\@xs {
     padding: $inset-half-x;
   }
 
-  .inset-three-quarter-x\@xs {
+  .cdr-inset-three-quarter-x\@xs {
     padding: $inset-three-quarter-x;
   }
 
-  .inset-1-x\@xs {
+  .cdr-inset-1-x\@xs {
     padding: $inset-1-x;
   }
 
-  .inset-1-and-a-half-x\@xs {
+  .cdr-inset-1-and-a-half-x\@xs {
     padding: $inset-1-and-a-half-x;
   }
 
-  .inset-2-x\@xs {
+  .cdr-inset-2-x\@xs {
     padding: $inset-2-x;
   }
 
-  .inset-4-x\@xs {
+  .cdr-inset-4-x\@xs {
     padding: $inset-4-x;
   }
 
   /* inset-squish */
-  .inset-eighth-x-squish\@xs {
+  .cdr-inset-eighth-x-squish\@xs {
     padding: $inset-eighth-x-squish;
   }
 
-  .inset-quarter-x-squish\@xs {
+  .cdr-inset-quarter-x-squish\@xs {
     padding: $inset-quarter-x-squish;
   }
 
-  .inset-half-x-squish\@xs {
+  .cdr-inset-half-x-squish\@xs {
     padding: $inset-half-x-squish;
   }
 
-  .inset-three-quarter-x-squish\@xs {
+  .cdr-inset-three-quarter-x-squish\@xs {
     padding: $inset-three-quarter-x-squish;
   }
 
-  .inset-1-x-squish\@xs {
+  .cdr-inset-1-x-squish\@xs {
     padding: $inset-1-x-squish;
   }
 
-  .inset-1-and-a-half-x-squish\@xs {
+  .cdr-inset-1-and-a-half-x-squish\@xs {
     padding: $inset-1-and-a-half-x-squish;
   }
 
-  .inset-2-x-squish\@xs {
+  .cdr-inset-2-x-squish\@xs {
     padding: $inset-2-x-squish;
   }
 
-  .inset-4-x-squish\@xs {
+  .cdr-inset-4-x-squish\@xs {
     padding: $inset-4-x-squish;
   }
 
   /* inset-stretch */
-  .inset-eighth-x-stretch\@xs {
+  .cdr-inset-eighth-x-stretch\@xs {
     padding: $inset-eighth-x-stretch;
   }
 
-  .inset-quarter-x-stretch\@xs {
+  .cdr-inset-quarter-x-stretch\@xs {
     padding: $inset-quarter-x-stretch;
   }
 
-  .inset-half-x-stretch\@xs {
+  .cdr-inset-half-x-stretch\@xs {
     padding: $inset-half-x-stretch;
   }
 
-  .inset-three-quarter-x-stretch\@xs {
+  .cdr-inset-three-quarter-x-stretch\@xs {
     padding: $inset-three-quarter-x-stretch;
   }
 
-  .inset-1-x-stretch\@xs {
+  .cdr-inset-1-x-stretch\@xs {
     padding: $inset-1-x-stretch;
   }
 
-  .inset-1-and-a-half-x-stretch\@xs {
+  .cdr-inset-1-and-a-half-x-stretch\@xs {
     padding: $inset-1-and-a-half-x-stretch;
   }
 
-  .inset-2-x-stretch\@xs {
+  .cdr-inset-2-x-stretch\@xs {
     padding: $inset-2-x-stretch;
   }
 
-  .inset-4-x-stretch\@xs {
+  .cdr-inset-4-x-stretch\@xs {
     padding: $inset-4-x-stretch;
   }
 
   /* stack values */
-  .stack-eighth-x\@xs {
+  .cdr-stack-eighth-x\@xs {
     margin-bottom: $space-eighth-x;
   }
 
-  .stack-quarter-x\@xs {
+  .cdr-stack-quarter-x\@xs {
     margin-bottom: $space-quarter-x;
   }
 
-  .stack-half-x\@xs {
+  .cdr-stack-half-x\@xs {
     margin-bottom: $space-half-x;
   }
 
-  .stack-three-quarter-x\@xs {
+  .cdr-stack-three-quarter-x\@xs {
     margin-bottom: $space-three-quarter-x;
   }
 
-  .stack-1-x\@xs {
+  .cdr-stack-1-x\@xs {
     margin-bottom: $space-1-x;
   }
 
-  .stack-1-and-a-half-x\@xs {
+  .cdr-stack-1-and-a-half-x\@xs {
     margin-bottom: $space-1-and-a-half-x;
   }
 
-  .stack-2-x\@xs {
+  .cdr-stack-2-x\@xs {
     margin-bottom: $space-2-x;
   }
 
-  .stack-4-x\@xs {
+  .cdr-stack-4-x\@xs {
     margin-bottom: $space-4-x;
   }
 
   /* inline values */
-  .inline-eighth-x\@xs {
+  .cdr-inline-eighth-x\@xs {
     margin-right: $space-eighth-x;
   }
 
-  .inline-quarter-x\@xs {
+  .cdr-inline-quarter-x\@xs {
     margin-right: $space-quarter-x;
   }
 
-  .inline-half-x\@xs {
+  .cdr-inline-half-x\@xs {
     margin-right: $space-half-x;
   }
 
-  .inline-three-quarter-x\@xs {
+  .cdr-inline-three-quarter-x\@xs {
     margin-right: $space-three-quarter-x;
   }
 
-  .inline-1-x\@xs {
+  .cdr-inline-1-x\@xs {
     margin-right: $space-1-x;
   }
 
-  .inline-1-and-a-half-x\@xs {
+  .cdr-inline-1-and-a-half-x\@xs {
     margin-right: $space-1-and-a-half-x;
   }
 
-  .inline-2-x\@xs {
+  .cdr-inline-2-x\@xs {
     margin-right: $space-2-x;
   }
 
-  .inline-4-x\@xs {
+  .cdr-inline-4-x\@xs {
     margin-right: $space-4-x;
   }
 }
@@ -379,167 +379,167 @@
   768px - 991px
   ========== */
 @media (--sm-mq-only) {
-  .inset-eighth-x\@sm {
+  .cdr-inset-eighth-x\@sm {
     padding: $inset-eighth-x;
   }
 
-  .inset-quarter-x\@sm {
+  .cdr-inset-quarter-x\@sm {
     padding: $inset-quarter-x;
   }
 
-  .inset-half-x\@sm {
+  .cdr-inset-half-x\@sm {
     padding: $inset-half-x;
   }
 
-  .inset-three-quarter-x\@sm {
+  .cdr-inset-three-quarter-x\@sm {
     padding: $inset-three-quarter-x;
   }
 
-  .inset-1-x\@sm {
+  .cdr-inset-1-x\@sm {
     padding: $inset-1-x;
   }
 
-  .inset-1-and-a-half-x\@sm {
+  .cdr-inset-1-and-a-half-x\@sm {
     padding: $inset-1-and-a-half-x;
   }
 
-  .inset-2-x\@sm {
+  .cdr-inset-2-x\@sm {
     padding: $inset-2-x;
   }
   
-  .inset-4-x\@sm {
+  .cdr-inset-4-x\@sm {
     padding: $inset-4-x;
   }
 
   /* inset-squish */
-  .inset-eighth-x-squish\@sm {
+  .cdr-inset-eighth-x-squish\@sm {
     padding: $inset-eighth-x-squish;
   }
 
-  .inset-quarter-x-squish\@sm {
+  .cdr-inset-quarter-x-squish\@sm {
     padding: $inset-quarter-x-squish;
   }
 
-  .inset-half-x-squish\@sm {
+  .cdr-inset-half-x-squish\@sm {
     padding: $inset-half-x-squish;
   }
 
-  .inset-three-quarter-x-squish\@sm {
+  .cdr-inset-three-quarter-x-squish\@sm {
     padding: $inset-three-quarter-x-squish;
   }
 
-  .inset-1-x-squish\@sm {
+  .cdr-inset-1-x-squish\@sm {
     padding: $inset-1-x-squish;
   }
 
-  .inset-1-and-a-half-x-squish\@sm {
+  .cdr-inset-1-and-a-half-x-squish\@sm {
     padding: $inset-1-and-a-half-x-squish;
   }
 
-  .inset-2-x-squish\@sm {
+  .cdr-inset-2-x-squish\@sm {
     padding: $inset-2-x-squish;
   }
 
-  .inset-4-x-squish\@sm {
+  .cdr-inset-4-x-squish\@sm {
     padding: $inset-4-x-squish;
   }
 
   /* inset-stretch */
-  .inset-eighth-x-stretch\@sm {
+  .cdr-inset-eighth-x-stretch\@sm {
     padding: $inset-eighth-x-stretch;
   }
 
-  .inset-quarter-x-stretch\@sm {
+  .cdr-inset-quarter-x-stretch\@sm {
     padding: $inset-quarter-x-stretch;
   }
 
-  .inset-half-x-stretch\@sm {
+  .cdr-inset-half-x-stretch\@sm {
     padding: $inset-half-x-stretch;
   }
 
-  .inset-three-quarter-x-stretch\@sm {
+  .cdr-inset-three-quarter-x-stretch\@sm {
     padding: $inset-three-quarter-x-stretch;
   }
 
-  .inset-1-x-stretch\@sm {
+  .cdr-inset-1-x-stretch\@sm {
     padding: $inset-1-x-stretch;
   }
 
-  .inset-1-and-a-half-x-stretch\@sm {
+  .cdr-inset-1-and-a-half-x-stretch\@sm {
     padding: $inset-1-and-a-half-x-stretch;
   }
 
-  .inset-2-x-stretch\@sm {
+  .cdr-inset-2-x-stretch\@sm {
     padding: $inset-2-x-stretch;
   }
 
-  .inset-4-x-stretch\@sm {
+  .cdr-inset-4-x-stretch\@sm {
     padding: $inset-4-x-stretch;
   }
 
   /* stack values */
-  .stack-eighth-x\@sm {
+  .cdr-stack-eighth-x\@sm {
     margin-bottom: $space-eighth-x;
   }
 
-  .stack-quarter-x\@sm {
+  .cdr-stack-quarter-x\@sm {
     margin-bottom: $space-quarter-x;
   }
 
-  .stack-half-x\@sm {
+  .cdr-stack-half-x\@sm {
     margin-bottom: $space-half-x;
   }
 
-  .stack-three-quarter-x\@sm {
+  .cdr-stack-three-quarter-x\@sm {
     margin-bottom: $space-three-quarter-x;
   }
 
-  .stack-1-x\@sm {
+  .cdr-stack-1-x\@sm {
     margin-bottom: $space-1-x;
   }
 
-  .stack-1-and-a-half-x\@sm {
+  .cdr-stack-1-and-a-half-x\@sm {
     margin-bottom: $space-1-and-a-half-x;
   }
 
-  .stack-2-x\@sm {
+  .cdr-stack-2-x\@sm {
     margin-bottom: $space-2-x;
   }
 
-  .stack-4-x\@sm {
+  .cdr-stack-4-x\@sm {
     margin-bottom: $space-4-x;
   }
 
   /* inline values */
-  .inline-eighth-x\@sm {
+  .cdr-inline-eighth-x\@sm {
     margin-right: $space-eighth-x;
   }
 
-  .inline-quarter-x\@sm {
+  .cdr-inline-quarter-x\@sm {
     margin-right: $space-quarter-x;
   }
 
-  .inline-half-x\@sm {
+  .cdr-inline-half-x\@sm {
     margin-right: $space-half-x;
   }
 
-  .inline-three-quarter-x\@sm {
+  .cdr-inline-three-quarter-x\@sm {
     margin-right: $space-three-quarter-x;
   }
 
-  .inline-1-x\@sm {
+  .cdr-inline-1-x\@sm {
     margin-right: $space-1-x;
   }
 
-  .inline-1-and-a-half-x\@sm {
+  .cdr-inline-1-and-a-half-x\@sm {
     margin-right: $space-1-and-a-half-x;
   }
 
-  .inline-2-x\@sm {
+  .cdr-inline-2-x\@sm {
     margin-right: $space-2-x;
   }
 
-  .inline-4-x\@sm {
+  .cdr-inline-4-x\@sm {
     margin-right: $space-4-x;
   }
 }
@@ -548,167 +548,167 @@
   992px - 1199px
   ========== */
 @media (--md-mq-only) {
-  .inset-eighth-x\@md {
+  .cdr-inset-eighth-x\@md {
     padding: $inset-eighth-x;
   }
 
-  .inset-quarter-x\@md {
+  .cdr-inset-quarter-x\@md {
     padding: $inset-quarter-x;
   }
 
-  .inset-half-x\@md {
+  .cdr-inset-half-x\@md {
     padding: $inset-half-x;
   }
 
-  .inset-three-quarter-x\@md {
+  .cdr-inset-three-quarter-x\@md {
     padding: $inset-three-quarter-x;
   }
 
-  .inset-1-x\@md {
+  .cdr-inset-1-x\@md {
     padding: $inset-1-x;
   }
 
-  .inset-1-and-a-half-x\@md {
+  .cdr-inset-1-and-a-half-x\@md {
     padding: $inset-1-and-a-half-x;
   }
 
-  .inset-2-x\@md {
+  .cdr-inset-2-x\@md {
     padding: $inset-2-x;
   }
 
-  .inset-4-x\@md {
+  .cdr-inset-4-x\@md {
     padding: $inset-4-x;
   }
 
   /* inset-squish */
-  .inset-eighth-x-squish\@md {
+  .cdr-inset-eighth-x-squish\@md {
     padding: $inset-eighth-x-squish;
   }
 
-  .inset-quarter-x-squish\@md {
+  .cdr-inset-quarter-x-squish\@md {
     padding: $inset-quarter-x-squish;
   }
 
-  .inset-half-x-squish\@md {
+  .cdr-inset-half-x-squish\@md {
     padding: $inset-half-x-squish;
   }
 
-  .inset-three-quarter-x-squish\@md {
+  .cdr-inset-three-quarter-x-squish\@md {
     padding: $inset-three-quarter-x-squish;
   }
 
-  .inset-1-x-squish\@md {
+  .cdr-inset-1-x-squish\@md {
     padding: $inset-1-x-squish;
   }
 
-  .inset-1-and-a-half-x-squish\@md {
+  .cdr-inset-1-and-a-half-x-squish\@md {
     padding: $inset-1-and-a-half-x-squish;
   }
 
-  .inset-2-x-squish\@md {
+  .cdr-inset-2-x-squish\@md {
     padding: $inset-2-x-squish;
   }
 
-  .inset-4-x-squish\@md {
+  .cdr-inset-4-x-squish\@md {
     padding: $inset-4-x-squish;
   }
 
   /* inset-stretch */
-  .inset-eighth-x-stretch\@md {
+  .cdr-inset-eighth-x-stretch\@md {
     padding: $inset-eighth-x-stretch;
   }
 
-  .inset-quarter-x-stretch\@md {
+  .cdr-inset-quarter-x-stretch\@md {
     padding: $inset-quarter-x-stretch;
   }
 
-  .inset-half-x-stretch\@md {
+  .cdr-inset-half-x-stretch\@md {
     padding: $inset-half-x-stretch;
   }
 
-  .inset-three-quarter-x-stretch\@md {
+  .cdr-inset-three-quarter-x-stretch\@md {
     padding: $inset-three-quarter-x-stretch;
   }
 
-  .inset-1-x-stretch\@md {
+  .cdr-inset-1-x-stretch\@md {
     padding: $inset-1-x-stretch;
   }
 
-  .inset-1-and-a-half-x-stretch\@md {
+  .cdr-inset-1-and-a-half-x-stretch\@md {
     padding: $inset-1-and-a-half-x-stretch;
   }
 
-  .inset-2-x-stretch\@md {
+  .cdr-inset-2-x-stretch\@md {
     padding: $inset-2-x-stretch;
   }
 
-  .inset-4-x-stretch\@md {
+  .cdr-inset-4-x-stretch\@md {
     padding: $inset-4-x-stretch;
   }
 
   /* stack values */
-  .stack-eighth-x\@md {
+  .cdr-stack-eighth-x\@md {
     margin-bottom: $space-eighth-x;
   }
 
-  .stack-quarter-x\@md {
+  .cdr-stack-quarter-x\@md {
     margin-bottom: $space-quarter-x;
   }
 
-  .stack-half-x\@md {
+  .cdr-stack-half-x\@md {
     margin-bottom: $space-half-x;
   }
 
-  .stack-three-quarter-x\@md {
+  .cdr-stack-three-quarter-x\@md {
     margin-bottom: $space-three-quarter-x;
   }
 
-  .stack-1-x\@md {
+  .cdr-stack-1-x\@md {
     margin-bottom: $space-1-x;
   }
 
-  .stack-1-and-a-half-x\@md {
+  .cdr-stack-1-and-a-half-x\@md {
     margin-bottom: $space-1-and-a-half-x;
   }
 
-  .stack-2-x\@md {
+  .cdr-stack-2-x\@md {
     margin-bottom: $space-2-x;
   }
 
-  .stack-4-x\@md {
+  .cdr-stack-4-x\@md {
     margin-bottom: $space-4-x;
   }
 
   /* inline values */
-  .inline-eighth-x\@md {
+  .cdr-inline-eighth-x\@md {
     margin-right: $space-eighth-x;
   }
 
-  .inline-quarter-x\@md {
+  .cdr-inline-quarter-x\@md {
     margin-right: $space-quarter-x;
   }
 
-  .inline-half-x\@md {
+  .cdr-inline-half-x\@md {
     margin-right: $space-half-x;
   }
 
-  .inline-three-quarter-x\@md {
+  .cdr-inline-three-quarter-x\@md {
     margin-right: $space-three-quarter-x;
   }
 
-  .inline-1-x\@md {
+  .cdr-inline-1-x\@md {
     margin-right: $space-1-x;
   }
 
-  .inline-1-and-a-half-x\@md {
+  .cdr-inline-1-and-a-half-x\@md {
     margin-right: $space-1-and-a-half-x;
   }
 
-  .inline-2-x\@md {
+  .cdr-inline-2-x\@md {
     margin-right: $space-2-x;
   }
 
-  .inline-4-x\@md {
+  .cdr-inline-4-x\@md {
     margin-right: $space-4-x;
   }
 }
@@ -718,167 +718,167 @@
   ========== */
 
 @media (--lg-mq-only) {
-  .inset-eighth-x\@lg {
+  .cdr-inset-eighth-x\@lg {
     padding: $inset-eighth-x;
   }
 
-  .inset-quarter-x\@lg {
+  .cdr-inset-quarter-x\@lg {
     padding: $inset-quarter-x;
   }
 
-  .inset-half-x\@lg {
+  .cdr-inset-half-x\@lg {
     padding: $inset-half-x;
   }
 
-  .inset-three-quarter-x\@lg {
+  .cdr-inset-three-quarter-x\@lg {
     padding: $inset-three-quarter-x;
   }
 
-  .inset-1-x\@lg {
+  .cdr-inset-1-x\@lg {
     padding: $inset-1-x;
   }
 
-  .inset-1-and-a-half-x\@lg {
+  .cdr-inset-1-and-a-half-x\@lg {
     padding: $inset-1-and-a-half-x;
   }
   
-  .inset-2-x\@lg {
+  .cdr-inset-2-x\@lg {
     padding: $inset-2-x;
   }
 
-  .inset-4-x\@lg {
+  .cdr-inset-4-x\@lg {
     padding: $inset-4-x;
   }
 
   /* inset-squish */
-  .inset-eighth-x-squish\@lg {
+  .cdr-inset-eighth-x-squish\@lg {
     padding: $inset-eighth-x-squish;
   }
 
-  .inset-quarter-x-squish\@lg {
+  .cdr-inset-quarter-x-squish\@lg {
     padding: $inset-quarter-x-squish;
   }
 
-  .inset-half-x-squish\@lg {
+  .cdr-inset-half-x-squish\@lg {
     padding: $inset-half-x-squish;
   }
 
-  .inset-three-quarter-x-squish\@lg {
+  .cdr-inset-three-quarter-x-squish\@lg {
     padding: $inset-three-quarter-x-squish;
   }
 
-  .inset-1-x-squish\@lg {
+  .cdr-inset-1-x-squish\@lg {
     padding: $inset-1-x-squish;
   }
 
-  .inset-1-and-a-half-x-squish\@lg {
+  .cdr-inset-1-and-a-half-x-squish\@lg {
     padding: $inset-1-and-a-half-x-squish;
   }
 
-  .inset-2-x-squish\@lg {
+  .cdr-inset-2-x-squish\@lg {
     padding: $inset-2-x-squish;
   }
 
-  .inset-4-x-squish\@lg {
+  .cdr-inset-4-x-squish\@lg {
     padding: $inset-4-x-squish;
   }
 
   /* inset-stretch */
-  .inset-eighth-x-stretch\@lg {
+  .cdr-inset-eighth-x-stretch\@lg {
     padding: $inset-eighth-x-stretch;
   }
 
-  .inset-quarter-x-stretch\@lg {
+  .cdr-inset-quarter-x-stretch\@lg {
     padding: $inset-quarter-x-stretch;
   }
 
-  .inset-half-x-stretch\@lg {
+  .cdr-inset-half-x-stretch\@lg {
     padding: $inset-half-x-stretch;
   }
 
-  .inset-three-quarter-x-stretch\@lg {
+  .cdr-inset-three-quarter-x-stretch\@lg {
     padding: $inset-three-quarter-x-stretch;
   }
 
-  .inset-1-x-stretch\@lg {
+  .cdr-inset-1-x-stretch\@lg {
     padding: $inset-1-x-stretch;
   }
 
-  .inset-1-and-a-half-x-stretch\@lg {
+  .cdr-inset-1-and-a-half-x-stretch\@lg {
     padding: $inset-1-and-a-half-x-stretch;
   }
 
-  .inset-2-x-stretch\@lg {
+  .cdr-inset-2-x-stretch\@lg {
     padding: $inset-2-x-stretch;
   }
 
-  .inset-4-x-stretch\@lg {
+  .cdr-inset-4-x-stretch\@lg {
     padding: $inset-4-x-stretch;
   }
 
   /* stack values */
-  .stack-eighth-x\@lg {
+  .cdr-stack-eighth-x\@lg {
     margin-bottom: $space-eighth-x;
   }
 
-  .stack-quarter-x\@lg {
+  .cdr-stack-quarter-x\@lg {
     margin-bottom: $space-quarter-x;
   }
 
-  .stack-half-x\@lg {
+  .cdr-stack-half-x\@lg {
     margin-bottom: $space-half-x;
   }
 
-  .stack-three-quarter-x\@lg {
+  .cdr-stack-three-quarter-x\@lg {
     margin-bottom: $space-three-quarter-x;
   }
 
-  .stack-1-x\@lg {
+  .cdr-stack-1-x\@lg {
     margin-bottom: $space-1-x;
   }
 
-  .stack-1-and-a-half-x\@lg {
+  .cdr-stack-1-and-a-half-x\@lg {
     margin-bottom: $space-1-and-a-half-x;
   }
 
-  .stack-2-x\@lg {
+  .cdr-stack-2-x\@lg {
     margin-bottom: $space-2-x;
   }
 
-  .stack-4-x\@lg {
+  .cdr-stack-4-x\@lg {
     margin-bottom: $space-4-x;
   }
 
   /* inline values */
-  .inline-eighth-x\@lg {
+  .cdr-inline-eighth-x\@lg {
     margin-right: $space-eighth-x;
   }
 
-  .inline-quarter-x\@lg {
+  .cdr-inline-quarter-x\@lg {
     margin-right: $space-quarter-x;
   }
 
-  .inline-half-x\@lg {
+  .cdr-inline-half-x\@lg {
     margin-right: $space-half-x;
   }
 
-  .inline-three-quarter-x\@lg {
+  .cdr-inline-three-quarter-x\@lg {
     margin-right: $space-three-quarter-x;
   }
 
-  .inline-1-x\@lg {
+  .cdr-inline-1-x\@lg {
     margin-right: $space-1-x;
   }
 
-  .inline-1-and-a-half-x\@lg {
+  .cdr-inline-1-and-a-half-x\@lg {
     margin-right: $space-1-and-a-half-x;
   }
 
-  .inline-2-x\@lg {
+  .cdr-inline-2-x\@lg {
     margin-right: $space-2-x;
   }
 
-  .inline-4-x\@lg {
+  .cdr-inline-4-x\@lg {
     margin-right: $space-4-x;
   }
 }


### PR DESCRIPTION
This branch add spacing utility classes to rei-cedar. The class names match the language used by design for an easy design to dev translation and can be applied responsively like `.inline-2-x@lg`.

The spacing classes these are replacing are still included in `cdr-assets` for backwards compatibility, but they are no longer documented in the README.