### PR TITLE
chore(tokens): update tokens version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "2.0.2",
+  "version": "2.1.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1417,9 +1417,9 @@
       "dev": true
     },
     "@rei/cdr-tokens": {
-      "version": "1.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-1.0.1-alpha.0.tgz",
-      "integrity": "sha512-wOmf8WISIIhF790tp/qujZvgdKNSt6zDQHKqn4ZxB0ZSLGXX1+t9YLFWGcX8QmkKhlrLN/XvgmReSMD+vVGnxQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-1.1.0.tgz",
+      "integrity": "sha512-MvCjIp80KdCOejz3m1SIPtUYeWrmmG45rILsmhYUY2yiHiKsTJ2uaa/y9qaT3xo2YPR5VQND+5F145ISz1yQDw==",
       "dev": true
     },
     "@sinonjs/commons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "2.0.2",
+  "version": "2.1.0-alpha.0",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",
@@ -57,7 +57,7 @@
     "@babel/runtime": "^7.4.3",
     "@commitlint/cli": "^7.5.2",
     "@commitlint/config-conventional": "^7.5.0",
-    "@rei/cdr-tokens": "^1.0.1-alpha.0",
+    "@rei/cdr-tokens": "^1.1.0",
     "@vue/test-utils": "^1.0.0-beta.29",
     "autoprefixer": "^9.4.7",
     "babel-core": "^7.0.0-bridge.0",

--- a/src/components/Utilities/demos/inset.vue
+++ b/src/components/Utilities/demos/inset.vue
@@ -39,7 +39,7 @@
 <script>
 
 import { CdrText } from 'componentsdir/_index';
-import tokens from '@rei/cdr-tokens';
+import * as tokens from '@rei/cdr-tokens';
 import pickBy from 'lodash/pickBy';
 import kebabCase from 'lodash/kebabCase';
 

--- a/src/components/Utilities/demos/spacing.vue
+++ b/src/components/Utilities/demos/spacing.vue
@@ -41,7 +41,7 @@
 
 <script>
 import { CdrText } from 'componentsdir/_index';
-import tokens from '@rei/cdr-tokens';
+import * as tokens from '@rei/cdr-tokens';
 import pickBy from 'lodash/pickBy';
 import kebabCase from 'lodash/kebabCase';
 

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -101,7 +101,7 @@ describe('CdrBreadcrumb.vue', () => {
   });
 
   it('breadcrumb breakpoints isLG returns true at lg breakpoint', () => {
-    window.outerWidth = 1201; // Force lg screen size
+    window.outerWidth = 1233; // Force lg screen size
     const wrapper = shallowMount(CdrBreadcrumb);
     const isLG = wrapper.vm.isLG();
     expect(isLG).toBe(true);

--- a/src/mixins/breakpoints.js
+++ b/src/mixins/breakpoints.js
@@ -2,15 +2,22 @@
  * Provides methods for working with screen size breakpoints
  *   XS < 768px
  *   SM >= 768px < 992px
- *   MD >= 992px < 1200px
- *   LG >= 1200px
+ *   MD >= 992px < 1232px
+ *   LG >= 1232px
  */
 /**
  * @mixin
  */
-const SMBreakpoint = 768;
-const MDBreakpoint = 992;
-const LGBreakpoint = 1200;
+import {
+  CdrBreakpointSm,
+  CdrBreakpointMd,
+  CdrBreakpointLg,
+} from '@rei/cdr-tokens/dist/js/cdr-tokens.esm';
+
+// TODO: is this the most optimal way to drop the units for use in JS?
+const SMBreakpoint = CdrBreakpointSm.replace(/px/, '');
+const MDBreakpoint = CdrBreakpointMd.replace(/px/, '');
+const LGBreakpoint = CdrBreakpointLg.replace(/px/, '');
 
 export default {
   methods: {


### PR DESCRIPTION
this should be a testable alpha

contains these updates: https://github.com/rei/rei-cedar-tokens/pull/46