### PR TITLE
fix(input): removed direct modification of input value

### DIFF
--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -24,7 +24,7 @@
         :rows="[rows]"
         :class="[inputClass, sizeClass]"
         v-bind="$attrs"
-        v-model="value"
+        v-model="newValue"
         :id="inputId"
         @blur="onBlur"
         @input="onInput"
@@ -41,7 +41,7 @@
         :type="type"
         :class="[inputClass, sizeClass]"
         v-bind="$attrs"
-        v-model="value"
+        v-model="newValue"
         :id="inputId"
         @blur="onBlur"
         @input="onInput"
@@ -125,7 +125,14 @@ export default {
     /** @ignore */
     required: Boolean,
     /** @ignore */
-    value: String,
+    value: {
+      type: [String, Number],
+    },
+  },
+  data() {
+    return {
+      newValue: this.value,
+    };
   },
   computed: {
     // Use given id or generate one

--- a/src/components/input/package.json
+++ b/src/components/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-input",
-  "version": "1.0.0",
+  "version": "1.0.1-alpha.0",
   "author": "REI Software Engineering",
   "description": "REI Cedar Style Framework - Vue Component for Input",
   "homepage": "https://rei.github.io/rei-cedar/#cdr-input",


### PR DESCRIPTION
affects: @rei/cdr-input

Direct modification of the input value was causing Vue warnings.  Added data variable to track.
This will help with possible element re-rendering issues.