### PR TITLE
docs(component readmes): add link to Cedar Docs in component readme

### DIFF
--- a/src/components/accordion/README.md
+++ b/src/components/accordion/README.md
@@ -1,5 +1,7 @@
 # CdrAccordion
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/accordion/).
+
 Accordions are built from two components, CdrAccordion and CdrAccordionItem, which are meant to be used together.
 
 ## Props

--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -1,5 +1,7 @@
 # CdrBreadcrumb
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/breadcrumb/).
+
 ## Properties
 
 | name                                                                              | type   | Default |

--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -1,4 +1,7 @@
 # CdrCheckbox
+
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/checkboxes/).
+
 ## Props
 
 | Name | Type   | Default |

--- a/src/components/cta/README.md
+++ b/src/components/cta/README.md
@@ -1,5 +1,7 @@
 # CdrCTA
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/cta/).
+
 ## Properties
 | name | type | default |
 | :--- | :--- | :--- |

--- a/src/components/dataTable/README.md
+++ b/src/components/dataTable/README.md
@@ -1,5 +1,7 @@
 # CdrDataTable
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/data-tables/).
+
 ## Properties
 
 | Name                                 | Type   | Default |

--- a/src/components/grid/README.md
+++ b/src/components/grid/README.md
@@ -1,5 +1,7 @@
 # CdrGrid
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/grid/).
+
 Grids are built from two components, **CdrRow** and **CdrCol**.
 
 ## Props

--- a/src/components/icon/README.md
+++ b/src/components/icon/README.md
@@ -18,8 +18,8 @@ For the most up-to-date information, see [REI Cedar documentation](https://rei.g
 
 | name                                                                      | type   | default            |
 |:--------------------------------------------------------------------------|:-------|:-------------------|
-| modifier                                                                  | string | N/A                |
-| Modifies the style variant fot this component. Possible values: { 'inherit-color' }                   |        |                    |
+| inherit-color                                                                  | boolean | none               |
+| Sets icon fill color to 'inherit'.                   |        |                    |
 
 ## Slots
 
@@ -234,12 +234,3 @@ Use any valid SVG markup in the CdrIcon slot.
 
 </script>
 ```
-
-## Modifiers
-
-Following variants are available to the `cdr-icon` modifier attribute:
-| Value | Description            |
-|:------|:-----------------------|
-| 'small'  | Sets icon size to 16px |
-| 'medium'  | Sets icon size to 24px |
-| 'large'  | Sets icon size to 32px |

--- a/src/components/image/README.md
+++ b/src/components/image/README.md
@@ -1,5 +1,7 @@
 ## Properties
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/image/).
+
 | name  | type | default     |
 |:-----|:-------|:--------|
 | alt | string   | empty |

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -1,5 +1,7 @@
 # CdrInput
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/input/).
+
 ## Properties
 
 | Name | Type   | Default        |

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -1,5 +1,7 @@
 # CdrLink
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/links/).
+
 ## Properties
 
 | tag  | string | 'a'     |

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -1,5 +1,7 @@
 # CdrList
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/lists/).
+
 ## Properties
 
 | name                                                                              | type   | default |

--- a/src/components/quote/README.md
+++ b/src/components/quote/README.md
@@ -1,4 +1,6 @@
-# <span class="display-name">CdrQuote</span>
+# CdrQuote
+
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/pull-quote/).
 
 ### Markup Tag
 the Tag attribute of cdr-quote allows one of the following options:

--- a/src/components/radio/README.md
+++ b/src/components/radio/README.md
@@ -1,5 +1,7 @@
 ## Props
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/radio/).
+
 | name       | type   | default |
 |:-----------|:-------|:--------|
 | labelClass | string | n/a     |

--- a/src/components/rating/README.md
+++ b/src/components/rating/README.md
@@ -1,5 +1,7 @@
 # CdrRating
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/rating/).
+
 ## Props
 
 | name                                                                    | type   | default |

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -1,5 +1,7 @@
 ## Props
 
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/tabs/).
+
 ### CdrTabs
 
 | Name     | Type   | Default |

--- a/src/components/text/README.md
+++ b/src/components/text/README.md
@@ -1,5 +1,7 @@
 # CdrText
 
+For the most up-to-date information, see [headings](https://rei.github.io/rei-cedar-docs/components/headings/) and [paragraphs](https://rei.github.io/rei-cedar-docs/components/paragraphs/) in REI Cedar Docs.
+
 ## Properties
 
 | tag  | string | 'p'     |

--- a/src/compositions/caption/README.md
+++ b/src/compositions/caption/README.md
@@ -1,4 +1,7 @@
 # CdrCaption
+
+For the most up-to-date information, see [REI Cedar documentation](https://rei.github.io/rei-cedar-docs/components/caption/).
+
 ## Properties
 
 | summary | string | N/A     |


### PR DESCRIPTION
affects: @rei/cdr-accordion, @rei/cdr-breadcrumb, @rei/cdr-checkbox, @rei/cdr-cta,
@rei/cdr-data-table, @rei/cdr-grid, @rei/cdr-img, @rei/cdr-input, @rei/cdr-link, @rei/cdr-list,
@rei/cdr-quote, @rei/cdr-radio, @rei/cdr-rating, @rei/cdr-tabs, @rei/cdr-text, @rei/cdr-caption