### PR TITLE
fix utils/reset output

### DIFF
--- a/build/extract-css.js
+++ b/build/extract-css.js
@@ -11,7 +11,7 @@ files.forEach((file) => {
   sass.render({
     file: `./src/css/${file}.scss`,
     outputStyle: 'compressed',
-    importer: tildeImporter,
+    importer: tildeImporter(),
   }, function(err, result) {
     if (err) {
       console.log(chalk.red('error!', err));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",


### PR DESCRIPTION
This file previously used `node-sass-tilde-importer`, 
which was passed in like this: `importer: tildeImporter`.

During the winter release, that package was 
replaced with `node-sass-package-importer` 
which must be invoked like this: `importer: tildeImporter()`

(weird that sass doesn't throw an error here though?)

Work on the CSS build for winter is either going to delete this file or beef it up, 
which will cover testing this output in the future.