### PR TITLE
fix(tests): point integration tests at kitchen sink

### DIFF
--- a/src/components/button/examples/demo/Icons.vue
+++ b/src/components/button/examples/demo/Icons.vue
@@ -14,7 +14,8 @@
         space="cdr-mb-space-one-x@xs cdr-mb-space-one-x@sm cdr-mr-space-one-x"
         data-backstop="cdr-button--icon"
       >
-        <icon-check-lg
+        <cdr-icon
+          use="#check-lg"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -26,7 +27,8 @@
         size="medium"
         space="cdr-mb-space-one-x@xs cdr-mb-space-one-x@sm cdr-mr-space-one-x"
       >
-        <icon-check-lg
+        <cdr-icon
+          use="#check-lg"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -37,7 +39,8 @@
         size="small"
         space="cdr-mr-space-one-x"
       >
-        <icon-check-lg
+        <cdr-icon
+          use="#check-lg"
           inherit-color
           slot="icon"
           size="small"
@@ -48,7 +51,8 @@
       <cdr-button
         size="small"
       >
-        <icon-check-sm
+        <cdr-icon
+          use="#check-sm"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -120,7 +124,8 @@
       <cdr-button
         size="large large@xs medium@sm small@lg"
       >
-        <icon-clock
+        <cdr-icon
+          use="#clock"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -133,7 +138,8 @@
         size="large"
         :full-width="true"
       >
-        <icon-clock
+        <cdr-icon
+          use="#clock"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -174,7 +180,8 @@
         size="small"
         aria-label="Check our Twitter feed"
       >
-        <icon-twitter
+        <cdr-icon
+          use="#twitter"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -184,7 +191,8 @@
         icon-only
         aria-label="Close"
       >
-        <icon-x-lg
+        <cdr-icon
+          use="#x-lg"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -196,7 +204,8 @@
         :icon-only="true"
         aria-label="This link goes elsewhere"
       >
-        <icon-external-link
+        <cdr-icon
+          use="#external-link"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -206,7 +215,8 @@
         :icon-only="true"
         aria-label="Play"
       >
-        <icon-play
+        <cdr-icon
+          use="#play"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -219,7 +229,8 @@
         :on-dark="true"
         aria-label="A Twitter button"
       >
-        <icon-twitter
+        <cdr-icon
+          use="#twitter"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -230,7 +241,8 @@
         on-dark
         aria-label="Close"
       >
-        <icon-x-lg
+        <cdr-icon
+          use="#x-lg"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -243,7 +255,8 @@
         :on-dark="true"
         aria-label="An external link"
       >
-        <icon-external-link
+        <cdr-icon
+          use="#external-link"
           inherit-color
           slot="icon"
           class="cdr-button__icon"
@@ -254,7 +267,8 @@
         on-dark
         aria-label="Play"
       >
-        <icon-play
+        <cdr-icon
+          use="#play"
           inherit-color
           slot="icon"
           class="cdr-button__icon"

--- a/src/components/button/examples/demo/Icons.vue
+++ b/src/components/button/examples/demo/Icons.vue
@@ -23,22 +23,6 @@
       </cdr-button>
 
       <cdr-button
-        tag="a"
-        href="https://rei.com"
-        size="large"
-        space="cdr-mb-space-one-x@xs cdr-mb-space-one-x@sm cdr-mr-space-one-x"
-        data-backstop="cdr-button--icon"
-        disabled
-      >
-        <icon-check-lg
-          inherit-color
-          slot="icon"
-          class="cdr-button__icon"
-        />
-        Anchor and Icon
-      </cdr-button>
-
-      <cdr-button
         size="medium"
         space="cdr-mb-space-one-x@xs cdr-mb-space-one-x@sm cdr-mr-space-one-x"
       >

--- a/src/components/icon/examples/Icons.vue
+++ b/src/components/icon/examples/Icons.vue
@@ -16,7 +16,8 @@
     >
       Default icon size
     </cdr-text>
-    <icon-account-profile
+    <cdr-icon
+      use="#account-profile"
       data-backstop="cdr-icon-hover"
       class="icon-hover"
     />
@@ -36,12 +37,8 @@
       >
         <div>
           <div class="cdr-text-center">
-            <svg :is="key" />
-            <cdr-text>{{ key }}</cdr-text>
-          </div>
-          <div class="cdr-text-center">
             <cdr-icon :use="`#${getSpriteId(key)}`" />
-            <cdr-text>using sprite</cdr-text>
+            <cdr-text>{{getSpriteId(key)}}</cdr-text>
           </div>
         </div>
       </cdr-col>

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -84,12 +84,14 @@
         </cdr-link>
       </template>
       <template slot="pre-icon">
-        <icon-twitter
+        <cdr-icon
+          use="#twitter"
           inherit-color
         />
       </template>
       <template slot="post-icon">
-        <icon-check-lg
+        <cdr-icon
+          use="#check-lg"
           inherit-color
         />
       </template>

--- a/test/e2e/nightwatch.conf.js
+++ b/test/e2e/nightwatch.conf.js
@@ -21,7 +21,7 @@ module.exports = {
     default: {
       silent: true,
       globals: {
-        devServerURL: `http://localhost:${process.env.PORT}` || 3000,
+        devServerURL: `http://localhost:${process.env.PORT}/#/kitchen-sink`,
       },
     },
 

--- a/test/e2e/specs/a11y.js
+++ b/test/e2e/specs/a11y.js
@@ -28,9 +28,9 @@ module.exports = {
 
     browser
       .url(devServer)
-      .waitForElementVisible('#app', 10000)
+      .waitForElementVisible('#kitchen-sink', 10000)
       .axeInject()
-      .axeRun('#app', {
+      .axeRun('#kitchen-sink', {
         reporter: 'v2',
         runOnly: {
           type: 'tag',

--- a/test/e2e/specs/test.js
+++ b/test/e2e/specs/test.js
@@ -10,7 +10,7 @@ module.exports = {
 
     browser
       .url(devServer)
-      .waitForElementVisible('#app', 10000)
+      .waitForElementVisible('#kitchen-sink', 10000)
       .end();
   },
 };


### PR DESCRIPTION
also removes 1 example for a disabled button with tag="a", as a "disabled link" doesn't make sense and breaks the a11y check due to insufficient color contrast (whereas a disabled button is fine with that level of contrast because it is not interactive)

aaaaalso deletes the single icon components from kitchen sink and replaces them with sprite references