### PR TITLE
Re fix rating 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/rating/CdrRating.jsx
+++ b/src/components/rating/CdrRating.jsx
@@ -121,26 +121,28 @@ export default {
           ))}
           {this.remainderEl }
         </div>
-        <span
-          aria-hidden="true"
-          class={this.style['cdr-rating__count']}
-        >
-          {this.href
-            && <span class={this.style['cdr-rating__number']}>
-              { this.rounded }
-            </span>
-          }
+        {this.count
+          ? <span
+            aria-hidden="true"
+            class={this.style['cdr-rating__count']}
+          >
+            {this.href
+              && <span class={this.style['cdr-rating__number']}>
+                { this.rounded }
+              </span>
+            }
 
-          <span>
-            { this.formattedCount }
-          </span>
-
-          {!this.compact
-            && <span>
-              &nbsp;Reviews
+            <span>
+              { this.formattedCount }
             </span>
-          }
-        </span>
+
+            {!this.compact
+              && <span>
+                &nbsp;Reviews
+              </span>
+            }
+          </span> : ''
+        }
 
         <span class="cdr-display-sr-only">
           rated { this.rounded } out of 5 with { this.count } reviews


### PR DESCRIPTION
3.0.0 introduced a bug where passing the number 0 as count caused an unstyled "0" to appear in the UI. (0 is also the default value for count)
3.0.1 fixed this but introduced a new bug if user did not pass a count at all (default was still 0, so it would show "0 reviews" even if you passed nothing)
this change restores the behavior from 2.0.2 (i.e, if you don't pass anything in as count, then that text does not show)