### PR TITLE
export per-component css

### DIFF
--- a/build/extract-css.js
+++ b/build/extract-css.js
@@ -1,15 +1,41 @@
 const sass = require('node-sass');
 const tildeImporter = require('node-sass-package-importer');
 const fs = require('fs-extra');
+const glob = require("glob");
 const chalk = require('chalk');
 const postcss = require('postcss');
 const postcssrc = require('postcss-load-config');
+const postcssModules = require('postcss-modules');
+const packageJson = require('../package.json')
 
-const files = ['utilities', 'reset'];
+const env = process.env.NODE_ENV;
 
-files.forEach((file) => {
+const globals = ['reset', 'utilities'];
+const components = glob.sync('./src/components/**/styles/*.scss');
+
+const globalOutputs = globals.map((file) => buildCss(file, false));
+const componentOutputs = components.map((file) => buildCss(file, true));
+const outputs = globalOutputs.concat(componentOutputs);
+
+const outFile = outputs.map(file => `@import url('${file.replace('.', '@rei/cedar')}');`).join('\n');
+
+fs.outputFile('./dist/cdr-full.css', outFile, function(err) {
+  if (!err) {
+    console.log(chalk.green(`success! created cdr-full.css`));
+  }
+});
+
+function buildCss(file, scopeClasses) {
+  const srcPath = scopeClasses ?
+    file :
+    `./src/css/${file}.scss`;
+    
+  const outPath = scopeClasses ?
+    `./dist/style/${file.split('/')[5].replace('scss', 'css')}` :
+    `./dist/style/${file}.css`;
+
   sass.render({
-    file: `./src/css/${file}.scss`,
+    file: srcPath,
     outputStyle: 'compressed',
     importer: tildeImporter(),
   }, function(err, result) {
@@ -17,16 +43,26 @@ files.forEach((file) => {
       console.log(chalk.red('error!', err));
     } else {
       postcssrc().then(({ plugins, options }) => {
+        if (scopeClasses) {
+          plugins.push(postcssModules({
+            generateScopedName: function (name) {
+              // scope classes for components
+              return `${name}_${packageJson.version}`;
+            }
+          }))
+        }
         postcss(plugins)
         .process(result.css, options)
         .then((result) => {
-          fs.outputFile(`./dist/${file}.css`, result, function(err) {
+          fs.outputFile(outPath, result, function(err) {
             if (!err) {
-              console.log(chalk.green(`success! created dist/${file}.css`));
+              console.log(chalk.green(`success! created ${outPath}`));
             }
           });
         });
       });
     }
   });
-});
+  
+  return outPath;
+}

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "postcss-calc": "^7.0.1",
     "postcss-import": "^12.0.1",
     "postcss-inline-svg": "^3.0.0",
+    "postcss-modules": "^1.4.1",
     "postcss-pxtorem": "^4.0.1",
     "postcss-scss": "^2.0.0",
     "rimraf": "^2.6.3",

--- a/src/components/accordion/styles/CdrAccordion.scss
+++ b/src/components/accordion/styles/CdrAccordion.scss
@@ -19,6 +19,7 @@
 ========================================================================== */
 @import '../../../css/settings/index.scss';
 @import './vars/CdrAccordion.vars.scss';
+@import url('@rei/cedar/dist/style/CdrIcon.css');
 
 .cdr-accordion {
   border-top: $cdr-accordion-border;

--- a/src/components/grid/styles/CdrCol.scss
+++ b/src/components/grid/styles/CdrCol.scss
@@ -1,5 +1,6 @@
 @import '../../../css/settings/index.scss';
 @import './vars/Grid.vars.scss';
+@import url('@rei/cedar/dist/style/CdrRow.css');
 
 // TODO: replace all of this with a mixin
 $colPct1: calc(1 / #{$rowColumns} * 100%);

--- a/src/components/pagination/styles/CdrPagination.scss
+++ b/src/components/pagination/styles/CdrPagination.scss
@@ -1,4 +1,6 @@
 @import '../../../css/settings/index.scss';
+@import url('@rei/cedar/dist/style/CdrIcon.css');
+@import url('@rei/cedar/dist/style/CdrSelect.css');
 /* ==========================================================================
   # CdrPagination
 

--- a/src/components/select/styles/CdrSelect.scss
+++ b/src/components/select/styles/CdrSelect.scss
@@ -1,5 +1,6 @@
 @import '../../../css/settings/index.scss';
 @import './vars/CdrSelect.vars.scss';
+@import url('@rei/cedar/dist/style/CdrIcon.css');
 /* ==========================================================================
   # CdrSelect
 

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -1,5 +1,6 @@
 @import '../../../css/settings/index.scss';
 @import './vars/CdrTabs.vars.scss';
+@import url('@rei/cedar/dist/style/CdrTabPanel.css');
 /* ==========================================================================
   # CdrTabs
 

--- a/src/components/text/styles/CdrText.scss
+++ b/src/components/text/styles/CdrText.scss
@@ -1,0 +1,1 @@
+@import url('@rei/cedar/dist/style/utilities.css');


### PR DESCRIPTION
## Description

See https://git.rei.com/projects/CLIMB/repos/climbers-site/pull-requests/103/overview on bitbucket for febs/climbers related updates and an example of how this is used.

### Changes

- Creates an additional CSS output in `/dist/style` containing a "decomposed" version of `cedar.css`. 
- Moves reset and utilities into that folder. 
- Creates a `CdrText.scss` file that just imports the utilities. 
- Also creates a `/dist/cdr-full.css` file which simply imports everything inside `/dist/style`. This will allow consumers to still just "import everything" if they want, while still getting the benefits of de-duping any dependencies. 


### Testing

- We will be able to "test" that postcss imports are working for a version of cedar by loading it into climber-details-page and climbers-site and verifying that the page renders correctly. 
- FEBS also has unit tests added to it which verifies that it is handling postcss imports correctly. 
- The docs site can be used to test the old "cedar.css" output. 

tested the following use cases manually against climbers-site and search:

- 2 dependencies each import CdrButton@3.0.0 => one copy of CdrButton is bundled
- 1 dependency imports CdrButton@3.0.0 and another imports CdrButton@4.0.0 => 1 copy of each version is bundled
- 1 dependency imports CdrButton@3.0.0 and another imports cdr-full@3.0.0 => one copy of CdrButton is bundled


TODO: should we also decompose the utilities? utils are 100kb i.e, 1/3 of cedar.
TODO: additional testing needed?


