### PR TITLE
feat(tokens): add component token maps to cdr-assets

### DIFF
--- a/src/cdr-assets/build.js
+++ b/src/cdr-assets/build.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const fs = require('fs-extra');
 const path = require('path');
 const { exec } = require('child_process');
+const getMaps = require('./get-maps');
 
 // core-css variables
 const distDir = path.resolve(__dirname, 'dist');
@@ -33,3 +34,5 @@ fs.copySync(staticDir, distDir, {
     return false;
   },
 });
+
+getMaps(distDir);

--- a/src/cdr-assets/get-maps.js
+++ b/src/cdr-assets/get-maps.js
@@ -1,0 +1,20 @@
+const glob = require('glob');
+const fs = require('fs-extra');
+const path = require('path');
+
+module.exports = (outDir) => {
+  let index = '';
+  // get vars files
+  const files = glob.sync('../**/*.vars.pcss', { ignore: ['../**/node_modules/**'] });
+  // copy vars files
+  files.forEach((f) => {
+    const fname = path.basename(f);
+    const ext = path.extname(f);
+    const outFname = fname.replace(ext, '.scss');
+    fs.copySync(f, `${outDir}/scss/${outFname}`);
+    index += `@import "./${outFname}";
+`;
+  });
+
+  fs.outputFileSync(`${outDir}/scss/index.scss`, index);
+};

--- a/src/cdr-assets/package.json
+++ b/src/cdr-assets/package.json
@@ -18,9 +18,10 @@
   },
   "devDependencies": {
     "chalk": "^2.0.1",
-    "fs-extra": "^4.0.2",
-    "pkg-ok": "^1.1.0",
-    "postcss-cli": "^4.1.1"
+    "fs-extra": "^7.0.1",
+    "glob": "^7.1.3",
+    "pkg-ok": "^2.3.1",
+    "postcss-cli": "^6.1.1"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
affects: @rei/cdr-assets

This is the script I was talking about adding that looks for all *.vars.pcss files, copies them and creates an index file for easy consumption. I made the script separate in case we want to change this to it's own output outside of assets