### PR TITLE
fix utilities.scss build

### DIFF
--- a/src/components/dataTable/CdrDataTable.vue
+++ b/src/components/dataTable/CdrDataTable.vue
@@ -28,7 +28,7 @@
         :id="id ? id : null"
       >
         <caption
-          class="cdr-sr-only"
+          class="cdr-display-sr-only"
           v-if="caption"
         >
           {{ caption }}

--- a/src/components/rating/CdrRating.vue
+++ b/src/components/rating/CdrRating.vue
@@ -55,7 +55,7 @@
       Reviews
     </span></span>
     <span
-      class="cdr-sr-only"
+      class="cdr-display-sr-only"
     >rated {{ rounded }} out of 5 with {{ count }} reviews</span>
   </component>
 </template>

--- a/src/css/utilities.scss
+++ b/src/css/utilities.scss
@@ -4,10 +4,14 @@
 /* Settings */
 @import "./settings/index";
 
+/* Generic */
+@import "./generic/container";
+@import "./generic/color";
+@import "./generic/typography";
+
 /* Utilities */
 @import './utility/visibility';
 @import './utility/alignment';
 @import './utility/spacing';
 
-/* Deprecated utils */
 @import './deprecated/index';

--- a/src/css/utilities.scss
+++ b/src/css/utilities.scss
@@ -6,7 +6,8 @@
 
 /* Utilities */
 @import './utility/visibility';
-@import './utility/a11y';
-@import './utility/align';
+@import './utility/alignment';
 @import './utility/spacing';
-@import './utility/legacy';
+
+/* Deprecated utils */
+@import './deprecated/index';


### PR DESCRIPTION
fixes the utilities.scss imports to load the new utility files. (also updates two instances of `cdr-sr-only` to match the new name for that class.

side note: we should probably not use utility classes in the components, since it means cedar consumers then have to load the utilities even if they never use them