### PR TITLE
pull reset/utils into kitchen sink

### DIFF
--- a/build/rollup-plugins.js
+++ b/build/rollup-plugins.js
@@ -33,10 +33,6 @@ if (env !== 'test') {
   copyTargets = ['static/cdr-fonts.css'];
 }
 
-if (env === 'dev') {
-  copyTargets.push('dist/cedar.css')
-}
-
 const plugins = [
   (env == 'test' || env == 'dev') && alias({
     resolve: ['.json', '.js', '.jsx', '.scss', '.vue'],

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm-run-all lint build",
-    "dev:build": "npm-run-all build:cssfonts && cross-env NODE_ENV=dev rollup -c rollup.config.dev.js",
+    "dev:build": "npm run build:cssfonts && cross-env NODE_ENV=dev rollup -c rollup.config.dev.js",
     "dev": "npm run dev:build -- -w",
     "build": "npm-run-all clean build:cssfonts build:cjs build:esm build:extractcss build:cssdocs",
     "build:cjs": "cross-env NODE_ENV=prod BABEL_ENV=cjs rollup -c rollup.config.js",

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400|Roboto:400" rel="stylesheet">
     <link rel="stylesheet" href="cdr-fonts.css">
-    <link rel="stylesheet" href="cedar.css">
   </head>
   <body>
     <!-- Uncomment to test vs normalize -->

--- a/src/dev.js
+++ b/src/dev.js
@@ -4,8 +4,7 @@ import Vue from 'vue/dist/vue.esm';
 import VueRouter from 'vue-router';
 import { CdrIconSprite } from 'componentsdir/icon/index';
 import routes from './router';
-import './css/main.scss';
-
+import cedarcss from './css/main.scss';
 
 Vue.config.devtools = true;
 
@@ -28,6 +27,7 @@ new Vue({
   data() {
     return {
       routes,
+      cedarcss,
     };
   },
   mounted() {


### PR DESCRIPTION
https://rei.github.io/rei-cedar/#/breadcrumbs kitchen-sink on gh-pages works except it's missing the CSS reset so everything is **B I G**

previously the kitchen sink was depending on there already being a copy of `cedar.css` built in dist for it to use for the reset/utils. kitchen sink uses css-in-js, so it doesn't make sense to pull in the full cedar twice. 