### PR TITLE
fix(dev): inline CSS for dev build

### DIFF
--- a/build/rollup-plugins.js
+++ b/build/rollup-plugins.js
@@ -51,9 +51,7 @@ const plugins = [
     extensions: ['.mjs', '.js', '.jsx', '.json'],
   }),
   env !== 'prod' &&  vue({
-    css: false,
     style: {
-      // postcssCleanOptions: { disabled: true },
       postcssModulesOptions: {
         generateScopedName(name, filename, css) {
           // to preseve '@' in responsive class names


### PR DESCRIPTION
this loads anything in the .vue example <style> blocks in the dev server.

previously we were running rollup-plugin-vue on everything in the dev env (examples and components), which meant cedar.css would end up containing these styles. Since that is now separate, we must include those manually.