### PR TITLE
chore(input): fixed failing travis ci build

### DIFF
--- a/src/compositions/search/package.json
+++ b/src/compositions/search/package.json
@@ -30,7 +30,7 @@
     "@rei/cdr-assets": "^0.3.0",
     "@rei/cdr-button": "^1.0.0",
     "@rei/cdr-icon": "^1.0.0",
-    "@rei/cdr-input": "^0.1.0",
+    "@rei/cdr-input": "^1.0.0",
     "vue": "^2.5.13"
   },
   "devDependencies": {


### PR DESCRIPTION
affects: @rei/cdr-search

updated mismatch in new input version and dependency on input in search composition