### PR TITLE
feat: 🎸 Adding modifier for tab center alignment option

### DIFF
--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -189,6 +189,77 @@
         </cdr-tab-panel>
       </cdr-tabs>
     </div>
+
+    <!-- Centered Modifier -->
+    <div class="tab-demo-section">
+      <cdr-text
+        tag="h3"
+        modifier="heading-small"
+      >
+        Centered Tabs
+      </cdr-text>
+      <cdr-tabs modifier="centered">
+        <cdr-tab-panel name="one">
+          <cdr-text
+            tag="strong"
+            modifier="subheading"
+          >
+            Tab One Content
+          </cdr-text>
+        </cdr-tab-panel>
+        <cdr-tab-panel name="two">
+          <cdr-text
+            tag="strong"
+            modifier="subheading"
+          >
+            Tab Two Content
+          </cdr-text>
+        </cdr-tab-panel>
+        <cdr-tab-panel name="three">
+          <cdr-text
+            tag="h1"
+            modifier="heading-large"
+          >tab three content</cdr-text>
+          <cdr-text
+            tag="strong"
+            modifier="subheading"
+          >
+            <cdr-text>What's a rerun? Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Whoa, whoa, kid, kid, stop, stop, stop, stop. Leave me alone. Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh.
+
+              I have a feeling too. What? Well, I figured, what the hell. Alright, we're the pinheads. C'mon.
+
+              Yeah, well, I still don't understand what Dad was doing in the middle of the street. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Great good, good, Lorraine, I had a feeling about you two. Right. Well, Marty, I want to thank you for all your good advise, I'll never forget it.</cdr-text>
+            <cdr-text
+              tag="h1"
+              modifier="heading-large"
+            >tab three content</cdr-text>
+            Tab Two Content
+            <cdr-text>What's a rerun? Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Whoa, whoa, kid, kid, stop, stop, stop, stop. Leave me alone. Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh.
+
+              I have a feeling too. What? Well, I figured, what the hell. Alright, we're the pinheads. C'mon.
+
+              Yeah, well, I still don't understand what Dad was doing in the middle of the street. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Great good, good, Lorraine, I had a feeling about you two. Right. Well, Marty, I want to thank you for all your good advise, I'll never forget it.</cdr-text>
+          </cdr-text>
+        </cdr-tab-panel>
+        <cdr-tab-panel name="four">
+          <cdr-text
+            tag="strong"
+            modifier="subheading"
+          >
+            Tab Four Content
+          </cdr-text>
+        </cdr-tab-panel>
+        <cdr-tab-panel name="five">
+          <cdr-text
+            tag="strong"
+            modifier="subheading"
+          >
+            Tab Five Content
+          </cdr-text>
+        </cdr-tab-panel>
+      </cdr-tabs>
+    </div>
+
     <!-- No Border Modifier -->
     <div class="tab-demo-section">
       <cdr-text

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -18,6 +18,7 @@
       :compact
       :no-border
       :full-width
+      :centered
 ========================================================================== */
 
 .cdr-tabs {
@@ -129,10 +130,9 @@
     height: $cdr-space-quarter-x;
     box-sizing: border-box;
     border: none;
-
-    /* border: none; */
     background: $easily-excited;
     transition: 0.6s cubic-bezier(0.32, 0.94, 0.6, 1);
+    z-index: 1;
   }
 
   &__content-container {
@@ -177,6 +177,16 @@
   &--full-width {
     .cdr-tabs__header {
       justify-content: space-between;
+    }
+  }
+
+  /* Centered
+  ========== */
+  &--centered {
+    .cdr-tabs__gradient-container {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
     }
   }
 }


### PR DESCRIPTION
Per design and cedar convo, we are wishing to include a variant for
center aligned tabs. *Added the addition of `z-index: 1` to address an issue of tab underline disappearing under `cdr-tab-panel` content.

BREAKING CHANGE: 🧨 no

✅ Closes: N/A