### PR TITLE
Breadcrumb bugs

### DIFF
--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -94,12 +94,15 @@ export default {
         >
           /
         </span>) : '';
+
         const attrs = {
           class: this.style['cdr-breadcrumb__link'],
         };
         if (index === this.items.length - 1) {
           attrs['aria-current'] = 'page';
         }
+
+        const ref = index === 0 ? 'firstBreadcrumb' : null;
 
         return (<li
           class={this.style['cdr-breadcrumb__item']}
@@ -111,9 +114,11 @@ export default {
               attrs,
               href: breadcrumb.item.url,
               content: breadcrumb.item.name,
+              ref,
             })
             : (<a
               {... { attrs: attrs }}
+              ref={ref}
               href={breadcrumb.item.url}
             >
               { breadcrumb.item.name }
@@ -127,6 +132,7 @@ export default {
   methods: {
     handleEllipsisClick() {
       this.truncate = false;
+      this.$nextTick(() => { this.$refs.firstBreadcrumb.focus() });
     },
   },
   render() {

--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -46,11 +46,6 @@ export default {
       style,
     };
   },
-  watch: {
-    items() {
-      this.truncate = this.truncationEnabled && this.items.length > 2;
-    },
-  },
   computed: {
     baseClass() {
       return 'cdr-breadcrumb';
@@ -95,13 +90,6 @@ export default {
           /
         </span>) : '';
 
-        const attrs = {
-          class: this.style['cdr-breadcrumb__link'],
-        };
-        if (index === this.items.length - 1) {
-          attrs['aria-current'] = 'page';
-        }
-
         const ref = index === 0 ? 'firstBreadcrumb' : null;
 
         return (<li
@@ -111,13 +99,13 @@ export default {
         >
           {this.$scopedSlots.link
             ? this.$scopedSlots.link({
-              attrs,
+              class: this.style['cdr-breadcrumb__link'],
               href: breadcrumb.item.url,
               content: breadcrumb.item.name,
               ref,
             })
             : (<a
-              {... { attrs: attrs }}
+              class={this.style['cdr-breadcrumb__link']}
               ref={ref}
               href={breadcrumb.item.url}
             >
@@ -129,10 +117,15 @@ export default {
       });
     },
   },
+  watch: {
+    items() {
+      this.truncate = this.truncationEnabled && this.items.length > 2;
+    },
+  },
   methods: {
     handleEllipsisClick() {
       this.truncate = false;
-      this.$nextTick(() => { this.$refs.firstBreadcrumb.focus() });
+      this.$nextTick(() => { this.$refs.firstBreadcrumb.focus(); });
     },
   },
   render() {

--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -94,6 +94,12 @@ export default {
         >
           /
         </span>) : '';
+        const attrs = {
+          class: this.style['cdr-breadcrumb__link'],
+        };
+        if (index === this.items.length - 1) {
+          attrs['aria-current'] = 'page';
+        }
 
         return (<li
           class={this.style['cdr-breadcrumb__item']}
@@ -102,12 +108,12 @@ export default {
         >
           {this.$scopedSlots.link
             ? this.$scopedSlots.link({
-              class: this.style['cdr-breadcrumb__link'],
+              attrs,
               href: breadcrumb.item.url,
               content: breadcrumb.item.name,
             })
             : (<a
-              class={this.style['cdr-breadcrumb__link']}
+              {... { attrs: attrs }}
               href={breadcrumb.item.url}
             >
               { breadcrumb.item.name }

--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -42,16 +42,18 @@ export default {
   },
   data() {
     return {
-      shouldTruncate: this.truncationEnabled && this.items.length > 2,
+      truncate: this.truncationEnabled && this.items.length > 2,
       style,
     };
+  },
+  watch: {
+    items() {
+      this.truncate = this.truncationEnabled && this.items.length > 2;
+    },
   },
   computed: {
     baseClass() {
       return 'cdr-breadcrumb';
-    },
-    truncate() {
-      return this.shouldTruncate;
     },
     ellipsis() {
       return this.truncate ? (<li
@@ -118,7 +120,7 @@ export default {
   },
   methods: {
     handleEllipsisClick() {
-      this.shouldTruncate = false;
+      this.truncate = false;
     },
   },
   render() {

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -2,41 +2,32 @@ import { shallowMount, mount } from '@vue/test-utils';
 import CdrBreadcrumb from 'componentdir/breadcrumb/CdrBreadcrumb';
 
 describe('CdrBreadcrumb', () => {
-  const BreadcrumbItems = [
-    {
-      item: {
-        url: 'http://google.com',
-        name: 'Breadcrumb Step 1',
-      },
-    },
-    {
-      item:{
-        url: 'http://rei.com',
-        name: 'Long Breadcrumb Step 2',
-      },
-    },
-    {
-      item:{
-        url: 'http://yahoo.com',
-        name: 'Breadcrumb Step 3',
-      },
-    },
-    {
-      item:{
-        url: 'http://bing.com',
-        name: 'Really Really Long Breadcrumb Step 4',
-      },
-    },
-    {
-      item:{
-        url: 'http://amazon.com',
-        name: 'Last Step',
-      },
-    },
-  ];
-
   test('renders correctly', () => {
-    const wrapper = mount(CdrBreadcrumb);
+    const items = [
+      {
+        item: {
+          url: 'http://google.com',
+          name: 'Breadcrumb Step 1',
+        },
+      },
+      {
+        item:{
+          url: 'http://rei.com',
+          name: 'Long Breadcrumb Step 2',
+        },
+      },
+      {
+        item:{
+          url: 'http://rei.com',
+          name: 'Long Breadcrumb Step 3',
+        },
+      },
+    ];
+    const wrapper = mount(CdrBreadcrumb, {
+      propsData: {
+        items: items,
+      }
+    });
     expect(wrapper.element).toMatchSnapshot();
   });
 
@@ -163,6 +154,39 @@ describe('CdrBreadcrumb', () => {
       }
     });
     expect(wrapper.text()).toBe('http://rei.com TEST Scoped cdr-breadcrumb__link');
+  });
+
+  it('applies focus to first breadcrumb on ellipsis click', async () => {
+    const items = [
+      {
+        item: {
+          url: 'http://google.com',
+          name: 'First Breadcrumb',
+        },
+      },
+      {
+        item:{
+          url: 'http://rei.com',
+          name: 'Second Breadcrumn',
+        },
+      },
+      {
+        item:{
+          url: 'http://rei.com',
+          name: 'Third Breadcrumb',
+        },
+      },
+    ];
+    const wrapper = mount(CdrBreadcrumb, {
+      propsData: {
+        items: items,
+      },
+      attachToDocument: true, // enables focus testing
+    });
+    wrapper.vm.handleEllipsisClick()
+    wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$refs.firstBreadcrumb).toBe(document.activeElement);
+    });
   });
 
 });

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -111,31 +111,6 @@ describe('CdrBreadcrumb', () => {
     expect(wrapper.vm.truncate).toBe(true);
   });
 
-  it('puts aria-current label on last breadcrumb', () => {
-    const items = [
-      {
-        item: {
-          url: 'http://google.com',
-          name: 'First Breadcrumb',
-        },
-      },
-      {
-        item:{
-          url: 'http://rei.com',
-          name: 'Last Breadcrumb',
-        },
-      },
-    ];
-    const wrapper = shallowMount(CdrBreadcrumb, {
-      propsData: {
-        items: items,
-      }
-    });
-    const ariaElement = wrapper.findAll('a[aria-current="page"]');
-    expect(ariaElement.length).toBe(1);
-    expect(ariaElement.at(0).text()).toBe('Last Breadcrumb');
-  });
-
   it('breadcrumb link can be overridden with link scopedSlot', () => {
     const items = [
       {
@@ -150,7 +125,7 @@ describe('CdrBreadcrumb', () => {
         items: items,
       },
       scopedSlots: {
-        link: '<p slot-scope="link">{{link.href}} TEST {{link.content}} {{link.attrs.class}}</p>'
+        link: '<p slot-scope="link">{{link.href}} TEST {{link.content}} {{link.class}}</p>'
       }
     });
     expect(wrapper.text()).toBe('http://rei.com TEST Scoped cdr-breadcrumb__link');

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -95,6 +95,32 @@ describe('CdrBreadcrumb', () => {
 
   });
 
+  it('breadcrumb should evaluate truncation when items are updated', () => {
+    const items = [
+      {
+        item: {
+          url: 'http://google.com',
+          name: 'Breadcrumb Step 1',
+        },
+      },
+      {
+        item:{
+          url: 'http://rei.com',
+          name: 'Long Breadcrumb Step 2',
+        },
+      },
+    ];
+    const wrapper = shallowMount(CdrBreadcrumb, {
+      propsData: {
+        items: items,
+      }
+    });
+    expect(wrapper.vm.truncate).toBe(false);
+    wrapper.setProps({items: items.concat(items)})
+    expect(wrapper.vm.truncate).toBe(true);
+
+  });
+
   it('breadcrumb link can be overridden with link scopedSlot', () => {
     const items = [
       {

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -118,7 +118,31 @@ describe('CdrBreadcrumb', () => {
     expect(wrapper.vm.truncate).toBe(false);
     wrapper.setProps({items: items.concat(items)})
     expect(wrapper.vm.truncate).toBe(true);
+  });
 
+  it('puts aria-current label on last breadcrumb', () => {
+    const items = [
+      {
+        item: {
+          url: 'http://google.com',
+          name: 'First Breadcrumb',
+        },
+      },
+      {
+        item:{
+          url: 'http://rei.com',
+          name: 'Last Breadcrumb',
+        },
+      },
+    ];
+    const wrapper = shallowMount(CdrBreadcrumb, {
+      propsData: {
+        items: items,
+      }
+    });
+    const ariaElement = wrapper.findAll('a[aria-current="page"]');
+    expect(ariaElement.length).toBe(1);
+    expect(ariaElement.at(0).text()).toBe('Last Breadcrumb');
   });
 
   it('breadcrumb link can be overridden with link scopedSlot', () => {
@@ -135,7 +159,7 @@ describe('CdrBreadcrumb', () => {
         items: items,
       },
       scopedSlots: {
-        link: '<p slot-scope="link">{{link.href}} TEST {{link.content}} {{link.class}}</p>'
+        link: '<p slot-scope="link">{{link.href}} TEST {{link.content}} {{link.attrs.class}}</p>'
       }
     });
     expect(wrapper.text()).toBe('http://rei.com TEST Scoped cdr-breadcrumb__link');

--- a/src/components/breadcrumb/__tests__/__snapshots__/CdrBreadcrumb.spec.js.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/CdrBreadcrumb.spec.js.snap
@@ -73,7 +73,6 @@ exports[`CdrBreadcrumb renders correctly 1`] = `
       class="cdr-breadcrumb__item"
     >
       <a
-        aria-current="page"
         class="cdr-breadcrumb__link"
         href="http://rei.com"
       >

--- a/src/components/breadcrumb/__tests__/__snapshots__/CdrBreadcrumb.spec.js.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/CdrBreadcrumb.spec.js.snap
@@ -7,6 +7,79 @@ exports[`CdrBreadcrumb renders correctly 1`] = `
 >
   <ol
     class="cdr-breadcrumb__list"
-  />
+  >
+    <li
+      class="cdr-breadcrumb__item"
+    >
+      <button
+        aria-expanded="false"
+        aria-label="ellipsis"
+        class="cdr-breadcrumb__ellipses"
+      >
+        <svg
+          class="cdr-breadcrumb__ellipses-icon"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            ellipsis
+          </title>
+          <path
+            d="M17.5 22a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM12 22a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm-5.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+          />
+        </svg>
+      </button>
+      <span
+        aria-hidden="true"
+        class="cdr-breadcrumb__delimiter"
+      >
+        /
+      </span>
+    </li>
+    <li
+      class="cdr-breadcrumb__item"
+      style="display: none;"
+    >
+      <a
+        class="cdr-breadcrumb__link"
+        href="http://google.com"
+      >
+        Breadcrumb Step 1
+      </a>
+      <span
+        aria-hidden="true"
+        class="cdr-breadcrumb__delimiter"
+      >
+        /
+      </span>
+    </li>
+    <li
+      class="cdr-breadcrumb__item"
+    >
+      <a
+        class="cdr-breadcrumb__link"
+        href="http://rei.com"
+      >
+        Long Breadcrumb Step 2
+      </a>
+      <span
+        aria-hidden="true"
+        class="cdr-breadcrumb__delimiter"
+      >
+        /
+      </span>
+    </li>
+    <li
+      class="cdr-breadcrumb__item"
+    >
+      <a
+        aria-current="page"
+        class="cdr-breadcrumb__link"
+        href="http://rei.com"
+      >
+        Long Breadcrumb Step 3
+      </a>
+    </li>
+  </ol>
 </nav>
 `;


### PR DESCRIPTION
## Description

- on ellipsis click, updates focus to the first breadcrumb item
- adds watcher to `items` that re-evaluates the truncation logic

docs PR: https://github.com/rei/rei-cedar-docs/pull/499

### Design:
- n/a Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- n/a Added/updated backstop tests
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
- [x] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- [x] API docs created/updated
- [x] Examples created/updated
