### PR TITLE
Fix ssr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13741,6 +13741,12 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
+        },
+        "vue-runtime-helpers": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/vue-runtime-helpers/-/vue-runtime-helpers-1.0.1.tgz",
+          "integrity": "sha512-yodqdAWt/QrUkb51jN2DS4dtF4vQWg5YejYdBAcHIOi6kBoGLRVEDz5NYGdh5IhzLrElgi+eKX1DQJmj3bCuJw==",
+          "dev": true
         }
       }
     },
@@ -16311,9 +16317,9 @@
       "dev": true
     },
     "vue-runtime-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-runtime-helpers/-/vue-runtime-helpers-1.0.0.tgz",
-      "integrity": "sha512-DgwCNgIXkq1GJsWwtFOjA/K2nxpjyon/QqAut0EiwrMHBatAPbfdqksDdRoK15b5YrSJRa59rx3pc0L6V4udUA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vue-runtime-helpers/-/vue-runtime-helpers-1.0.1.tgz",
+      "integrity": "sha512-yodqdAWt/QrUkb51jN2DS4dtF4vQWg5YejYdBAcHIOi6kBoGLRVEDz5NYGdh5IhzLrElgi+eKX1DQJmj3bCuJw==",
       "dev": true
     },
     "vue-template-compiler": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "tinycolor2": "^1.4.1",
     "vue": "^2.5.22",
     "vue-router": "^3.0.2",
+    "vue-runtime-helpers": "^1.0.1",
     "vue-template-compiler": "^2.5.22"
   },
   "engines": {


### PR DESCRIPTION
This hacks our package-lock to force rollup-plugin-vue to use vue-runtime-helps@1.0.1 instead of 1.0.0

1.0.1 contains a critical SSR fix: https://github.com/znck/vue-runtime-helpers/commit/02d9dfaf54388128a7eac8013f0af6526f6e8586 

This has been verified on an SSR try server

This hack will be obliterated any time someone runs `npm install` in this repo, so we must address it before the next release. The ideal solution would be to submit a PR/issue to rollup-plugin-vue to update that dependency, then update our rollup-plugin-vue version.