### PR TITLE
fix(dev): remove `inject` setting

### DIFF
--- a/build/rollup-plugins.js
+++ b/build/rollup-plugins.js
@@ -74,7 +74,6 @@ const plugins = [
     config: true,
     plugins: [],
     extract: postcssExtract,
-    inject: false,
     extensions: ['.scss', '.css'],
     sourceMap: env === 'dev' ? 'inline' : false,
     modules: {


### PR DESCRIPTION
## Description
`inject: false` was an artifact of my css build debugging that i should have removed. if `extract` is false, then `inject` defaults to true and vice versa, so we don't need to set this option.

### Design:
- N/A Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] IE11
- [ ] iOS
- [ ] Android

### Visual regression testing:
- N/A  Added/updated backstop tests
- N/A  Passes with existing reference images (or failed as expected)

### Unit testing:
- N/A Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- N/A  Meets WCAG AA standards

### Documentation:
- N/A API docs created/updated
- N/A Examples created/updated
