### PR TITLE
fix(cta, button, link): properly handle firefox outline color

### DIFF
--- a/src/components/button/styles/vars/CdrButton.vars.scss
+++ b/src/components/button/styles/vars/CdrButton.vars.scss
@@ -39,6 +39,7 @@ $cdr-button-primary-fill-focus: #ffffff;
 $cdr-button-primary-color-focus: #ffffff;
 $cdr-button-primary-box-shadow-focus: inset 0 0 0 1px #2b6692;
 $cdr-button-base-outline-focus: $default-outline;
+$cdr-button-base-outline-color-focus: -webkit-focus-ring-color;
 $cdr-button-base-outline-offset-focus: 0;
 $cdr-button-base-text-decoration-focus: none;
 
@@ -170,6 +171,7 @@ $cdr-button-icon-only-fill-darkmode: $cdr-color-icon-emphasis-darkmode;
 
   &:focus {
     outline: $cdr-button-base-outline-focus;
+    outline-color: $cdr-button-base-outline-color-focus;
     outline-offset: $cdr-button-base-outline-offset-focus;
     text-decoration: $cdr-button-base-text-decoration-focus;
   }

--- a/src/components/cta/styles/vars/CdrCta.vars.scss
+++ b/src/components/cta/styles/vars/CdrCta.vars.scss
@@ -16,6 +16,7 @@ $cdr-cta-base-text-decoration-hover: none;
 $cdr-cta-base-text-decoration-active: none;
 $cdr-cta-base-text-decoration-focus: none;
 $cdr-cta-base-outline-focus: $default-outline;
+$cdr-cta-base-outline-color-focus: -webkit-focus-ring-color;
 $cdr-cta-base-outline-offset-focus: 0;
 
 @mixin cdr-cta-base-mixin() {
@@ -43,6 +44,7 @@ $cdr-cta-base-outline-offset-focus: 0;
   &:focus {
     text-decoration: $cdr-cta-base-text-decoration-focus;
     outline: $cdr-cta-base-outline-focus;
+    outline-color: $cdr-cta-base-outline-color-focus;
     outline-offset: $cdr-cta-base-outline-offset-focus;
   }
 }

--- a/src/components/link/styles/vars/CdrLink.vars.scss
+++ b/src/components/link/styles/vars/CdrLink.vars.scss
@@ -24,6 +24,7 @@ $cdr-link-base-text-decoration-active: underline;
 
 $cdr-link-base-color-focus: $cdr-color-text-link-lightmode;
 $cdr-link-base-outline-focus: $default-outline;
+$cdr-link-base-outline-color-focus: -webkit-focus-ring-color;
 $cdr-link-base-outline-offset-focus: 0;
 $cdr-link-base-text-decoration-focus: underline;
 
@@ -80,6 +81,7 @@ $cdr-link-base-fill-darkmode: $cdr-color-text-link-darkmode;
   &:focus {
     color: $cdr-link-base-color-focus;
     outline: $cdr-link-base-outline-focus;
+    outline-color: $cdr-link-base-outline-color-focus;
     outline-offset: $cdr-link-base-outline-offset-focus;
     text-decoration: $cdr-link-base-text-decoration-focus;
   }

--- a/src/css/settings/_options.vars.scss
+++ b/src/css/settings/_options.vars.scss
@@ -326,4 +326,4 @@
 /* ---------------------
 * Outline
 * ------------------- */
-$default-outline: 0.2rem auto -webkit-focus-ring-color;
+$default-outline: 0.2rem solid Highlight;


### PR DESCRIPTION
firefox gets Highlight, everything webkit gets webkit-focus-color.
FF doesn't know what `webkit-focus-color` is, so it just ignores that declaration.

ie11 interprets `outline-style: auto` as `outline-style: none`. `auto` seems to turn into `solid` in chrome and FF anyways so doesn't change much 😹 