### PR TITLE
fix(tests): temporary fix for chromedriver in CI environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ addons:
   chrome: stable
 dist: xenial
 before_install:
-- if [ "$TRAVIS_OS_NAME" == "linux" ]; then export CHROME_BIN=/usr/bin/google-chrome;
-  fi
-- if [ "$TRAVIS_OS_NAME" == "linux" ]; then export DISPLAY=:99.0; fi
-- if [ "$TRAVIS_OS_NAME" == "linux" ]; then sh -e /etc/init.d/xvfb start; fi
+- if [ "$TRAVIS_OS_NAME" == "linux" ]; then export CHROME_BIN=/usr/bin/google-chrome; fi
+# Not needed since not running backstop visual regressions
+# - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export DISPLAY=:99.0; fi
+# - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sh -e /etc/init.d/xvfb start; fi
 - npm i -g npm
 install:
 - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 sudo: required
 addons:
   chrome: stable
-dist: trusty
+dist: xenial
 before_install:
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export CHROME_BIN=/usr/bin/google-chrome;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ dist: xenial
 services:
   - xvfb
 before_install:
-# - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export CHROME_BIN=/usr/bin/google-chrome; fi
-# Not needed since not running backstop visual regressions
-# - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export DISPLAY=:99.0; fi
-# - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sh -e /etc/init.d/xvfb start; fi
 - npm i -g npm
 install:
 - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ sudo: required
 addons:
   chrome: stable
 dist: xenial
+services:
+  - xvfb
 before_install:
-- if [ "$TRAVIS_OS_NAME" == "linux" ]; then export CHROME_BIN=/usr/bin/google-chrome; fi
+# - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export CHROME_BIN=/usr/bin/google-chrome; fi
 # Not needed since not running backstop visual regressions
 # - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export DISPLAY=:99.0; fi
 # - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sh -e /etc/init.d/xvfb start; fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -3152,9 +3152,8 @@
       }
     },
     "chromedriver": {
-      "version": "76.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-76.0.0.tgz",
-      "integrity": "sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==",
+      "version": "github:dmlemeshko/node-chromedriver#d7b2cb44ea507841dfa41adfdeb622cebce0f7cb",
+      "from": "github:dmlemeshko/node-chromedriver#bump-chromedriver-to-77.0.3865.40",
       "dev": true,
       "requires": {
         "del": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "backstopjs": "^3.8.8",
     "chalk": "^2.4.2",
     "chokidar": "^2.1.6",
-    "chromedriver": "^76.0.0",
+    "chromedriver": "dmlemeshko/node-chromedriver#bump-chromedriver-to-77.0.3865.40",
     "concat": "^1.0.3",
     "cross-env": "^5.2.0",
     "cross-spawn": "^6.0.4",


### PR DESCRIPTION
this will allow us to unblock the CI check. if 77 isn't out before we want to release then we can rollback to 76, doesn't matter much since this is just a devDep.

https://github.com/giggio/node-chromedriver/pull/227 the branch/PR is just 2 version bumps so LGTM