### PR TITLE
un-break assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/css/generic/_reset.scss
+++ b/src/css/generic/_reset.scss
@@ -31,7 +31,7 @@ html {
 body {
   @include redwood-body-20;
 
-  line-height: 1;
+  line-height: 1.5;
   margin: 0;
   color: $text-color-primary-on-light;
   background-color: #fff;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -15,3 +15,4 @@
 @import './utility/a11y';
 @import './utility/align';
 @import './utility/spacing';
+@import './utility/legacy';

--- a/src/css/utility/_legacy.scss
+++ b/src/css/utility/_legacy.scss
@@ -1,0 +1,209 @@
+/*
+  LEGACY utility classes
+  TODO: deprecation process?
+*/ 
+
+.cdr-inset {
+    padding: 1.6rem !important;
+    display: block;
+}
+
+.cdr-inset--squish {
+    padding: .8rem 1.6rem !important;
+}
+
+.cdr-inset--stretch {
+    padding: 2.4rem 1.6rem !important;
+}
+
+.cdr-inset--sm {
+    padding: .8rem !important;
+}
+
+.cdr-inset--sm.cdr-inset--squish {
+    padding: .4rem .8rem !important;
+}
+
+.cdr-inset--sm.cdr-inset--stretch {
+    padding: 1.2rem .8rem !important;
+}
+
+.cdr-inset--xs {
+    padding: .4rem !important;
+}
+
+.cdr-inset--xs.cdr-inset--squish {
+    padding: .2rem .4rem !important;
+}
+
+.cdr-inset--xs.cdr-inset--stretch {
+    padding: .6rem .4rem !important;
+}
+
+.cdr-inset--xxs {
+    padding: .2rem !important;
+}
+
+.cdr-inset--xxs.cdr-inset--squish {
+    padding: .1rem .2rem !important;
+}
+
+.cdr-inset--xxs.cdr-inset--stretch {
+    padding: .3rem .2rem !important;
+}
+
+.cdr-inset--lg {
+    padding: 3.2rem !important;
+}
+
+.cdr-inset--lg.cdr-inset--squish {
+    padding: 1.6rem 3.2rem !important;
+}
+
+.cdr-inset--lg.cdr-inset--stretch {
+    padding: 4.8rem 3.2rem !important;
+}
+
+.cdr-inset--xl {
+    padding: 6.4rem !important;
+}
+
+.cdr-inset--xl.cdr-inset--squish {
+    padding: 3.2rem 6.4rem !important;
+}
+
+.cdr-inset--xl.cdr-inset--stretch {
+    padding: 9.6rem 6.4rem !important;
+}
+
+.cdr-inset--remove-all {
+    padding: 0
+}
+
+.cdr-inset--remove-top {
+    padding-top: 0
+}
+
+.cdr-inset--remove-right {
+    padding-right: 0
+}
+
+.cdr-inset--remove-bottom {
+    padding-bottom: 0
+}
+
+.cdr-inset--remove-left {
+    padding-left: 0
+}
+
+.cdr-inline {
+    margin-right: 1.6rem !important;
+}
+
+.cdr-inline--xxs {
+    margin-right: .2rem !important;
+}
+
+.cdr-inline--xs {
+    margin-right: .4rem !important;
+}
+
+.cdr-inline--sm {
+    margin-right: .8rem !important;
+}
+
+.cdr-inline--lg {
+    margin-right: 3.2rem !important;
+}
+
+.cdr-inline--xl {
+    margin-right: 6.4rem !important;
+}
+
+.cdr-inline--xxl {
+    margin-right: 12.8rem !important;
+}
+
+.cdr-inline-left {
+    margin-right: 1.6rem !important;
+}
+
+.cdr-inline-left--xxs {
+    margin-right: .2rem !important;
+}
+
+.cdr-inline-left--xs {
+    margin-right: .4rem !important;
+}
+
+.cdr-inline-left--sm {
+    margin-right: .8rem !important;
+}
+
+.cdr-inline-left--lg {
+    margin-right: 3.2rem !important;
+}
+
+.cdr-inline-left--xl {
+    margin-right: 6.4rem !important;
+}
+
+.cdr-inline-left--xxl {
+    margin-right: 12.8rem !important;
+}
+
+.cdr-inline-right {
+    margin-left: 1.6rem !important;
+}
+
+.cdr-inline-right--xxs {
+    margin-left: .2rem !important;
+}
+
+.cdr-inline-right--xs {
+    margin-left: .4rem !important;
+}
+
+.cdr-inline-right--sm {
+    margin-left: .8rem !important;
+}
+
+.cdr-inline-right--lg {
+    margin-left: 3.2rem !important;
+}
+
+.cdr-inline-right--xl {
+    margin-left: 6.4rem !important;
+}
+
+.cdr-inline-right--xxl {
+    margin-left: 12.8rem !important;
+}
+
+.cdr-stack {
+    margin-bottom: 1.6rem !important;
+}
+
+.cdr-stack--xxs {
+    margin-bottom: .2rem !important;
+}
+
+.cdr-stack--xs {
+    margin-bottom: .4rem !important;
+}
+
+.cdr-stack--sm {
+    margin-bottom: .8rem !important;
+}
+
+.cdr-stack--lg {
+    margin-bottom: 3.2rem !important;
+}
+
+.cdr-stack--xl {
+    margin-bottom: 6.4rem !important;
+}
+
+.cdr-stack--xxl {
+    margin-bottom: 12.8rem !important;
+}

--- a/src/css/utility/_spacing.scss
+++ b/src/css/utility/_spacing.scss
@@ -43,27 +43,27 @@
     
     // loop through sides
     @each $full, $short in $sides {
-      .cdr-p#{$short}-#{$name} { padding-#{$full}: #{$value}; }
-      .cdr-m#{$short}-#{$name} { margin-#{$full}: #{$value}; }
+      .cdr-p#{$short}-#{$name} { padding-#{$full}: #{$value} !important; }
+      .cdr-m#{$short}-#{$name} { margin-#{$full}: #{$value} !important; }
 
       @include xs-mq-only {
-        .cdr-p#{$short}-#{$name}\@xs { padding-#{$full}: #{$value}; }
-        .cdr-m#{$short}-#{$name}\@xs { margin-#{$full}: #{$value}; }
+        .cdr-p#{$short}-#{$name}\@xs { padding-#{$full}: #{$value} !important; }
+        .cdr-m#{$short}-#{$name}\@xs { margin-#{$full}: #{$value} !important; }
       }
 
       @include sm-mq-only {
-        .cdr-p#{$short}-#{$name}\@sm { padding-#{$full}: #{$value}; }
-        .cdr-m#{$short}-#{$name}\@sm { margin-#{$full}: #{$value}; }
+        .cdr-p#{$short}-#{$name}\@sm { padding-#{$full}: #{$value} !important; }
+        .cdr-m#{$short}-#{$name}\@sm { margin-#{$full}: #{$value} !important; }
       }
 
       @include md-mq-only {
-        .cdr-p#{$short}-#{$name}\@md { padding-#{$full}: #{$value}; }
-        .cdr-m#{$short}-#{$name}\@md { margin-#{$full}: #{$value}; }
+        .cdr-p#{$short}-#{$name}\@md { padding-#{$full}: #{$value} !important; }
+        .cdr-m#{$short}-#{$name}\@md { margin-#{$full}: #{$value} !important; }
       }
 
       @include lg-mq-only {
-        .cdr-p#{$short}-#{$name}\@lg { padding-#{$full}: #{$value}; }
-        .cdr-m#{$short}-#{$name}\@lg { margin-#{$full}: #{$value}; }
+        .cdr-p#{$short}-#{$name}\@lg { padding-#{$full}: #{$value} !important; }
+        .cdr-m#{$short}-#{$name}\@lg { margin-#{$full}: #{$value} !important; }
       }
     }
   }
@@ -74,22 +74,22 @@
 // inset
 @mixin make-inset-space-utilities() {
   @each $key, $value in $spacing-inset {
-    .#{$key} { padding: #{$value}; }
+    .#{$key} { padding: #{$value} !important; }
 
     @include xs-mq-only {
-        .#{$key}\@xs { padding: #{$value}; }
+        .#{$key}\@xs { padding: #{$value} !important; }
       }
 
       @include sm-mq-only {
-        .#{$key}\@sm { padding: #{$value}; }
+        .#{$key}\@sm { padding: #{$value} !important; }
       }
 
       @include md-mq-only {
-        .#{$key}\@md { padding: #{$value}; }
+        .#{$key}\@md { padding: #{$value} !important; }
       }
 
       @include lg-mq-only {
-        .#{$key}\@lg { padding: #{$value}; }
+        .#{$key}\@lg { padding: #{$value} !important; }
       }
   }
 }


### PR DESCRIPTION
- adds !important to spacing utility classes
- restores body line-height to 1.5 in the CSS reset
- includes the legacy spacing classes with !important applied

https://gist.github.com/cowills/a868cd959f57be1b70a313b57a8dbe2b 0.3.0 CSS reset vs. single package CSS reset (for reference)