### PR TITLE
backstop: add ability to target one element but capture another

### DIFF
--- a/backstop.js
+++ b/backstop.js
@@ -44,8 +44,8 @@ function splitScenario(def, type = '', selectorsArr, extraOptions = {}) {
   const scenario = Object.assign({}, extraOptions, def);
   selectorsArr.forEach((s, idx) => {
     scenario.label = `${def.label} ${type}${idx}`;
-    scenario[`${type}Selector`] = true;
-    scenario.selectors = [s];
+    scenario[`${type}Selector`] = s.target ? s.target : s;
+    scenario.selectors = [s.capture ? s.capture : s];
     createScenario(scenario);
   });
 }
@@ -71,7 +71,7 @@ defs.forEach((def) => {
     delete currDef.focusSelectors;
     splitScenario(currDef, 'focus', focusSelectors);
   }
-  
+
   if (Object.prototype.hasOwnProperty.call(currDef, 'responsive')) {
     delete currDef.responsive;
     currDef.viewports = responsiveViewports;

--- a/backstop_data/engine_scripts/focus.js
+++ b/backstop_data/engine_scripts/focus.js
@@ -1,6 +1,6 @@
 module.exports = async (page, scenario) => {
   if (Object.prototype.hasOwnProperty.call(scenario, 'focusSelector')) {
-    const focusSelector = scenario.selectors[0];
+    const focusSelector = scenario.focusSelector;
     await page.waitFor(focusSelector);
     await page.focus(focusSelector);
     if (scenario.wait) {

--- a/backstop_data/engine_scripts/hover.js
+++ b/backstop_data/engine_scripts/hover.js
@@ -1,6 +1,6 @@
 module.exports = async (page, scenario) => {
   if (Object.prototype.hasOwnProperty.call(scenario, 'hoverSelector')) {
-    const hoverSelector = scenario.selectors[0];
+    const hoverSelector = scenario.hoverSelector;
     await page.waitFor(hoverSelector);
     await page.hover(hoverSelector);
     if (scenario.wait) {

--- a/src/components/breadcrumb/CdrBreadcrumb.backstop.js
+++ b/src/components/breadcrumb/CdrBreadcrumb.backstop.js
@@ -8,16 +8,28 @@ module.exports = [
     url: 'http://localhost:3000/#/breadcrumbs',
     label: 'Breadcrumb',
     selectors: [
-      '[data-backstop="breadcrumbs-default"] a:first-child',
-      '[data-backstop="breadcrumbs-ellipsis"] button:first-child',
+      '[data-backstop="breadcrumbs-default"]',
+      '[data-backstop="breadcrumbs-ellipsis"]',
     ],
     hoverSelectors: [
-      '[data-backstop="breadcrumbs-default"] a:first-child',
-      '[data-backstop="breadcrumbs-ellipsis"] button:first-child',
+      {
+        target: '[data-backstop="breadcrumbs-default"] a:first-child',
+        capture: '[data-backstop="breadcrumbs-default"]',
+      },
+      {
+        target: '[data-backstop="breadcrumbs-ellipsis"] button:first-child',
+        capture: '[data-backstop="breadcrumbs-ellipsis"]',
+      },
     ],
     focusSelectors: [
-      '[data-backstop="breadcrumbs-default"] a:first-child',
-      '[data-backstop="breadcrumbs-ellipsis"] button:first-child',
+      {
+        target: '[data-backstop="breadcrumbs-default"] a:first-child',
+        capture: '[data-backstop="breadcrumbs-default"]',
+      },
+      {
+        target: '[data-backstop="breadcrumbs-ellipsis"] button:first-child',
+        capture: '[data-backstop="breadcrumbs-ellipsis"]',
+      },
     ],
   },
 ];

--- a/src/components/button/CdrButton.backstop.js
+++ b/src/components/button/CdrButton.backstop.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    url: 'http://localhost:3000/#/default-buttons',
+    url: 'http://localhost:3000/#/buttons',
     label: 'Responsive Button',
     responsive: true,
   },
@@ -11,16 +11,32 @@ module.exports = [
       '[data-backstop="buttons"]',
     ],
     focusSelectors: [
-      '[data-backstop="cdr-button--size"]',
-      '[data-backstop="cdr-button--responsive"]',
-      '[data-backstop="cdr-button--disabled"]',
-      '[data-backstop="cdr-button--anchor"]',
+      {
+        target: '[data-backstop="cdr-button--size"] button',
+        capture: '[data-backstop="cdr-button--size"]',
+      },
+      {
+        target: '[data-backstop="cdr-button--disabled"] button',
+        capture: '[data-backstop="cdr-button--disabled"]',
+      },
+      {
+        target: '[data-backstop="cdr-button--anchor"] a',
+        capture: '[data-backstop="cdr-button--anchor"]',
+      },
     ],
     hoverSelectors: [
-      '[data-backstop="cdr-button--size"]',
-      '[data-backstop="cdr-button--responsive"]',
-      '[data-backstop="cdr-button--disabled"]',
-      '[data-backstop="cdr-button--anchor"]',
+      {
+        target: '[data-backstop="cdr-button--size"] button',
+        capture: '[data-backstop="cdr-button--size"]',
+      },
+      {
+        target: '[data-backstop="cdr-button--disabled"] button',
+        capture: '[data-backstop="cdr-button--disabled"]',
+      },
+      {
+        target: '[data-backstop="cdr-button--anchor"] a',
+        capture: '[data-backstop="cdr-button--anchor"]',
+      },
     ],
   },
   {
@@ -30,10 +46,16 @@ module.exports = [
       '[data-backstop="buttons"]',
     ],
     focusSelectors: [
-      '[data-backstop="cdr-button--secondary"]',
+      {
+        target: '[data-backstop="cdr-button--secondary"] button',
+        capture: '[data-backstop="cdr-button--secondary"]',
+      },
     ],
     hoverSelectors: [
-      '[data-backstop="cdr-button--secondary"]',
+      {
+        target: '[data-backstop="cdr-button--secondary"] button',
+        capture: '[data-backstop="cdr-button--secondary"]',
+      },
     ],
   },
   {
@@ -43,10 +65,16 @@ module.exports = [
       '[data-backstop="buttons"]',
     ],
     focusSelectors: [
-      '[data-backstop="cdr-button--icon"]',
+      {
+        target: '[data-backstop="cdr-button--icon"] button',
+        capture: '[data-backstop="cdr-button--icon"]',
+      },
     ],
     hoverSelectors: [
-      '[data-backstop="cdr-button--icon"]',
+      {
+        target: '[data-backstop="cdr-button--icon"] button',
+        capture: '[data-backstop="cdr-button--icon"]',
+      },
     ],
   },
   {

--- a/src/components/button/examples/demo/Default.vue
+++ b/src/components/button/examples/demo/Default.vue
@@ -4,6 +4,7 @@
       class="button-example cdr-space-inset-one-x"
       v-for="(section, index) in data"
       :key="index"
+      :data-backstop="section.backstop ? section.backstop : null"
     >
       <cdr-text
         tag="h3"
@@ -19,13 +20,15 @@
         :full-width="button.fullWidth"
         :type="button.type"
         :disabled="button.disabled"
-        :data-backstop="button.backstop ? button.backstop : null"
         @click="log"
       >
         {{ button.label }}
       </cdr-button>
     </div>
-    <div class="button-example cdr-space-inset-one-x">
+    <div
+      class="button-example cdr-space-inset-one-x"
+      data-backstop="cdr-button--anchor"
+    >
       <cdr-text
         tag="h3"
         modifier="heading-400 heading-500@md heading-500@lg"
@@ -36,9 +39,16 @@
         tag="a"
         href="https://rei.com"
         size="large"
-        data-backstop="cdr-button--anchor"
       >
-        Link
+        Large Link
+      </cdr-button>
+
+      <cdr-button
+        tag="a"
+        href="https://rei.com"
+        size="small"
+      >
+        Small Link
       </cdr-button>
     </div>
     <div>
@@ -50,26 +60,8 @@
       </cdr-text>
       <cdr-button
         size="large large@xs medium@sm small@lg"
-        data-backstop="cdr-button--responsive"
       >
         Responsive
-      </cdr-button>
-    </div>
-    <div>
-      <cdr-button
-        :full-width="true"
-        size="large@lg"
-        space="cdr-mb-space-one-x cdr-mr-space-one-x@md"
-      >
-        button 1
-      </cdr-button>
-
-      <cdr-button
-        :full-width="true"
-        modifier="secondary"
-        size="large@lg"
-      >
-        button 2
       </cdr-button>
     </div>
   </div>
@@ -88,6 +80,7 @@ export default {
       data: [
         {
           title: 'Default sizes',
+          backstop: 'cdr-button--size',
           buttons: [
             {
               label: 'Large',
@@ -115,6 +108,7 @@ export default {
         },
         {
           title: 'Disabled',
+          backstop: 'cdr-button--disabled',
           buttons: [
             {
               label: 'Large',

--- a/src/components/button/examples/demo/Icons.vue
+++ b/src/components/button/examples/demo/Icons.vue
@@ -1,6 +1,9 @@
 <template>
   <div data-backstop="buttons">
-    <div class="button-example cdr-space-inset-one-x">
+    <div
+      class="button-example cdr-space-inset-one-x"
+      data-backstop="cdr-button--icon"
+    >
       <cdr-text
         tag="h3"
         modifier="heading-400"
@@ -10,7 +13,6 @@
       <cdr-button
         size="large"
         space="cdr-mr-space-one-x"
-        data-backstop="cdr-button--icon"
       >
         <cdr-icon
           use="#check-lg"

--- a/src/components/button/examples/demo/Secondary.vue
+++ b/src/components/button/examples/demo/Secondary.vue
@@ -4,6 +4,7 @@
       class="button-example cdr-space-inset-one-x"
       v-for="(section, index) in data"
       :key="index"
+      :data-backstop="section.backstop ? section.backstop : null"
     >
       <cdr-text
         tag="h3"
@@ -55,13 +56,13 @@ export default {
       data: [
         {
           title: 'Secondary',
+          backstop: 'cdr-button--secondary',
           buttons: [
             {
               label: 'Large',
               disabled: false,
               size: 'large',
               modifier: 'secondary',
-              backstop: 'cdr-button--secondary',
             },
             {
               label: 'Medium',

--- a/src/components/checkbox/CdrCheckbox.backstop.js
+++ b/src/components/checkbox/CdrCheckbox.backstop.js
@@ -5,14 +5,17 @@ module.exports = [
     responsive: true,
   },
   // TODO: need method for focus/hovering one element but snapshotting it's parent
-  // {
-  //   url: 'http://localhost:3000/#/checkboxes',
-  //   label: 'Checkbox',
-  //   selectors: [
-  //     '[data-backstop="checkbox-checked"]',
-  //   ],
-  //   focusSelectors: [
-  //     '[data-backstop="checkbox-checked"]',
-  //   ],
-  // },
+  {
+    url: 'http://localhost:3000/#/checkboxes',
+    label: 'Checkbox',
+    selectors: [
+      '[data-backstop="checkbox-checked"]',
+    ],
+    focusSelectors: [
+      {
+        target: '[data-backstop="checkbox-checked"] input',
+        capture: '[data-backstop="checkbox-checked"]',
+      },
+    ],
+  },
 ];

--- a/src/components/checkbox/examples/checkboxes.vue
+++ b/src/components/checkbox/examples/checkboxes.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-backstop="checkboxes">
+  <div>
     <cdr-text
       tag="h2"
       modifier="heading-400 heading-500@md heading-500@lg"

--- a/src/components/cta/CdrCta.backstop.js
+++ b/src/components/cta/CdrCta.backstop.js
@@ -1,9 +1,19 @@
 module.exports = [
   {
     url: 'http://localhost:3000/#/cta',
+    label: 'Cta responsive',
+    responsive: true,
+  },
+  {
+    url: 'http://localhost:3000/#/cta',
     label: 'Cta',
     selectors: [
-      '[data-backstop="cta-links"]',
+      '[data-backstop="cdr-cta--brand"]',
+      '[data-backstop="cdr-cta--dark"]',
+      '[data-backstop="cdr-cta--light"]',
+      '[data-backstop="cdr-cta--sale"]',
+      '[data-backstop="cdr-cta--full-width"]',
+      '[data-backstop="cdr-cta--elevated"]',
     ],
     focusSelectors: [
       '[data-backstop="cdr-cta--brand"]',
@@ -20,14 +30,6 @@ module.exports = [
       '[data-backstop="cdr-cta--sale"]',
       '[data-backstop="cdr-cta--full-width"]',
       '[data-backstop="cdr-cta--elevated"]',
-    ],
-  },
-  {
-    url: 'http://localhost:3000/#/cta',
-    label: 'Cta full width responsive',
-    responsive: true,
-    selectors: [
-      '[data-backstop="cdr-cta--full-width-responsive"]',
     ],
   },
 ];

--- a/src/components/input/CdrInput.backstop.js
+++ b/src/components/input/CdrInput.backstop.js
@@ -8,10 +8,13 @@ module.exports = [
     url: 'http://localhost:3000/#/inputs',
     label: 'Input',
     selectors: [
-      '[data-backstop="input-default"]',
+      '[data-backstop="input-target"]',
     ],
     focusSelectors: [
-      '[data-backstop="input-default"]',
+      {
+        capture: '[data-backstop="input-target"]',
+        target: '[data-backstop="input-target"] input',
+      },
     ],
   },
 ];

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -1,22 +1,22 @@
 <template>
-  <div data-backstop="inputs">
+  <div>
     <cdr-text
       tag="h2"
     >Text Inputs</cdr-text>
+    <div data-backstop="input-target">
+      <cdr-input
+        class="demo-input"
+        v-model="defaultModel"
+        label="#1 Default"
+      />
 
-    <cdr-input
-      class="demo-input"
-      v-model="defaultModel"
-      label="#1 Default"
-      data-backstop="input-default"
-    />
-
-    <cdr-input
-      class="demo-input"
-      v-model="requiredModel"
-      label="#2 Required"
-      required
-    />
+      <cdr-input
+        class="demo-input"
+        v-model="requiredModel"
+        label="#2 Required"
+        required
+      />
+    </div>
 
     <cdr-input
       class="demo-input"

--- a/src/components/pagination/CdrPagination.backstop.js
+++ b/src/components/pagination/CdrPagination.backstop.js
@@ -9,16 +9,27 @@ module.exports = [
     label: 'Pagination',
     // first page is the "current" so it has no hover or focus effect.
     selectors: [
-      '[data-backstop="pagination-default"] li:first-child a',
-      '[data-backstop="pagination-default"] li:nth-child(2) a',
+      '[data-backstop="pagination-default"]',
     ],
     focusSelectors: [
-      '[data-backstop="pagination-default"] li:first-child a',
-      '[data-backstop="pagination-default"] li:nth-child(2) a',
+      {
+        target: '[data-backstop="pagination-default"] li:first-child a',
+        capture: '[data-backstop="pagination-default"]',
+      },
+      {
+        target: '[data-backstop="pagination-default"] li:nth-child(2) a',
+        capture: '[data-backstop="pagination-default"]',
+      },
     ],
     hoverSelectors: [
-      '[data-backstop="pagination-default"] li:first-child a',
-      '[data-backstop="pagination-default"] li:nth-child(2) a',
+      {
+        target: '[data-backstop="pagination-default"] li:first-child a',
+        capture: '[data-backstop="pagination-default"]',
+      },
+      {
+        target: '[data-backstop="pagination-default"] li:nth-child(2) a',
+        capture: '[data-backstop="pagination-default"]',
+      },
     ],
   },
 ];

--- a/src/components/radio/CdrRadio.backstop.js
+++ b/src/components/radio/CdrRadio.backstop.js
@@ -4,15 +4,17 @@ module.exports = [
     label: 'Radio responsive',
     responsive: true,
   },
-  // TODO: need method for focus/hovering one element but snapshotting it's parent
-  // {
-  //   url: 'http://localhost:3000/#/radios',
-  //   label: 'Radio',
-  //   selectors: [
-  //     '[data-backstop="radio-focus"]'
-  //   ],
-  //   focusSelectors: [
-  //     '[data-backstop="radio-focus"]'
-  //   ],
-  // },
+  {
+    url: 'http://localhost:3000/#/radios',
+    label: 'Radio',
+    selectors: [
+      '[data-backstop="radio-focus"]',
+    ],
+    focusSelectors: [
+      {
+        target: '[data-backstop="radio-focus"] input',
+        capture: '[data-backstop="radio-focus"]',
+      },
+    ],
+  },
 ];

--- a/src/components/radio/examples/Radios.vue
+++ b/src/components/radio/examples/Radios.vue
@@ -1,35 +1,36 @@
 <template>
-  <div data-backstop="radios">
+  <div>
     <cdr-text
       tag="h2"
       modifier="heading-600 heading-700@md heading-700@lg"
     >
       Radios
     </cdr-text>
-    <cdr-radio
-      id="test1"
-      name="example"
-      custom-value="a1"
-      v-model="ex1"
-      data-backstop="radio-focus"
-    >A1</cdr-radio>
-    <cdr-radio
-      name="example"
-      custom-value="a2"
-      v-model="ex1"
-    >A2</cdr-radio>
-    <cdr-radio
-      name="example"
-      :custom-value="{val:'a3'}"
-      v-model="ex1"
-    >A3</cdr-radio>
-    <cdr-radio
-      name="example"
-      custom-value="a4"
-      v-model="ex1"
-      disabled
-    >A4 (disabled)</cdr-radio>
-    <cdr-text>Group A Picked: {{ ex1 }}</cdr-text>
+    <div data-backstop="radio-focus">
+      <cdr-radio
+        id="test1"
+        name="example"
+        custom-value="a1"
+        v-model="ex1"
+      >A1</cdr-radio>
+      <cdr-radio
+        name="example"
+        custom-value="a2"
+        v-model="ex1"
+      >A2</cdr-radio>
+      <cdr-radio
+        name="example"
+        :custom-value="{val:'a3'}"
+        v-model="ex1"
+      >A3</cdr-radio>
+      <cdr-radio
+        name="example"
+        custom-value="a4"
+        v-model="ex1"
+        disabled
+      >A4 (disabled)</cdr-radio>
+      <cdr-text>Group A Picked: {{ ex1 }}</cdr-text>
+    </div>
     <hr>
     <cdr-radio
       modifier="compact"

--- a/src/components/select/CdrSelect.backstop.js
+++ b/src/components/select/CdrSelect.backstop.js
@@ -8,10 +8,13 @@ module.exports = [
     url: 'http://localhost:3000/#/selects',
     label: 'Select',
     selectors: [
-      '[data-backstop="select-default"]',
+      '[data-backstop="select-target"]',
     ],
     focusSelectors: [
-      '[data-backstop="select-default"]',
+      {
+        capture: '[data-backstop="select-target"]',
+        target: '[data-backstop="select-target"] select',
+      },
     ],
   },
 ];

--- a/src/components/select/examples/Selects.vue
+++ b/src/components/select/examples/Selects.vue
@@ -9,27 +9,54 @@
     </cdr-text>
     <hr class="icon-hr">
 
-    <!-- Default Example -->
-    <cdr-select
-      label="Default"
-      v-model="selectedA"
-      prompt="Choose one"
-      space="cdr-my-space-two-x"
-    >
-      <option value="1">
-        1
-      </option>
-      <option value="2">
-        2
-      </option>
-      <option value="3">
-        3
-      </option>
-      <option value="4">
-        4
-      </option>
-    </cdr-select>
-    <cdr-text>Selected Value: {{ selectedA }}</cdr-text>
+    <div data-backstop="select-target">
+      <!-- Default Example -->
+      <cdr-select
+        label="Default"
+        v-model="selectedA"
+        prompt="Choose one"
+        space="cdr-my-space-two-x"
+      >
+        <option value="1">
+          1
+        </option>
+        <option value="2">
+          2
+        </option>
+        <option value="3">
+          3
+        </option>
+        <option value="4">
+          4
+        </option>
+      </cdr-select>
+      <cdr-text>Selected Value: {{ selectedA }}</cdr-text>
+
+      <hr class="icon-hr">
+
+      <!-- Required with Prompt Example -->
+      <cdr-select
+        label="Required with Prompt"
+        v-model="selectedB"
+        prompt="Choose one"
+        required
+        space="cdr-my-space-two-x"
+      >
+        <option value="1">
+          1
+        </option>
+        <option value="2">
+          2
+        </option>
+        <option value="3">
+          3
+        </option>
+        <option value="4">
+          4
+        </option>
+      </cdr-select>
+      <cdr-text>Selected Value: {{ selectedB }}</cdr-text>
+    </div>
     <hr class="icon-hr">
 
     <!-- Disabled Select -->
@@ -44,31 +71,6 @@
       </option>
     </cdr-select>
     <cdr-text>Selected: {{ selectedDisabled }}</cdr-text>
-    <hr class="icon-hr">
-
-    <!-- Required with Prompt Example -->
-    <cdr-select
-      label="Required with Prompt"
-      v-model="selectedB"
-      prompt="Choose one"
-      data-backstop="select-default"
-      required
-      space="cdr-my-space-two-x"
-    >
-      <option value="1">
-        1
-      </option>
-      <option value="2">
-        2
-      </option>
-      <option value="3">
-        3
-      </option>
-      <option value="4">
-        4
-      </option>
-    </cdr-select>
-    <cdr-text>Selected Value: {{ selectedB }}</cdr-text>
     <hr class="icon-hr">
 
     <!-- Hidden Label Example -->

--- a/src/components/tabs/CdrTabs.backstop.js
+++ b/src/components/tabs/CdrTabs.backstop.js
@@ -8,13 +8,19 @@ module.exports = [
     url: 'http://localhost:3000/#/tabs',
     label: 'Tabs',
     selectors: [
-      '[data-backstop="tab-default"] li:nth-child(2)',
+      '[data-backstop="tab-default"]',
     ],
     hoverSelectors: [
-      '[data-backstop="tab-default"] li:nth-child(2)',
+      {
+        target: '[data-backstop="tab-default"] li:nth-child(2) a',
+        capture: '[data-backstop="tab-default"]',
+      },
     ],
     focusSelectors: [
-      '[data-backstop="tab-default"] li:nth-child(2)',
+      {
+        target: '[data-backstop="tab-default"] li:nth-child(2) a',
+        capture: '[data-backstop="tab-default"]',
+      },
     ],
     wait: 1000,
   },


### PR DESCRIPTION
previously, backstop was set up so hoverSelectors and focusSelectors both interacted with and captured the same element. This causes a bunch of issues:
- hard to tell if an element is focused/hovered or not without seeing it next to an non-focused/hovered version
- lots of cedar components pass through their `$attrs` to an internal element, which includes `data-backstop`...so if you attach that to a cedar component instead of a wrapper element you end up missing most of the component (for example, the label elements around input and select)
- some components like checkbox and radio use a hidden native element behind a UI wrapper, making it difficult to craft a selector that works for both interaction and capturing

This change lets you pass objects to either of the `___Selectors` arrays in a scenario, specifying a separate `target` and `capture` selector. passing strings will continue to behave as before.

lets us do neat things like this:
<img width="481" alt="Screen Shot 2019-10-25 at 10 39 33 AM" src="https://user-images.githubusercontent.com/48567940/67595525-b850ee00-f71b-11e9-8851-e2a6cd2a8171.png">
