### PR TITLE
Fix/input v model add watcher

### DIFF
--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -167,6 +167,19 @@ export default {
       };
     },
   },
+  watch: {
+    value(val) {
+      this.newValue = val;
+    },
+    newValue(val) {
+      /**
+       * `v-model` value. Fires on input.
+       * @event input
+       * @type value | event
+       * */
+      this.$emit('input', val);
+    },
+  },
   methods: {
     onInput(e) {
       const { value } = e.target;

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount, mount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { CdrInput } from 'distdir/cedar.esm.js';
 
 describe('CdrInput.vue', () => {

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount } from '@vue/test-utils';
 import { CdrInput } from 'distdir/cedar.esm.js';
 
 describe('CdrInput.vue', () => {
@@ -251,4 +251,8 @@ describe('CdrInput.vue', () => {
     input.trigger('keydown')
     expect(wrapper.emitted().keydown).toBeTruthy();
   });
+
+  // TODO - If Vue Test Utils adds a way to mount with v-model,
+  // or if we can figure out a way to test that a v-model change
+  // updates the input value, then we should add that test.
 });

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -104,6 +104,13 @@
       placeholder="#6 Multi Line Input/TextArea"
       label="#6 Multi Line Input/TextArea"
     />
+    <cdr-input
+      class="demo-input "
+      v-model="masterModel"
+      @input="onMasterInput"
+      placeholder="What would you like to set all input values to?"
+      label="Master input that overwrites all other inputs on this page"
+    />
 
     <div class="demo-input">
       Input #1 Value = {{ defaultModel }}
@@ -125,6 +132,9 @@
     </div>
     <div class="demo-input">
       Size Inputs Value = {{ sizeModel }}
+    </div>
+    <div class="demo-input">
+      Master Inputs Value = {{ masterModel }}
     </div>
   </div>
 </template>
@@ -149,7 +159,20 @@ export default {
       requiredWithIcons: '',
       multiRowModel: '',
       sizeModel: '',
+      masterModel: '',
     };
+  },
+  methods: {
+    onMasterInput(value, e) {
+      console.log('On Master Input value = ', value, ' e = ', e);
+      this.defaultModel = value;
+      this.requiredModel = value;
+      this.hiddenModel = value;
+      this.disabledModel = value;
+      this.requiredWithIcons = value;
+      this.multiRowModel = value;
+      this.sizeModel = value;
+    },
   },
 };
 </script>


### PR DESCRIPTION
Tried to add unit test for v-model to input value change, but the Vue Test Utils does not support how v-model works at runtime(It does 1 way binding), so there is no way to test this as I know of through Vue Test Utils.  So instead I created an example where we can test it visually in the example.  If you change the master input value, that triggers changes to all the other input's v-models.  This was not working before the watcher was added and is now working.  I feel this is sufficient for now, but we should modify our v-model implementation in the near future to match how Vue recommends.   