### PR TITLE
fix(rating): make rating handle string and number input the same

### DIFF
--- a/src/components/rating/CdrRating.jsx
+++ b/src/components/rating/CdrRating.jsx
@@ -121,28 +121,26 @@ export default {
           ))}
           {this.remainderEl }
         </div>
-        {this.count
-          && <span
-            aria-hidden="true"
-            class={this.style['cdr-rating__count']}
-          >
-            {this.href
-              && <span class={this.style['cdr-rating__number']}>
-                { this.rounded }
-              </span>
-            }
-
-            <span>
-              { this.formattedCount }
+        <span
+          aria-hidden="true"
+          class={this.style['cdr-rating__count']}
+        >
+          {this.href
+            && <span class={this.style['cdr-rating__number']}>
+              { this.rounded }
             </span>
+          }
 
-            {!this.compact
-              && <span>
-                &nbsp;Reviews
-              </span>
-            }
+          <span>
+            { this.formattedCount }
           </span>
-        }
+
+          {!this.compact
+            && <span>
+              &nbsp;Reviews
+            </span>
+          }
+        </span>
 
         <span class="cdr-display-sr-only">
           rated { this.rounded } out of 5 with { this.count } reviews

--- a/src/components/rating/__tests__/CdrRating.spec.js
+++ b/src/components/rating/__tests__/CdrRating.spec.js
@@ -13,7 +13,19 @@ describe('CdrRating.vue', () => {
     expect(wrapper.vm.remainder).toBe('50');
     expect(wrapper.vm.rounded).toBe(3.5);
   });
-  
+
+  it('computes and rounds rating stars correctly with string input', () => {
+    const wrapper = shallowMount(CdrRating, {
+      propsData: {
+        rating: '3.4441231',
+        count: '1',
+      }
+    });
+    expect(wrapper.vm.whole).toBe(3);
+    expect(wrapper.vm.remainder).toBe('50');
+    expect(wrapper.vm.rounded).toBe(3.5);
+  });
+
   it('renders an anchor when given an href', () => {
     const wrapper = shallowMount(CdrRating, {
       propsData: {
@@ -22,5 +34,40 @@ describe('CdrRating.vue', () => {
       }
     });
     expect(wrapper.is('a')).toBeTruthy();
+  });
+
+  it('renders normal placeholder stars when count is > 0', () => {
+    const wrapper = shallowMount(CdrRating, {
+      propsData: {
+        rating: 5,
+        count: 1,
+      }
+    });
+    expect(wrapper.contains('.cdr-rating__placeholder')).toBe(true);
+    expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(false);
+  });
+
+  it('renders custom placeholder stars when count is 0', () => {
+    const wrapper = shallowMount(CdrRating, {
+      propsData: {
+        rating: 5,
+        count: 0,
+        href: 'rei.com'
+      }
+    });
+    expect(wrapper.contains('.cdr-rating__placeholder')).toBe(false);
+    expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(true);
+  });
+
+  it('renders custom placeholder stars when count is "0"', () => {
+    const wrapper = shallowMount(CdrRating, {
+      propsData: {
+        rating: 5,
+        count: "0",
+        href: 'rei.com'
+      }
+    });
+    expect(wrapper.contains('.cdr-rating__placeholder')).toBe(false);
+    expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(true);
   });
 });


### PR DESCRIPTION
rating had 2 issues:
- passing count as "0" behaved differently than passing count as 0 (has been around...possible forever?)
- passing count as 0 caused an un-styled 0 to render in the UI (introduced in 3.0.0)

per the original design (https://rei.invisionapp.com/boards/XW3MOAQ38CB), the count should always be shown, so by removing the boolean check it now behaves the same for either type of input



