### PR TITLE
v-model/listeners consistency

### DIFF
--- a/src/components/button/CdrButton.vue
+++ b/src/components/button/CdrButton.vue
@@ -10,7 +10,8 @@
       space
     ]"
     :type="tag === 'button' ? type : null"
-    @click="onClick"
+
+    v-on="$listeners"
   >
     <!-- @slot for icon -->
     <slot name="icon" />
@@ -52,13 +53,6 @@ export default {
       type: String,
       default: 'button',
       validator: value => (['button', 'submit', 'reset'].indexOf(value) >= 0) || false,
-    },
-    /**
-     * Adds custom click actions.
-     */
-    onClick: {
-      type: Function,
-      default: () => () => null,
     },
     /**
      * Sets width to be 100%.

--- a/src/components/button/__tests__/CdrButton.spec.js
+++ b/src/components/button/__tests__/CdrButton.spec.js
@@ -29,18 +29,11 @@ describe('CdrButton.vue', () => {
     expect(wrapper.attributes().type).toBe('reset');
   });
 
-  it('has default click', () => {
-    const wrapper = shallowMount(CdrButton);
-    const defaultFunc = wrapper.vm.$props.onClick();
-    const result = defaultFunc();
-    expect(result).toBe(null)
-  });
-
   it('click function triggers correctly', () => {
     const spy = sinon.spy();
     const wrapper = shallowMount(CdrButton, {
-      propsData: {
-        onClick: spy
+      listeners: {
+        click: spy
       },
     });
     wrapper.trigger('click');

--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -153,20 +153,20 @@ export default {
         [this.$style['cdr-input-wrap']]: true,
       };
     },
-    inputListeners: function () {//
+    inputListeners() {
       // https://vuejs.org/v2/guide/components-custom-events.html#Binding-Native-Events-to-Components
       // handles conflict between v-model and v-on="$listeners"
-      var vm = this;
+      const vm = this;
       return Object.assign(
         {},
         this.$listeners,
         {
-          input: function (event) {
-            vm.$emit('input', event.target.value)
-          }
-        }
+          input(event) {
+            vm.$emit('input', event.target.value);
+          },
+        },
       );
-    }
+    },
   },
 };
 </script>

--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -26,13 +26,9 @@
         :rows="[rows]"
         :class="[inputClass, sizeClass, space]"
         v-bind="$attrs"
+        v-on="$listeners"
         v-model="newValue"
         :id="inputId"
-        @blur="onBlur"
-        @input="onInput"
-        @focus="onFocus"
-        @paste="onPaste"
-        @keydown="onKeydown"
         :disabled="disabled"
         :required="required"
         :aria-label="hideLabel ? label : null"
@@ -43,13 +39,9 @@
         :type="type"
         :class="[inputClass, sizeClass, space]"
         v-bind="$attrs"
+        v-on="$listeners"
         v-model="newValue"
         :id="inputId"
-        @blur="onBlur"
-        @input="onInput"
-        @focus="onFocus"
-        @paste="onPaste"
-        @keydown="onKeydown"
         :disabled="disabled"
         :required="required"
         :aria-label="hideLabel ? label : null"
@@ -178,49 +170,6 @@ export default {
        * @type value | event
        * */
       this.$emit('input', val);
-    },
-  },
-  methods: {
-    onInput(e) {
-      const { value } = e.target;
-      /**
-      * Current input value. Fires while typing.
-      * Returns (value, event)
-      * @event input
-      * @type {event}
-      */
-      this.$emit('input', value, e);
-    },
-    onBlur(e) {
-      /**
-      * Fires when input loses focus.
-      * @event blur
-      * @type {event}
-      */
-      this.$emit('blur', e);
-    },
-    onFocus(e) {
-      /**
-      * Fires when input gains focus.
-      * @event focus
-      * @type {event} */
-      this.$emit('focus', e);
-    },
-    onPaste(e) {
-      /**
-      * Fires when text is pasted into input.
-      * @event paste
-      * @type {event}
-       */
-      this.$emit('paste', e);
-    },
-    onKeydown(e) {
-      /**
-      * Fires when a key is pressed.
-      * @event keydown
-      * @type {event}
-       */
-      this.$emit('keydown', e);
     },
   },
 };

--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -153,7 +153,9 @@ export default {
         [this.$style['cdr-input-wrap']]: true,
       };
     },
-    inputListeners: function () {
+    inputListeners: function () {//
+      // https://vuejs.org/v2/guide/components-custom-events.html#Binding-Native-Events-to-Components
+      // handles conflict between v-model and v-on="$listeners"
       var vm = this;
       return Object.assign(
         {},

--- a/src/components/input/CdrInput.vue
+++ b/src/components/input/CdrInput.vue
@@ -26,8 +26,8 @@
         :rows="[rows]"
         :class="[inputClass, sizeClass, space]"
         v-bind="$attrs"
-        v-on="$listeners"
-        v-model="newValue"
+        v-on="inputListeners"
+        :value="value"
         :id="inputId"
         :disabled="disabled"
         :required="required"
@@ -39,8 +39,8 @@
         :type="type"
         :class="[inputClass, sizeClass, space]"
         v-bind="$attrs"
-        v-on="$listeners"
-        v-model="newValue"
+        v-on="inputListeners"
+        :value="value"
         :id="inputId"
         :disabled="disabled"
         :required="required"
@@ -127,11 +127,6 @@ export default {
       type: [String, Number],
     },
   },
-  data() {
-    return {
-      newValue: this.value,
-    };
-  },
   computed: {
     // Use given id or generate one
     inputId() {
@@ -158,19 +153,18 @@ export default {
         [this.$style['cdr-input-wrap']]: true,
       };
     },
-  },
-  watch: {
-    value(val) {
-      this.newValue = val;
-    },
-    newValue(val) {
-      /**
-       * `v-model` value. Fires on input.
-       * @event input
-       * @type value | event
-       * */
-      this.$emit('input', val);
-    },
+    inputListeners: function () {
+      var vm = this;
+      return Object.assign(
+        {},
+        this.$listeners,
+        {
+          input: function (event) {
+            vm.$emit('input', event.target.value)
+          }
+        }
+      );
+    }
   },
 };
 </script>

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -281,7 +281,7 @@ describe('CdrInput.vue', () => {
       },
     });
     const input = wrapper.find({ ref: 'input' });
-    wrapper.setData({newValue: ''});
+    wrapper.setProps({value: ''});
     expect(input.element.value).toBe('');
   });
 });

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import sinon from 'sinon';
 import { CdrInput } from 'distdir/cedar.esm.js';
 
 describe('CdrInput.vue', () => {
@@ -201,58 +202,86 @@ describe('CdrInput.vue', () => {
     const wrapper = shallowMount(CdrInput, {
       propsData: {
         label: 'test',
+        value: 'bar'
       },
     });
     const input = wrapper.find({ ref: 'input' });
-    input.trigger('input')
-    expect(wrapper.emitted().input).toBeTruthy();
+    input.setValue('foo');
+    expect(wrapper.emitted().input[0][0]).toBe('foo');
   });
 
   it('emits a blur event', () => {
+    const spy = sinon.spy();
     const wrapper = shallowMount(CdrInput, {
       propsData: {
         label: 'test',
       },
+      listeners: {
+        'blur': spy
+      }
     });
     const input = wrapper.find({ ref: 'input' });
     input.trigger('blur')
-    expect(wrapper.emitted().blur).toBeTruthy();
+    expect(spy.calledOnce).toBeTruthy();
   });
 
   it('emits a focus event', () => {
+    const spy = sinon.spy();
     const wrapper = shallowMount(CdrInput, {
       propsData: {
         label: 'test',
       },
+      listeners: {
+        'focus': spy
+      }
     });
     const input = wrapper.find({ ref: 'input' });
     input.trigger('focus')
-    expect(wrapper.emitted().focus).toBeTruthy();
+    expect(spy.calledOnce).toBeTruthy();
   });
 
   it('emits a paste event', () => {
+    const spy = sinon.spy();
     const wrapper = shallowMount(CdrInput, {
       propsData: {
         label: 'test',
       },
+      listeners: {
+        'paste': spy
+      }
     });
     const input = wrapper.find({ ref: 'input' });
     input.trigger('paste')
-    expect(wrapper.emitted().paste).toBeTruthy();
+    expect(spy.calledOnce).toBeTruthy();
   });
 
   it('emits a keydown event', () => {
+    const spy = sinon.spy();
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test'
+      },
+      listeners: {
+        'keydown': spy
+      }
+    });
+    const input = wrapper.find({ ref: 'input' });
+    input.trigger('keydown', {
+      key: 'a'
+    })
+    expect(spy.called).toBeTruthy();
+  });
+
+  // NOTE - can't use v-model directly here, targeting the `data` prop instead
+  it('updating v-model data updates the input', () => {
     const wrapper = shallowMount(CdrInput, {
       propsData: {
         label: 'test',
+        value: 'bar'
       },
     });
     const input = wrapper.find({ ref: 'input' });
-    input.trigger('keydown')
-    expect(wrapper.emitted().keydown).toBeTruthy();
+    wrapper.setData({newValue: ''});
+    expect(input.element.value).toBe('');
   });
-
-  // TODO - If Vue Test Utils adds a way to mount with v-model,
-  // or if we can figure out a way to test that a v-model change
-  // updates the input value, then we should add that test.
 });

--- a/src/components/link/__tests__/CdrLink.spec.js
+++ b/src/components/link/__tests__/CdrLink.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import sinon from 'sinon';
 import { CdrLink } from 'distdir/cedar.esm.js';
 // import CdrThemer from 'componentsdir/themer/CdrThemer';
 
@@ -44,13 +45,13 @@ describe('CdrLink.vue', () => {
     });
     expect(wrapper.attributes().rel).toBe('noopener noreferrer');
   });
-  
+
   it('computes the base class correctly', () => {
     const wrapper = shallowMount(CdrLink);
     // expect(wrapper.classes().length).toBe(1);
     expect(wrapper.vm.$style).toHaveProperty('cdr-link');
   });
-  
+
   it('computes classes correctly for standalone modifier', () => {
     const wrapper = shallowMount(CdrLink, {
       propsData: {
@@ -71,13 +72,17 @@ describe('CdrLink.vue', () => {
   });
 
   it('emits a click', () => {
+    const spy = sinon.spy();
     const wrapper = shallowMount(CdrLink, {
       propsData: {
         tag: 'button',
       },
+      listeners: {
+        'click': spy
+      },
     });
     wrapper.trigger('click');
-    expect(wrapper.emitted('click'));
+    expect(spy.called).toBeTruthy();
   });
 
   xit('inherits theme correctly', () => {

--- a/src/components/pagination/CdrPagination.vue
+++ b/src/components/pagination/CdrPagination.vue
@@ -4,7 +4,7 @@
   <nav aria-label="Pagination Navigation">
     <ul :class="$style['cdr-pagination']">
       <li
-        v-if="localCurrent > pages[0].page"
+        v-if="newValue > pages[0].page"
       >
         <a
           :class="[
@@ -30,11 +30,11 @@
           v-if="n !== '&hellip;'"
           :class="[
             $style['cdr-pagination__link'],
-            {'current': n.page === localCurrent}
+            {'current': n.page === newValue}
           ]"
           :href="n.url"
-          :aria-label=" n.page === localCurrent ? `Current page, page ${n.page}` : `Go to page ${n.page}`"
-          :aria-current="n.page === localCurrent"
+          :aria-label=" n.page === newValue ? `Current page, page ${n.page}` : `Go to page ${n.page}`"
+          :aria-current="n.page === newValue"
           @click="navigate(n.page, $event)"
         >{{ n.page }}</a>
         <!-- eslint-disable vue/no-v-html -->
@@ -64,7 +64,7 @@
         </cdr-select>
       </li>
       <li
-        v-if="localCurrent < pages[totalPageData - 1].page"
+        v-if="newValue < pages[totalPageData - 1].page"
       >
         <a
           :class="[
@@ -95,10 +95,6 @@ export default {
     IconCaretLeft,
     IconCaretRight,
     CdrSelect,
-  },
-  model: {
-    prop: 'currentPage',
-    event: 'change',
   },
   props: {
     /**
@@ -131,14 +127,14 @@ export default {
         return result;
       },
     },
-    /** @ignore used for binding v-model */
-    currentPage: {
+    /** @ignore used for binding v-model, represents the current page */
+    value: {
       type: Number,
     },
   },
   data() {
     return {
-      localCurrent: this.currentPage,
+      newValue: this.value,
       currentUrl: '',
     };
   },
@@ -153,7 +149,7 @@ export default {
       return this.currentIdx + 1;
     },
     currentIdx() {
-      return this.pages.map(x => x.page).indexOf(this.localCurrent);
+      return this.pages.map(x => x.page).indexOf(this.newValue);
     },
     /**
      * Creates an array of the pages that should be shown as links with logic for truncation.
@@ -176,7 +172,7 @@ export default {
      */
     paginationData() {
       const total = this.totalPageData;
-      const current = this.localCurrent;
+      const current = this.newValue;
       const delta = 1;
       let range = [];
       let over5 = true;
@@ -221,8 +217,8 @@ export default {
     },
   },
   watch: {
-    currentPage(v) {
-      this.localCurrent = v;
+    value(v) {
+      this.newValue = v;
       this.currentUrl = this.pages[this.currentIdx].url;
     },
   },
@@ -232,6 +228,7 @@ export default {
   methods: {
     navigate(num, e) {
       this.$emit('change', num, e);
+      this.$emit('input', num, e);
     },
     select(url, url2, e) {
       const idx = this.pages.map(x => x.url).indexOf(url);

--- a/src/components/pagination/CdrPagination.vue
+++ b/src/components/pagination/CdrPagination.vue
@@ -50,7 +50,7 @@
           v-model="currentUrl"
           label="Navigate to page"
           hide-label
-          @change="select(currentUrl, ...arguments)"
+          @change="select"
           :class="$style['cdr-pagination__select']"
           ref="select"
         >
@@ -228,7 +228,7 @@ export default {
       this.$emit('change', num, e);
       this.$emit('input', num, e);
     },
-    select(url, url2, e) {
+    select(url, e) {
       const idx = this.pages.map(x => x.url).indexOf(url);
       const n = this.pages[idx].page;
       this.$emit('select-change', url, e);

--- a/src/components/pagination/CdrPagination.vue
+++ b/src/components/pagination/CdrPagination.vue
@@ -216,7 +216,7 @@ export default {
     },
   },
   watch: {
-    value(v) {
+    value() {
       this.currentUrl = this.pages[this.currentIdx].url;
     },
   },

--- a/src/components/pagination/CdrPagination.vue
+++ b/src/components/pagination/CdrPagination.vue
@@ -4,7 +4,7 @@
   <nav aria-label="Pagination Navigation">
     <ul :class="$style['cdr-pagination']">
       <li
-        v-if="newValue > pages[0].page"
+        v-if="value > pages[0].page"
       >
         <a
           :class="[
@@ -30,11 +30,11 @@
           v-if="n !== '&hellip;'"
           :class="[
             $style['cdr-pagination__link'],
-            {'current': n.page === newValue}
+            {'current': n.page === value}
           ]"
           :href="n.url"
-          :aria-label=" n.page === newValue ? `Current page, page ${n.page}` : `Go to page ${n.page}`"
-          :aria-current="n.page === newValue"
+          :aria-label=" n.page === value ? `Current page, page ${n.page}` : `Go to page ${n.page}`"
+          :aria-current="n.page === value"
           @click="navigate(n.page, $event)"
         >{{ n.page }}</a>
         <!-- eslint-disable vue/no-v-html -->
@@ -64,7 +64,7 @@
         </cdr-select>
       </li>
       <li
-        v-if="newValue < pages[totalPageData - 1].page"
+        v-if="value < pages[totalPageData - 1].page"
       >
         <a
           :class="[
@@ -134,7 +134,6 @@ export default {
   },
   data() {
     return {
-      newValue: this.value,
       currentUrl: '',
     };
   },
@@ -149,7 +148,7 @@ export default {
       return this.currentIdx + 1;
     },
     currentIdx() {
-      return this.pages.map(x => x.page).indexOf(this.newValue);
+      return this.pages.map(x => x.page).indexOf(this.value);
     },
     /**
      * Creates an array of the pages that should be shown as links with logic for truncation.
@@ -172,7 +171,7 @@ export default {
      */
     paginationData() {
       const total = this.totalPageData;
-      const current = this.newValue;
+      const current = this.value;
       const delta = 1;
       let range = [];
       let over5 = true;
@@ -218,7 +217,6 @@ export default {
   },
   watch: {
     value(v) {
-      this.newValue = v;
       this.currentUrl = this.pages[this.currentIdx].url;
     },
   },

--- a/src/components/pagination/__tests__/CdrPagination.spec.js
+++ b/src/components/pagination/__tests__/CdrPagination.spec.js
@@ -33,7 +33,7 @@ describe('CdrPagination.vue', () => {
     const wrapper = shallowMount(CdrPagination, {
       propsData: {
         pages: makePages(20),
-        currentPage: 1,
+        value: 1,
       },
     });
     expect(wrapper.is('nav')).toBe(true);
@@ -43,7 +43,7 @@ describe('CdrPagination.vue', () => {
     const wrapper = shallowMount(CdrPagination, {
       propsData: {
         pages: makePages(20),
-        currentPage: 1,
+        value: 1,
       },
     });
     let prev = wrapper.find({ref: 'prev-link'});
@@ -52,22 +52,22 @@ describe('CdrPagination.vue', () => {
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5,'...',20]);
     expect(prev.exists()).toBeFalsy();
     expect(next.exists()).toBeTruthy();
-    
-    wrapper.setProps({ currentPage: 4 })
+
+    wrapper.setData({ newValue: 4 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5,'...',20]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
-    
-    wrapper.setProps({ currentPage: 20 })
+
+    wrapper.setData({ newValue: 20 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,'...',16,17,18,19,20]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeFalsy();
-    
-    wrapper.setProps({ currentPage: 17 })
+
+    wrapper.setData({ newValue: 17 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,'...',16,17,18,19,20]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
@@ -79,7 +79,7 @@ describe('CdrPagination.vue', () => {
     const wrapper = shallowMount(CdrPagination, {
       propsData: {
         pages: makePages(5),
-        currentPage: 1,
+        value: 1,
       },
     });
     let prev = wrapper.find({ref: 'prev-link'});
@@ -87,15 +87,15 @@ describe('CdrPagination.vue', () => {
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5]);
     expect(prev.exists()).toBeFalsy();
     expect(next.exists()).toBeTruthy();
-    
-    wrapper.setProps({ currentPage: 4 })
+
+    wrapper.setData({ newValue: 4 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
-    
-    wrapper.setProps({ currentPage: 5 })
+
+    wrapper.setData({ newValue: 5 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
@@ -107,48 +107,43 @@ describe('CdrPagination.vue', () => {
     const wrapper = shallowMount(CdrPagination, {
       propsData: {
         pages: makePages(getPrevNextPages(5), 3),
-        currentPage: 5,
+        value: 5,
       },
     });
-    
+
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([4, 5, 6]);
     let prev = wrapper.find({ ref: 'prev-link' });
     let next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
-    
-    wrapper.setProps({
-      currentPage: 4,
-      pages: makePages(getPrevNextPages(4), 2),
-    });
-    expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([3, 4, 5]);
-    prev = wrapper.find({ ref: 'prev-link' });
-    next = wrapper.find({ ref: 'next-link' });
-    expect(prev.exists()).toBeTruthy();
-    expect(next.exists()).toBeTruthy();
   });
 
-  it('sorts prev/next only pages correctly when at first/last', () => {
+  it('shows next but not prev link when at first page', () => {
     const wrapper = shallowMount(CdrPagination, {
       propsData: {
         pages: makePages(getPrevNextPages(1), -1),
-        currentPage: 1,
+        value: 1,
       },
     });
-    
+
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1, 2]);
-    let prev = wrapper.find({ ref: 'prev-link' });
-    let next = wrapper.find({ ref: 'next-link' });
+    const prev = wrapper.find({ ref: 'prev-link' });
+    const next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeFalsy();
     expect(next.exists()).toBeTruthy();
+  });
 
-    wrapper.setProps({
-      pages: makePages(getPrevNextPages(10), 8),
-      currentPage: 10,
+  it('shows prev but not next link when at last page', () => {
+    const wrapper = shallowMount(CdrPagination, {
+      propsData: {
+        pages: makePages(getPrevNextPages(10), 8),
+        value: 10,
+      },
     });
+
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([9, 10]);
-    prev = wrapper.find({ ref: 'prev-link' });
-    next = wrapper.find({ ref: 'next-link' });
+    const prev = wrapper.find({ ref: 'prev-link' });
+    const next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeFalsy();
   });
@@ -157,22 +152,22 @@ describe('CdrPagination.vue', () => {
     const wrapper = mount(CdrPagination, {
       propsData: {
         pages: makePages(20),
-        currentPage: 5,
+        value: 5,
       },
     });
     let next = wrapper.find({ ref: 'next-link' });
     let prev = wrapper.find({ ref: 'prev-link' });
-    
+
     // click next
     next.trigger('click');
     expect(wrapper.emitted().change[0][0]).toBe(6);
     expect(wrapper.emitted().change[0][1] instanceof Event).toBeTruthy();
-    
+
     // click previous
     prev.trigger('click');
     expect(wrapper.emitted().change[1][0]).toBe(4);
     expect(wrapper.emitted().change[1][1] instanceof Event).toBeTruthy();
-    
+
     // click a page link
     let link = wrapper.findAll('ul > li > a').at(1);
     link.trigger('click');
@@ -185,18 +180,18 @@ describe('CdrPagination.vue', () => {
     expect(wrapper.emitted()['select-change'][0][0]).toBe('?page=4');
     expect(wrapper.emitted()['select-change'][0][1] instanceof Event).toBeTruthy();
   });
-  
+
   it('adds "of x" when a total is provided', () => {
     const wrapper = shallowMount(CdrPagination, {
       propsData: {
         pages: makePages(20),
-        currentPage: 1,
+        value: 1,
       },
     });
 
     let option = wrapper.find({ ref: 'select' }).findAll('option').at(0);
     expect(option.text()).toBe('Page 1');
-    
+
     wrapper.setProps({ totalPages: 20 });
     option = wrapper.find({ ref: 'select' }).findAll('option').at(0);
     expect(option.text()).toBe('Page 1 of 20');

--- a/src/components/pagination/__tests__/CdrPagination.spec.js
+++ b/src/components/pagination/__tests__/CdrPagination.spec.js
@@ -53,21 +53,21 @@ describe('CdrPagination.vue', () => {
     expect(prev.exists()).toBeFalsy();
     expect(next.exists()).toBeTruthy();
 
-    wrapper.setData({ newValue: 4 })
+    wrapper.setProps({ value: 4 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5,'...',20]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
 
-    wrapper.setData({ newValue: 20 })
+    wrapper.setProps({ value: 20 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,'...',16,17,18,19,20]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeFalsy();
 
-    wrapper.setData({ newValue: 17 })
+    wrapper.setProps({ value: 17 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,'...',16,17,18,19,20]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
@@ -88,14 +88,14 @@ describe('CdrPagination.vue', () => {
     expect(prev.exists()).toBeFalsy();
     expect(next.exists()).toBeTruthy();
 
-    wrapper.setData({ newValue: 4 })
+    wrapper.setProps({ value: 4 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
 
-    wrapper.setData({ newValue: 5 })
+    wrapper.setProps({ value: 5 })
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5]);
     prev = wrapper.find({ ref: 'prev-link' });
     next = wrapper.find({ ref: 'next-link' });

--- a/src/components/pagination/examples/Pagination.vue
+++ b/src/components/pagination/examples/Pagination.vue
@@ -15,34 +15,38 @@
       :pages="makePages(20, 'router-page')"
       :total-pages="20"
       v-model="ex1Page"
-      @change="doChange"
+      @input="handleInput"
       @select-change="doSelect"
     />
+
+    <hr>
 
     <p>Previous/Next only (known total)</p>
 
     <cdr-pagination
-      :pages="makePages(ex2Pages, 'router-page-b', ex2Page - 2)"
+      :pages="makePages(ex2Pages, 'router-page-b', ex2PageKnown - 2)"
       :total-pages="10"
-      v-model="ex2Page"
-      @change="doChange"
+      v-model="ex2PageKnown"
+      @input="handleInput"
     />
 
+    <hr>
     <p>Previous/Next only (unknown total)</p>
 
     <cdr-pagination
-      :pages="makePages(ex2Pages, 'router-page-b', ex2Page - 2)"
-      v-model="ex2Page"
-      @change="doChange"
+      :pages="makePages(ex2Pages, 'router-page-b', ex2PageUnknown - 2)"
+      v-model="ex2PageUnknown"
+      @input="handleInput"
     />
 
+    <hr>
     <p>Only 5 pages provided</p>
 
     <cdr-pagination
       :pages="makePages(5, 'router-page-c')"
       :total-pages="5"
       v-model="ex3Page"
-      @change="doChange"
+      @input="handleInput"
     />
 
   </div>
@@ -62,7 +66,8 @@ export default {
     return {
       paginationData,
       ex1Page: 1,
-      ex2Page: 5,
+      ex2PageKnown: 5,
+      ex2PageUnknown: 5,
       ex3Page: 1,
     };
   },
@@ -87,7 +92,7 @@ export default {
       });
       return result;
     },
-    doChange(num, e) {
+    handleInput(num, e) {
       e.preventDefault();
       console.log('changed', num); // eslint-disable-line
       this.$router.replace({ query: Object.assign({}, this.$route.query, { 'router-page': num }) });

--- a/src/components/radio/CdrRadio.vue
+++ b/src/components/radio/CdrRadio.vue
@@ -91,7 +91,6 @@ export default {
        * @type value | event
        * */
       this.$emit('input', val);
-
     },
   },
   methods: {

--- a/src/components/radio/CdrRadio.vue
+++ b/src/components/radio/CdrRadio.vue
@@ -8,10 +8,10 @@
         :class="[$style['cdr-radio__input'], inputClass]"
         type="radio"
         v-bind="$attrs"
+        v-model="newValue"
         :name="name"
-        :checked="isChecked"
-        @change="onChange"
-        :value="value"
+        @change="updateValue(newValue, $event)"
+        :value="customValue"
         ref="radio"
       >
       <span :class="$style['cdr-radio__figure']" />
@@ -26,7 +26,6 @@
 <script>
 import modifier from 'mixinsdir/modifier';
 import space from 'mixinsdir/space';
-import isEqual from 'lodash/isEqual';
 
 /**
  * Cedar 2 component for radio
@@ -38,9 +37,10 @@ export default {
   name: 'CdrRadio',
   mixins: [modifier, space],
   inheritAttrs: false,
-  model: {
-    prop: 'modelValue',
-    event: 'change',
+  data() {
+    return {
+      newValue: this.value,
+    };
   },
   props: {
     /**
@@ -62,35 +62,46 @@ export default {
       type: String,
       required: true,
     },
+
     /**
      * Sets the value of the radio. Required.
     */
+    customValue: {
+      type: [String, Number, Boolean, Object, Array, Symbol, Function],
+    },
+
+    /** @ignore v-model binding */
     value: {
       type: [String, Number, Boolean, Object, Array, Symbol, Function],
-      required: true,
-    },
-    /** @ignore */
-    modelValue: {
-      type: [String, Number, Boolean, Object, Array, Symbol, Function],
-      required: false,
     },
   },
   computed: {
-    isChecked() {
-      return isEqual(this.modelValue, this.value);
-    },
     baseClass() {
       return 'cdr-radio';
     },
   },
+  watch: {
+    value(val) {
+      this.newValue = val;
+    },
+    newValue(val) {
+      /**
+       * `v-model` value. Fires on check/uncheck.
+       * @event input
+       * @type value | event
+       * */
+      this.$emit('input', val);
+    },
+  },
   methods: {
-    onChange() {
+    updateValue(newValue, e) {
     /**
      * Selected radio value. Fires on section.
      * @event change
      * @type boolean|array
      */
-      this.$emit('change', this.value);
+      this.newValue = newValue;
+      this.$emit('change', newValue, e);
     },
   },
 };

--- a/src/components/radio/CdrRadio.vue
+++ b/src/components/radio/CdrRadio.vue
@@ -37,11 +37,6 @@ export default {
   name: 'CdrRadio',
   mixins: [modifier, space],
   inheritAttrs: false,
-  data() {
-    return {
-      newValue: this.value,
-    };
-  },
   props: {
     /**
      * Class that is added to the label for custom styles
@@ -75,6 +70,11 @@ export default {
       type: [String, Number, Boolean, Object, Array, Symbol, Function],
     },
   },
+  data() {
+    return {
+      newValue: this.value,
+    };
+  },
   computed: {
     baseClass() {
       return 'cdr-radio';
@@ -91,6 +91,7 @@ export default {
        * @type value | event
        * */
       this.$emit('input', val);
+
     },
   },
   methods: {

--- a/src/components/radio/__tests__/CdrRadio.spec.js
+++ b/src/components/radio/__tests__/CdrRadio.spec.js
@@ -5,7 +5,7 @@ describe('CdrRadio.vue', () => {
   it('renders an input', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
       }
     });
@@ -15,7 +15,7 @@ describe('CdrRadio.vue', () => {
   it('is type radio', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
       }
     });
@@ -25,7 +25,7 @@ describe('CdrRadio.vue', () => {
   it('renders a label element', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
       }
     });
@@ -36,7 +36,7 @@ describe('CdrRadio.vue', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
         labelClass: 'custom-label-class',
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
       },
       slots: {
@@ -45,12 +45,12 @@ describe('CdrRadio.vue', () => {
     });
     expect(wrapper.vm.$refs.label.classList.contains('custom-label-class')).toBe(true);
   });
-  
+
   it('adds a custom input class correctly', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
         inputClass: 'custom-input-class',
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
       },
       slots: {
@@ -59,12 +59,12 @@ describe('CdrRadio.vue', () => {
     });
     expect(wrapper.vm.$refs.radio.classList.contains('custom-input-class')).toBe(true);
   });
-  
+
   it('adds a custom content class correctly', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
         contentClass: 'custom-content-class',
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
       },
       slots: {
@@ -77,7 +77,7 @@ describe('CdrRadio.vue', () => {
   it('sets name attribute correctly', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
       }
     });
@@ -87,79 +87,58 @@ describe('CdrRadio.vue', () => {
   it('evaluates simple not checked state correctly', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
-        modelValue: 'AA',
+        value: 'AA',
       },
     });
-    expect(wrapper.vm.isChecked).toBe(false);
+    expect(wrapper.vm.$refs.radio.checked).toBe(false);
   });
 
   it('evaluates simple checked state correctly', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
+        customValue: 'A',
+        name: 'testName',
         value: 'A',
-        name: 'testName',
-        modelValue: 'A',
       },
     });
-    expect(wrapper.vm.isChecked).toBe(true);
-  });
-
-  it('evaluates group not checked state correctly', () => {
-    const wrapper = shallowMount(CdrRadio, {
-      propsData: {
-        value: 'B',
-        name: 'testName',
-        modelValue: 'A',
-      },
-    });
-    expect(wrapper.vm.isChecked).toBe(false);
-  });
-
-  it('evaluates group checked state correctly', () => {
-    const wrapper = shallowMount(CdrRadio, {
-      propsData: {
-        value: 'A',
-        name: 'testName',
-        modelValue: 'A',
-      },
-    });
-    expect(wrapper.vm.isChecked).toBe(true);
+    expect(wrapper.vm.$refs.radio.checked).toBe(true);
   });
 
   it('evaluates complex group not checked state correctly', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
-        value: {test: 'B', arr: [1,2,3]},
+        customValue: {test: 'B', arr: [1,2,3]},
         name: 'testName',
-        modelValue: {test: 'B'},
+        value: {test: 'B'},
       },
     });
-    expect(wrapper.vm.isChecked).toBe(false);
+    expect(wrapper.vm.$refs.radio.checked).toBe(false);
   });
 
   it('evaluates complex group checked state correctly', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
-        value: {test: 'B', arr: [1,2,3]},
+        customValue: {test: 'B', arr: [1,2,3]},
         name: 'testName',
-        modelValue: {test: 'B', arr: [1,2,3]},
+        value: {test: 'B', arr: [1,2,3]},
       },
     });
-    expect(wrapper.vm.isChecked).toBe(true);
+    expect(wrapper.vm.$refs.radio.checked).toBe(true);
   });
 
   it('emits a change event with correct value', () => {
     const wrapper = shallowMount(CdrRadio, {
       propsData: {
-        value: 'A',
+        customValue: 'A',
         name: 'testName',
-        modelValue: '',
+        value: '',
       },
     });
-    wrapper.setProps({ value: 'B' });
-    wrapper.vm.onChange();
-    expect(wrapper.emitted().change[0][0]).toBe('B');
+
+    const rb = wrapper.find({ ref: 'radio'});
+    rb.trigger('click')
+    expect(wrapper.emitted().change[0][0]).toBe('A');
   });
 });

--- a/src/components/radio/examples/Radios.vue
+++ b/src/components/radio/examples/Radios.vue
@@ -9,53 +9,56 @@
     <cdr-radio
       id="test1"
       name="example"
-      value="a1"
+      custom-value="a1"
       v-model="ex1"
       data-backstop="radio-focus"
     >A1</cdr-radio>
     <cdr-radio
       name="example"
-      value="a2"
+      custom-value="a2"
       v-model="ex1"
     >A2</cdr-radio>
     <cdr-radio
       name="example"
-      :value="{val:'a3'}"
+      :custom-value="{val:'a3'}"
       v-model="ex1"
     >A3</cdr-radio>
     <cdr-radio
       name="example"
-      value="a4"
+      custom-value="a4"
       v-model="ex1"
       disabled
     >A4 (disabled)</cdr-radio>
     <cdr-text>Group A Picked: {{ ex1 }}</cdr-text>
-
+    <hr>
     <cdr-radio
       modifier="compact"
       name="examplecompact"
-      value="a1"
+      custom-value="a1"
       v-model="ex1compact"
     >A1 compact</cdr-radio>
     <cdr-radio
       modifier="compact"
       name="examplecompact"
-      value="a2"
+      custom-value="a2"
       v-model="ex1compact"
     >A2 compact</cdr-radio>
     <cdr-radio
       modifier="compact"
       name="examplecompact"
-      :value="{val:'a3'}"
+      :custom-value="{val:'a3'}"
       v-model="ex1compact"
     >A3 compact</cdr-radio>
     <cdr-radio
       modifier="compact"
       name="examplecompact"
-      value="a4"
+      custom-value="a4"
       v-model="ex1compact"
       disabled
     >A4 compact (disabled)</cdr-radio>
+
+    <cdr-text>Group A compact Picked: {{ ex1compact }}</cdr-text>
+    <hr>
 
     <cdr-text>
       Radios with spacing
@@ -63,57 +66,56 @@
     <cdr-radio
       space="cdr-ml-space-one-x cdr-mt-space-half-x"
       id="test2"
-      name="example"
-      value="a1"
-      v-model="ex1"
+      name="examplespacing"
+      custom-value="a1"
+      v-model="ex1spacing"
       data-backstop="radio-focus"
     >A1</cdr-radio>
     <cdr-radio
       space="cdr-ml-space-one-x cdr-mt-space-half-x"
-      name="example"
-      value="a2"
-      v-model="ex1"
+      name="examplespacing"
+      custom-value="a2"
+      v-model="ex1spacing"
     >A2</cdr-radio>
     <cdr-radio
       space="cdr-ml-space-one-x cdr-mt-space-half-x"
-      name="example"
-      :value="{val:'a3'}"
-      v-model="ex1"
+      name="examplespacing"
+      :custom-value="{val:'a3'}"
+      v-model="ex1spacing"
     >A3</cdr-radio>
-
-    <cdr-text>Group A compact Picked: {{ ex1compact }}</cdr-text>
-
+    <cdr-text>Spacing Picked: {{ ex1spacing }}</cdr-text>
+    <hr>
     <div style="max-width: 200px;">
       <cdr-radio
         name="example2"
-        value="b1"
+        custom-value="b1"
         v-model="ex2"
       >B1</cdr-radio>
       <cdr-radio
         name="example2"
-        value="b2"
+        custom-value="b2"
         v-model="ex2"
       >B2</cdr-radio>
       <cdr-text>Group B Picked: {{ ex2 }}</cdr-text>
     </div>
-
+    <hr>
     <cdr-radio
       modifier="compact"
       name="example2compact"
-      value="b1"
+      custom-value="b1"
       v-model="ex2compact"
     >B1 compact</cdr-radio>
     <cdr-radio
       modifier="compact"
       name="example2compact"
-      value="b2"
+      custom-value="b2"
       v-model="ex2compact"
     >B2 compact</cdr-radio>
     <cdr-text>Group B compact Picked: {{ ex2compact }}</cdr-text>
-
+    <hr>
     <cdr-radio
       name="example3"
-      value="c1"
+      custom-value="c1"
       v-model="ex3"
       disabled
     >C1 (selected + disabled)</cdr-radio>
@@ -121,31 +123,31 @@
     <cdr-radio
       modifier="compact"
       name="example3compact"
-      value="c1"
+      custom-value="c1"
       v-model="ex3compact"
       disabled
     >C1 compact (selected + disabled)</cdr-radio>
 
     <cdr-radio
       name="custom"
-      value="customA"
+      custom-value="customA"
       v-model="custom"
       modifier="hide-figure"
     >Custom A (hide-figure)</cdr-radio>
 
     <cdr-radio
       name="custom"
-      value="customB"
+      custom-value="customB"
       v-model="custom"
       modifier="hide-figure"
       input-class="no-box"
       content-class="no-box__content"
     >Custom B</cdr-radio>
-
+    <hr>
     <div class="wrap">
       <cdr-radio
         name="example3"
-        value="c2"
+        custom-value="c2"
         v-model="ex3"
       >A longer label text to make things wrap for testing
       </cdr-radio>
@@ -163,6 +165,7 @@ export default {
     return {
       ex1: '',
       ex1compact: '',
+      ex1spacing: '',
       ex2: 'b2',
       ex2compact: 'b2',
       ex3: 'c1',

--- a/src/components/select/CdrSelect.vue
+++ b/src/components/select/CdrSelect.vue
@@ -15,7 +15,7 @@
       :size="size"
       @change="onChange"
       ref="select"
-      v-model="val"
+      v-model="newValue"
       :required="required"
       :multiple="multiple"
       :aria-label="hideLabel ? label : null"
@@ -49,10 +49,6 @@ import toArray from 'lodash/toArray';
 export default {
   name: 'CdrSelect',
   inheritAttrs: false,
-  model: {
-    prop: 'extVal',
-    event: 'change',
-  },
   props: {
     /**
      * Label text.
@@ -80,7 +76,7 @@ export default {
       type: Array,
     },
     /** @ignore */
-    extVal: {
+    value: {
       type: [String, Number, Boolean, Object, Array, Symbol, Function],
       required: false,
     },
@@ -93,7 +89,7 @@ export default {
   },
   data() {
     return {
-      val: this.extVal,
+      newValue: this.value,
     };
   },
   computed: {
@@ -137,9 +133,9 @@ export default {
     },
   },
   watch: {
-    extVal() {
+    value() {
       if (!this.multiple) {
-        this.val = this.extVal;
+        this.newValue = this.value;
       }
     },
   },
@@ -149,7 +145,7 @@ export default {
       const opts = toArray(this.$refs.select.options);
       opts.forEach((opt) => {
         const o = opt;
-        if (this.val.indexOf(o.value) !== -1) {
+        if (this.newValue.indexOf(o.value) !== -1) {
           o.selected = true;
         }
       });
@@ -165,11 +161,13 @@ export default {
       if (this.multiple) {
         const optArr = toArray(e.target.options);
         const selected = optArr.filter(o => o.selected === true).map(o => o.value);
-        this.val = selected;
+        this.newValue = selected;
         this.$emit('change', selected, e);
+        this.$emit('input', selected, e);
       } else {
-        this.val = e.target.value;
+        this.newValue = e.target.value;
         this.$emit('change', e.target.value, e);
+        this.$emit('input', e.target.value, e);
       }
     },
   },

--- a/src/components/select/__tests__/CdrSelect.spec.js
+++ b/src/components/select/__tests__/CdrSelect.spec.js
@@ -112,7 +112,7 @@ describe('cdrSelect.vue', () => {
       propsData: {
         label: 'Label Test',
         multiple: true,
-        extVal: [],
+        value: [],
       },
     });
     expect(wrapper.vm.$refs.select.hasAttribute('multiple')).toBe(true);
@@ -122,12 +122,12 @@ describe('cdrSelect.vue', () => {
     const wrapper = shallowMount(CdrSelect, {
       propsData: {
         label: 'test',
-        extVal: '2',
+        value: '2',
         options: ['1', '2'],
       },
     });
     const select = wrapper.find({ ref: 'select'});
-    wrapper.setProps({ extVal: '1' });
+    wrapper.setProps({ value: '1' });
     select.trigger('change');
     expect(wrapper.emitted().change[0][0]).toBe('1');
   });
@@ -137,7 +137,7 @@ describe('cdrSelect.vue', () => {
       propsData: {
         label: 'test',
         multiple: true,
-        extVal: ['1', '2'],
+        value: ['1', '2'],
         options: [{
           value: '1',
           text: 'one',
@@ -152,8 +152,8 @@ describe('cdrSelect.vue', () => {
         }],
       },
     });
-    wrapper.setProps({ extVal: ['1', '3'] });
-    const propValues = wrapper.vm.extVal;
+    wrapper.setProps({ value: ['1', '3'] });
+    const propValues = wrapper.vm.value;
     for(let o of wrapper.vm.$refs.select.options) {
       propValues.indexOf(o.value) >= 0 ? o.selected = true : o.selected = false;
     }

--- a/src/mixins/buttonBase.js
+++ b/src/mixins/buttonBase.js
@@ -21,13 +21,6 @@ export default {
       validator: value => (['button', 'submit', 'reset'].indexOf(value) >= 0) || false,
     },
     /**
-     * Adds custom click actions.
-     */
-    onClick: {
-      type: Function,
-      default: () => () => null,
-    },
-    /**
      * Sets width to be 100%.
     */
     fullWidth: {

--- a/src/router.js
+++ b/src/router.js
@@ -31,6 +31,7 @@ import Utilities from 'componentsdir/Utilities/Utilities';
 
 const routes = [
   { path: '/', component: App },
+  { path: '/kitchen-sink', name: 'KitchenSink', component: KitchenSink },
   { path: '/accordion', name: 'Accordion', component: Accordions },
   { path: '/breadcrumbs', name: 'Breadcrumb', component: Breadcrumb },
   { path: '/buttons', name: 'Buttons', component: Buttons },
@@ -42,10 +43,9 @@ const routes = [
   { path: '/grids', name: 'Grids', component: Grids },
   { path: '/icons', name: 'Icons', component: Icons },
   { path: '/images', name: 'Images', component: Images },
-  { path: '/kitchen-sink', name: 'KitchenSink', component: KitchenSink },
+  { path: '/inputs', name: 'Input', component: Input },
   { path: '/links', name: 'Links', component: Links },
   { path: '/lists', name: 'Lists', component: Lists },
-  { path: '/inputs', name: 'Input', component: Input },
   { path: '/pagination', name: 'Pagination', component: Pagination },
   { path: '/quotes', name: 'Quotes', component: Quotes },
   { path: '/radios', name: 'Radios', component: Radios },


### PR DESCRIPTION
- updating anything that has a v-model to make it:
--  use `value` as the v-model attr
--  emit an `input` event when that value changes
- using the $listeners pattern wherever possible to replace previously hardcoded bindings

radio, pagination, and select were the only components that deviated from the standard v-model pattern. all three will have simple breaking changes for JSX users (they'll just need to rename the prop they bound to.) Aliasing props does not seem to be a thing in Vue, so not sure there is a good way to gracefully deprecate those without possibly causing a bigger mess.

docs updates: https://github.com/rei/rei-cedar-docs/pull/390