### PR TITLE
refactor(variables): remove text from component variables export

### DIFF
--- a/build/component-variables-transfer.js
+++ b/build/component-variables-transfer.js
@@ -12,7 +12,6 @@ const SUPPORTED_COMPONENTS = [
   /* component vars */
   'CdrButton.vars.scss',
   'CdrLink.vars.scss',
-  'text.vars.scss',
   'form-label.vars.scss',
   'CdrInput.vars.scss',
   'CdrSelect.vars.scss',
@@ -50,4 +49,3 @@ console.log('updating component-variables peerDependencies', { cedarVersion, tok
 variablesPackageJson.peerDependencies['@rei/cdr-tokens'] = tokenVersion;
 variablesPackageJson.peerDependencies['@rei/cedar'] = cedarVersion;
 fs.outputFileSync('../../rei-cedar-component-variables/package.json', JSON.stringify(variablesPackageJson));
-


### PR DESCRIPTION
consumers should use tokens or utilities for typography instead.

with the typography/utilities updates it doesn't make sense to have component variables for typography (it didn't really make sense before either...but i didn't understand cedar back then 😆 )