### PR TITLE
chore(cedar): bump calendar version for tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rei-cedar",
-  "version": "18.12.2",
+  "version": "19.02.1",
   "description": "REI Cedar Style Framework",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",


### PR DESCRIPTION
Updated the calendar version since we released an updated `cdr-data-table`. Will manually create a matching annotated tag for this release, which should allow lerna to only look for component updates after the tagged commit. 