### PR TITLE
fix(img): make alt default to empty string

### DIFF
--- a/src/components/image/CdrImg.vue
+++ b/src/components/image/CdrImg.vue
@@ -51,7 +51,7 @@ export default {
      */
     alt: {
       type: String,
-      default: ' ',
+      default: '',
     },
     /**
      * Enable lazy loading.


### PR DESCRIPTION
this was pointed out in user-support and was a 1 character change so 🚀 🎸 🎉 

https://www.w3.org/WAI/tutorials/images/tips/

"If you use a null (empty) text alternative (alt="") to hide decorative images, make sure that there is no space character in between the quotes. If a space character is present, the image may not be effectively hidden from assistive technologies. For instance, some screen readers will still announce the presence of an image if a space character is put between the quotes."

