### PR TITLE
fix(input): fix border and box shadow on ios

### DIFF
--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -48,6 +48,12 @@
   overflow: visible;
   margin: 0;
 
+  /* Prevent iOS from altering border and box-shadow */
+  @supports (-webkit-overflow-scrolling: touch) {
+    /* CSS specific to iOS devices */
+    -webkit-appearance: none;
+  }
+
   /* States
   ---------- */
   &[disabled] {


### PR DESCRIPTION
iOS Platform default styling was overriding border and box-shadow styles.  Added webkit property to prevent this and isolated it to only apply on iOS devices.  Tested this in browserstack on iPhone X and iPhone 8 as well as Android Samsung S9, Chrome OSX, Safari OSX, Edge Windows 10, and Firefox OSX.

This is linked to github issue #627