### PR TITLE
make count default to `null`

### DIFF
--- a/src/components/rating/CdrRating.jsx
+++ b/src/components/rating/CdrRating.jsx
@@ -26,7 +26,7 @@ export default {
     count: {
       required: false,
       type: [String, Number],
-      default: 0,
+      default: null,
     },
     /**
      * Hides the word 'reviews' if true
@@ -83,6 +83,12 @@ export default {
       }
       return remainder;
     },
+    ratingSrText() {
+      return `rated ${this.rounded} out of 5`;
+    },
+    countSrText() {
+      return this.count !== null ? ` with ${this.count} reviews` : '';
+    },
   },
   render() {
     const Component = this.href ? 'a' : 'div';
@@ -121,7 +127,7 @@ export default {
           ))}
           {this.remainderEl }
         </div>
-        {this.count
+        {this.count !== null
           ? <span
             aria-hidden="true"
             class={this.style['cdr-rating__count']}
@@ -145,7 +151,7 @@ export default {
         }
 
         <span class="cdr-display-sr-only">
-          rated { this.rounded } out of 5 with { this.count } reviews
+          { this.ratingSrText }{ this.countSrText }
         </span>
       </Component>
     );

--- a/src/components/rating/__tests__/CdrRating.spec.js
+++ b/src/components/rating/__tests__/CdrRating.spec.js
@@ -95,4 +95,49 @@ describe('CdrRating', () => {
     expect(wrapper.contains('.cdr-rating__placeholder')).toBe(false);
     expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(true);
   });
+
+  it('renders custom placeholder stars when count is not passed', () => {
+    const wrapper = shallowMount(CdrRating, {
+      propsData: {
+        rating: 5,
+        href: 'rei.com'
+      }
+    });
+    expect(wrapper.contains('.cdr-rating__placeholder')).toBe(false);
+    expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(true);
+  });
+
+  it('renders review text when count is 0', () => {
+    const wrapper = shallowMount(CdrRating, {
+      propsData: {
+        rating: 5,
+        count: 0,
+        href: 'rei.com'
+      }
+    });
+    expect(wrapper.contains('.cdr-rating__count')).toBe(true);
+    expect(wrapper.find('.cdr-display-sr-only').text()).toBe('rated 5 out of 5 with 0 reviews');
+  });
+
+  it('renders review text when count is "0"', () => {
+    const wrapper = shallowMount(CdrRating, {
+      propsData: {
+        rating: 5,
+        count: "0",
+        href: 'rei.com'
+      }
+    });
+    expect(wrapper.contains('.cdr-rating__count')).toBe(true);
+    expect(wrapper.find('.cdr-display-sr-only').text()).toBe('rated 5 out of 5 with 0 reviews');
+  });
+
+  it('renders no review text if count is not passed', () => {
+    const wrapper = shallowMount(CdrRating, {
+      propsData: {
+        rating: 5,
+      }
+    });
+    expect(wrapper.contains('.cdr-rating__count')).toBe(false);
+    expect(wrapper.find('.cdr-display-sr-only').text()).toBe('rated 5 out of 5');
+  });
 });

--- a/src/components/rating/examples/Ratings.vue
+++ b/src/components/rating/examples/Ratings.vue
@@ -46,6 +46,26 @@
       />
     </div>
 
+    <cdr-text>
+      0 String Count
+    </cdr-text>
+    <cdr-rating
+      rating="1.2"
+      count="0"
+    />
+    <cdr-text>
+      0 Num Count
+    </cdr-text>
+    <cdr-rating
+      rating="1.2"
+      :count="0"
+    />
+    <cdr-text>
+      no Count
+    </cdr-text>
+    <cdr-rating
+      rating="1.2"
+    />
     <!-- Default Size -->
     <cdr-rating
       rating="1.2"


### PR DESCRIPTION
## Description

makes it so if count is passed a string or a number it renders, but otherwise it will not show any count info. previously this depended on `0` being falsey to make that default behavior happen. 

Docsite update PR: https://github.com/rei/rei-cedar-docs/pull/482

### Design:
- [x] Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- [ ] Added/updated backstop tests
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
- [x] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [x] Examples created/updated
