### PR TITLE
fix input slots, update table header

### DIFF
--- a/jsx.md
+++ b/jsx.md
@@ -1,7 +1,7 @@
 JSX & Cedar
 ------------
 
-Cedar component templates are currently written in JSX to allow us to export a tree-shakeable ES module build. There is currently a lack of support for building `.vue` single file components as ES modules (see https://github.com/rollup/rollup/issues/2497 and https://github.com/vuejs/vue-component-compiler/issues/80 and https://github.com/vuejs/vue-loader/issues/1234). 
+Cedar component templates are currently written in JSX to allow us to export a tree-shakeable ES module build. There is currently a lack of support for building `.vue` single file components as ES modules (see https://github.com/rollup/rollup/issues/2497 and https://github.com/vuejs/vue-component-compiler/issues/80 and https://github.com/vuejs/vue-loader/issues/1234).
 
 ## JSX Tips
 
@@ -38,6 +38,9 @@ render slots:
 {this.$slots.default} // default slot
 
 {this.$slots.foobar} // named slot
+
+// Named slots should not be rendered via computed properties,
+// as the child component does not know when the parent updates.
 ```
 
 conditionally render element:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.7",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/dataTable/examples/demo/AllHeaders.vue
+++ b/src/components/dataTable/examples/demo/AllHeaders.vue
@@ -55,7 +55,9 @@ export default {
   name: 'AllHeaders',
   components: Components,
   data() {
-    return tableData;
+    return {
+      tableData
+    };
   },
 };
 </script>

--- a/src/components/dataTable/examples/demo/AllHeaders.vue
+++ b/src/components/dataTable/examples/demo/AllHeaders.vue
@@ -56,7 +56,7 @@ export default {
   components: Components,
   data() {
     return {
-      tableData
+      tableData,
     };
   },
 };

--- a/src/components/dataTable/examples/demo/ContentResilience.vue
+++ b/src/components/dataTable/examples/demo/ContentResilience.vue
@@ -54,7 +54,7 @@ export default {
   name: 'ContentResilience',
   components: Components,
   data() {
-    return tableData;
+    return { tableData };
   },
 };
 </script>

--- a/src/components/dataTable/examples/demo/NoColHeaders.vue
+++ b/src/components/dataTable/examples/demo/NoColHeaders.vue
@@ -40,7 +40,7 @@ export default {
   name: 'NoColHeaders',
   components: Components,
   data() {
-    return tableData;
+    return { tableData };
   },
 };
 </script>

--- a/src/components/dataTable/examples/demo/NoHeaders.vue
+++ b/src/components/dataTable/examples/demo/NoHeaders.vue
@@ -34,7 +34,7 @@ export default {
   name: 'NoHeaders',
   components: Components,
   data() {
-    return tableData;
+    return { tableData };
   },
 };
 </script>

--- a/src/components/dataTable/examples/demo/Variants.vue
+++ b/src/components/dataTable/examples/demo/Variants.vue
@@ -51,7 +51,7 @@ export default {
   name: 'Variants',
   components: Components,
   data() {
-    return tableData;
+    return { tableData };
   },
 };
 </script>

--- a/src/components/dataTable/styles/CdrDataTable.scss
+++ b/src/components/dataTable/styles/CdrDataTable.scss
@@ -17,8 +17,7 @@
   position: relative;
 
   &__caption {
-    // TODO: typography token
-    @include spruce-display-20();
+    @include cdr-text-heading-400();
 
     color: $cdr-color-text-primary-lightmode;
   }

--- a/src/components/icon/examples/Icons.vue
+++ b/src/components/icon/examples/Icons.vue
@@ -38,7 +38,7 @@
         <div>
           <div class="cdr-text-center">
             <cdr-icon :use="`#${getSpriteId(key)}`" />
-            <cdr-text>{{getSpriteId(key)}}</cdr-text>
+            <cdr-text>{{ getSpriteId(key) }}</cdr-text>
           </div>
         </div>
       </cdr-col>

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -119,42 +119,6 @@ export default {
         </label>
       ) : '';
     },
-    infoEl() {
-      return this.$slots.info ? (
-        <span
-          class={this.style['cdr-input__info-container']}
-        >
-          {this.$slots.info}
-        </span>
-      ) : '';
-    },
-    preIconEl() {
-      return this.$slots['pre-icon'] ? (
-        <span
-          class={this.style['cdr-input__pre-icon']}
-        >
-          {this.$slots['pre-icon']}
-        </span>
-      ) : '';
-    },
-    postIconEl() {
-      return this.$slots['post-icon'] ? (
-        <span
-          class={this.style['cdr-input__post-icon']}
-        >
-          {this.$slots['post-icon']}
-        </span>
-      ) : '';
-    },
-    helperEl() {
-      return this.$slots['helper-text'] ? (
-        <span
-          class={this.style['cdr-input__helper-text']}
-        >
-          {this.$slots['helper-text']}
-        </span>
-      ) : '';
-    },
     inputEl() {
       if (this.rows && this.rows > 1) {
         return (
@@ -190,13 +154,37 @@ export default {
     return (
       <div class={this.style['cdr-input-container']}>
         {this.labelEl}
-        {this.infoEl}
+        {this.$slots.info && (
+          <span
+            class={this.style['cdr-input__info-container']}
+          >
+            {this.$slots.info}
+          </span>
+        )}
         <div class={this.inputWrapClass}>
           {this.inputEl}
-          {this.preIconEl}
-          {this.postIconEl}
+          {this.$slots['pre-icon'] && (
+            <span
+              class={this.style['cdr-input__pre-icon']}
+            >
+              {this.$slots['pre-icon']}
+            </span>
+          )}
+          {this.$slots['post-icon'] && (
+            <span
+              class={this.style['cdr-input__post-icon']}
+            >
+              {this.$slots['post-icon']}
+            </span>
+          )}
         </div>
-        {this.helperEl}
+        {this.$slots['helper-text'] && (
+          <span
+            class={this.style['cdr-input__helper-text']}
+          >
+            {this.$slots['helper-text']}
+          </span>
+        )}
       </div>
     );
   },

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -272,6 +272,54 @@ describe('CdrInput.vue', () => {
     expect(spy.called).toBeTruthy();
   });
 
+  it('renders helper-text slot', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      slots: {
+        'helper-text': 'very helpful',
+      },
+    });
+    expect(wrapper.find('.cdr-input__helper-text').text()).toBe('very helpful');
+  });
+
+  it('renders info slot', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      slots: {
+        info: 'very informative',
+      },
+    });
+    expect(wrapper.find('.cdr-input__info-container').text()).toBe('very informative');
+  });
+
+  it('renders pre-icon slot', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      slots: {
+        'pre-icon': '🤠',
+      },
+    });
+    expect(wrapper.find('.cdr-input__pre-icon').text()).toBe('🤠');
+  });
+
+  it('renders post-icon slot', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      slots: {
+        'post-icon': '😎',
+      },
+    });
+    expect(wrapper.find('.cdr-input__post-icon').text()).toBe('😎');
+  });
+
   // NOTE - can't use v-model directly here, targeting the `data` prop instead
   it('updating v-model data updates the input', () => {
     const wrapper = shallowMount(CdrInput, {

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -96,7 +96,7 @@
         />
       </template>
       <template slot="helper-text">
-        This is helper text. Input length: {{requiredWithIcons.length}}
+        This is helper text. Input length: {{ requiredWithIcons.length }}
       </template>
     </cdr-input>
     <cdr-input

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -96,7 +96,7 @@
         />
       </template>
       <template slot="helper-text">
-        This is helper text.
+        This is helper text. Input length: {{requiredWithIcons.length}}
       </template>
     </cdr-input>
     <cdr-input

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -138,9 +138,10 @@ $cdr-input-height-large: 48px;
 
 /* required label */
 $cdr-input-required-label-color: $cdr-color-text-secondary-lightmode;
-
+$cdr-input-required-label-ml: $cdr-space-inset-quarter-x;
 @mixin cdr-input-required-label-mixin() {
   color: $cdr-input-required-label-color;
+  margin-left: $cdr-input-required-label-ml
 }
 
 /* info link */


### PR DESCRIPTION
also adds some basic tests for the slots (couldn't figure out how to test the reactivity bit)
and fixes all the data-table examples 😬 

named slots have access to the parent scope, not the child scope.
computed properties are in the child scope.
thus, the input slots weren't updating because computed properties only update
when smth in their scope changes 🙃 