### PR TITLE
Add size to checkbox and radio

### DIFF
--- a/src/components/accordion/CdrAccordion.jsx
+++ b/src/components/accordion/CdrAccordion.jsx
@@ -105,7 +105,10 @@ export default {
   },
   render() {
     return (<div
-      class={clsx(this.modifierClass, this.styleClass, this.focusedClass)}
+      class={clsx(this.style[this.baseClass],
+        this.modifierClass,
+        this.styleClass,
+        this.focusedClass)}
       id={`${this.id}-accordion`}
       ref="accordion-container"
     >

--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import modifier from '../../mixins/modifier';
 import style from './styles/CdrBreadcrumb.scss';
 
@@ -131,7 +132,7 @@ export default {
   render() {
     return (<nav
       ref="container"
-      class={this.modifierClass}
+      class={clsx(this.style[this.baseClass], this.modifierClass)}
       aria-label="Breadcrumb"
     >
       <ol

--- a/src/components/button/CdrButton.jsx
+++ b/src/components/button/CdrButton.jsx
@@ -78,6 +78,7 @@ export default {
     const Component = this.tag;
     return (<Component
       class={clsx(this.defaultClass,
+        this.style[this.baseClass],
         this.modifierClass,
         this.buttonSizeClass,
         this.fullWidthClass,

--- a/src/components/button/__tests__/__snapshots__/CdrButton.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/CdrButton.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrButton renders correctly 1`] = `
 <button
-  class="cdr-button--primary cdr-button cdr-button cdr-button--medium"
+  class="cdr-button--primary cdr-button cdr-button--medium"
   type="button"
 />
 `;

--- a/src/components/card/CdrCard.jsx
+++ b/src/components/card/CdrCard.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import modifier from '../../mixins/modifier';
 import style from './styles/CdrCard.scss';
 
@@ -15,7 +16,7 @@ export default {
     },
   },
   render() {
-    return (<article class={this.modifierClass}>
+    return (<article class={clsx(this.style[this.baseClass], this.modifierClass)}>
       {this.$slots.default}
     </article>);
   },

--- a/src/components/checkbox/CdrCheckbox.backstop.js
+++ b/src/components/checkbox/CdrCheckbox.backstop.js
@@ -3,6 +3,10 @@ module.exports = [
     url: 'http://localhost:3000/#/checkboxes',
     label: 'Checkbox responsive',
     responsive: true,
+    selectors: [
+      'document',
+      '[data-backstop="checkbox-responsive"]',
+    ],
   },
   // TODO: need method for focus/hovering one element but snapshotting it's parent
   {

--- a/src/components/checkbox/CdrCheckbox.jsx
+++ b/src/components/checkbox/CdrCheckbox.jsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx';
 import modifier from '../../mixins/modifier';
 import space from '../../mixins/space';
+import size from '../../mixins/size';
 import style from './styles/CdrCheckbox.scss';
 
 export default {
   name: 'CdrCheckbox',
-  mixins: [modifier, space],
+  mixins: [modifier, space, size],
   inheritAttrs: false,
   props: {
     /**
@@ -84,7 +85,7 @@ export default {
     return (
       <div class={clsx(this.space, this.style['cdr-checkbox__wrap'])}>
         <label
-          class={clsx(this.modifierClass, this.labelClass)}
+          class={clsx(this.modifierClass, this.labelClass, this.sizeClass)}
           ref="label"
         >
           <input

--- a/src/components/checkbox/CdrCheckbox.jsx
+++ b/src/components/checkbox/CdrCheckbox.jsx
@@ -85,7 +85,10 @@ export default {
     return (
       <div class={clsx(this.space, this.style['cdr-checkbox__wrap'])}>
         <label
-          class={clsx(this.modifierClass, this.labelClass, this.sizeClass)}
+          class={clsx(this.style[this.baseClass],
+            this.modifierClass,
+            this.labelClass,
+            this.sizeClass)}
           ref="label"
         >
           <input

--- a/src/components/checkbox/__tests__/__snapshots__/CdrCheckbox.spec.js.snap
+++ b/src/components/checkbox/__tests__/__snapshots__/CdrCheckbox.spec.js.snap
@@ -5,7 +5,7 @@ exports[`CdrCheckbox renders correctly 1`] = `
   class="cdr-checkbox__wrap"
 >
   <label
-    class="cdr-checkbox custom-label-class"
+    class="cdr-checkbox custom-label-class cdr-checkbox cdr-checkbox--medium"
   >
     <input
       class="cdr-checkbox__input"

--- a/src/components/checkbox/__tests__/__snapshots__/CdrCheckbox.spec.js.snap
+++ b/src/components/checkbox/__tests__/__snapshots__/CdrCheckbox.spec.js.snap
@@ -5,7 +5,7 @@ exports[`CdrCheckbox renders correctly 1`] = `
   class="cdr-checkbox__wrap"
 >
   <label
-    class="cdr-checkbox custom-label-class cdr-checkbox cdr-checkbox--medium"
+    class="cdr-checkbox custom-label-class cdr-checkbox--medium"
   >
     <input
       class="cdr-checkbox__input"

--- a/src/components/checkbox/examples/checkboxes.vue
+++ b/src/components/checkbox/examples/checkboxes.vue
@@ -7,6 +7,40 @@
       Checkboxes
     </cdr-text>
     <cdr-checkbox
+      v-model="sizeEx"
+      size="small"
+    >small</cdr-checkbox>
+    <cdr-checkbox
+      v-model="sizeEx"
+      size="medium"
+    >medium</cdr-checkbox>
+    <cdr-checkbox
+      v-model="sizeEx"
+      size="large"
+    >large</cdr-checkbox>
+    <div data-backstop="checkbox-responsive">
+      <cdr-checkbox
+        v-model="sizeEx"
+        size="small@lg medium@sm large@xs"
+      >responsive</cdr-checkbox>
+    </div>
+    <cdr-checkbox
+      v-model="sizeEx2"
+      size="small"
+    >small</cdr-checkbox>
+    <cdr-checkbox
+      v-model="sizeEx2"
+      size="medium"
+    >medium</cdr-checkbox>
+    <cdr-checkbox
+      v-model="sizeEx2"
+      size="large"
+    >large</cdr-checkbox>
+    <cdr-checkbox
+      v-model="sizeEx2"
+      size="small@lg medium@sm large@xs"
+    >responsive</cdr-checkbox>
+    <cdr-checkbox
       v-model="ex1"
       @change="logChange"
     >single</cdr-checkbox>
@@ -143,6 +177,8 @@ export default {
   data() {
     return {
       checked: true,
+      sizeEx: false,
+      sizeEx2: true,
       ex1: false,
       ex2: 'checked',
       ex3: 'checked',

--- a/src/components/checkbox/styles/CdrCheckbox.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.scss
@@ -14,8 +14,8 @@
         :figure
       :States
       :Modifiers
-        :compact
         :hide-figure
+      :Sizes
 ========================================================================== */
 @import '../../../css/settings/index.scss';
 @import './vars/CdrCheckbox.vars.scss';
@@ -23,7 +23,7 @@
   @include cdr-label-base-mixin;
 
   position: relative;
-  padding-left: calc(#{$checkbox-figure-size} + #{$cdr-label-base-spacing});
+  padding-left: calc(#{$checkbox-figure-size-medium} + #{$cdr-label-base-spacing});
 
   /* Elements
     ========================================================================== */
@@ -33,6 +33,7 @@
   &__wrap {
     /* get rid of inline-block whitespace from label element */
     font-size: 0;
+    line-height: 1;
   }
 
   /* Input
@@ -48,9 +49,10 @@
   &__figure {
     position: absolute;
     top: $checkbox-figure-space-top;
+    transform: translateY(-50%); // center it automatically
     left: 0;
-    width: $checkbox-figure-size;
-    height: $checkbox-figure-size;
+    width: $checkbox-figure-size-medium;
+    height: $checkbox-figure-size-medium;
     border-radius: $checkbox-figure-radius;
     background-color: $checkbox-figure-background-color;
     border: 1px solid $checkbox-figure-border-color;
@@ -169,19 +171,13 @@
   /* Modifiers
     ========================================================================== */
 
-  /* Compact
-    ========== */
-
-  &--compact {
-    @include cdr-label-compact-mixin;
-
-    & > .cdr-checkbox__figure {
-      top: $checkbox-compact-figure-space-top;
-    }
-  }
-
   /* Hide Figure
     ========== */
+
+  // TODO: remove compact?
+  &--compact {
+    @include cdr-label-compact-mixin;
+  }
 
   &--hide-figure {
     padding-left: 0;
@@ -190,4 +186,60 @@
       display: none;
     }
   }
+
+  /* Sizes
+    ========================================================================== */
+  @include cdr-checkbox-small-mixin(&);
+
+  @include cdr-checkbox-medium-mixin(&);
+
+  @include cdr-checkbox-large-mixin(&);
+
+  /* Breakpoint variants
+
+  /* @xs
+    0px - 767px
+    ========== */
+  @include xs-mq-only {
+    @include cdr-checkbox-small-mixin(&, \@xs);
+
+    @include cdr-checkbox-medium-mixin(&, \@xs);
+
+    @include cdr-checkbox-large-mixin(&, \@xs);
+  }
+
+  /* @sm
+    768px - 991px
+    ========== */
+  @include sm-mq-only {
+    @include cdr-checkbox-small-mixin(&, \@sm);
+
+    @include cdr-checkbox-medium-mixin(&, \@sm);
+
+    @include cdr-checkbox-large-mixin(&, \@sm);
+  }
+
+  /* @md
+    992px - 1199px
+    ========== */
+  @include md-mq-only {
+    @include cdr-checkbox-small-mixin(&, \@md);
+
+    @include cdr-checkbox-medium-mixin(&, \@md);
+
+    @include cdr-checkbox-large-mixin(&, \@md);
+  }
+
+  /* @lg
+    1200px and up
+    ========== */
+
+  @include lg-mq-only {
+    @include cdr-checkbox-small-mixin(&, \@lg);
+
+    @include cdr-checkbox-medium-mixin(&, \@lg);
+
+    @include cdr-checkbox-large-mixin(&, \@lg);
+  }
+
 }

--- a/src/components/checkbox/styles/CdrCheckbox.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.scss
@@ -20,7 +20,7 @@
 @import '../../../css/settings/index.scss';
 @import './vars/CdrCheckbox.vars.scss';
 .cdr-checkbox {
-  @include cdr-checkbox-text;
+  @include checkbox-text;
   position: relative;
   padding-left: calc(#{$checkbox-figure-size-medium} + #{$cdr-label-base-spacing});
 
@@ -174,7 +174,7 @@
 
   // TODO: remove compact?
   &--compact {
-    @include cdr-checkbox-text-compact;
+    @include checkbox-text-compact;
   }
 
   &--hide-figure {
@@ -187,11 +187,11 @@
 
   /* Sizes
     ========================================================================== */
-  @include cdr-checkbox-small-mixin(&);
+  @include checkbox-small-mixin(&);
 
-  @include cdr-checkbox-medium-mixin(&);
+  @include checkbox-medium-mixin(&);
 
-  @include cdr-checkbox-large-mixin(&);
+  @include checkbox-large-mixin(&);
 
   /* Breakpoint variants
 
@@ -199,33 +199,33 @@
     0px - 767px
     ========== */
   @include xs-mq-only {
-    @include cdr-checkbox-small-mixin(&, \@xs);
+    @include checkbox-small-mixin(&, \@xs);
 
-    @include cdr-checkbox-medium-mixin(&, \@xs);
+    @include checkbox-medium-mixin(&, \@xs);
 
-    @include cdr-checkbox-large-mixin(&, \@xs);
+    @include checkbox-large-mixin(&, \@xs);
   }
 
   /* @sm
     768px - 991px
     ========== */
   @include sm-mq-only {
-    @include cdr-checkbox-small-mixin(&, \@sm);
+    @include checkbox-small-mixin(&, \@sm);
 
-    @include cdr-checkbox-medium-mixin(&, \@sm);
+    @include checkbox-medium-mixin(&, \@sm);
 
-    @include cdr-checkbox-large-mixin(&, \@sm);
+    @include checkbox-large-mixin(&, \@sm);
   }
 
   /* @md
     992px - 1199px
     ========== */
   @include md-mq-only {
-    @include cdr-checkbox-small-mixin(&, \@md);
+    @include checkbox-small-mixin(&, \@md);
 
-    @include cdr-checkbox-medium-mixin(&, \@md);
+    @include checkbox-medium-mixin(&, \@md);
 
-    @include cdr-checkbox-large-mixin(&, \@md);
+    @include checkbox-large-mixin(&, \@md);
   }
 
   /* @lg
@@ -233,11 +233,11 @@
     ========== */
 
   @include lg-mq-only {
-    @include cdr-checkbox-small-mixin(&, \@lg);
+    @include checkbox-small-mixin(&, \@lg);
 
-    @include cdr-checkbox-medium-mixin(&, \@lg);
+    @include checkbox-medium-mixin(&, \@lg);
 
-    @include cdr-checkbox-large-mixin(&, \@lg);
+    @include checkbox-large-mixin(&, \@lg);
   }
 
 }

--- a/src/components/checkbox/styles/CdrCheckbox.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.scss
@@ -20,8 +20,7 @@
 @import '../../../css/settings/index.scss';
 @import './vars/CdrCheckbox.vars.scss';
 .cdr-checkbox {
-  @include cdr-label-base-mixin;
-
+  @include cdr-checkbox-text;
   position: relative;
   padding-left: calc(#{$checkbox-figure-size-medium} + #{$cdr-label-base-spacing});
 
@@ -49,7 +48,6 @@
   &__figure {
     position: absolute;
     top: $checkbox-figure-space-top;
-    transform: translateY(-50%); // center it automatically
     left: 0;
     width: $checkbox-figure-size-medium;
     height: $checkbox-figure-size-medium;
@@ -176,7 +174,7 @@
 
   // TODO: remove compact?
   &--compact {
-    @include cdr-label-compact-mixin;
+    @include cdr-checkbox-text-compact;
   }
 
   &--hide-figure {

--- a/src/components/checkbox/styles/vars/CdrCheckbox.vars.scss
+++ b/src/components/checkbox/styles/vars/CdrCheckbox.vars.scss
@@ -1,11 +1,11 @@
-@mixin cdr-checkbox-text {
+@mixin checkbox-text {
   @include cdr-text-utility-300;
   color: $cdr-color-text-form-label-lightmode;
   display: inline-block;
   margin: 0;
 }
 
-@mixin cdr-checkbox-text-compact {
+@mixin checkbox-text-compact {
   @include cdr-text-utility-200;
 }
 
@@ -35,7 +35,7 @@ $checkbox-compact-figure-space-top: 2px;
 $checkbox-figure-checked-hover-background-color: #2b6692;
 $checkbox-focus-outline: 0 0 8px 0 rgb(50, 120, 174);
 
-@mixin cdr-checkbox-small-mixin($parent-selector, $breakpoint: '') {
+@mixin checkbox-small-mixin($parent-selector, $breakpoint: '') {
   &--small#{$breakpoint} {
     @include cdr-text-utility-200;
     padding-left: calc(#{$checkbox-figure-size-small} + #{$cdr-label-base-spacing});
@@ -48,7 +48,7 @@ $checkbox-focus-outline: 0 0 8px 0 rgb(50, 120, 174);
   }
 }
 
-@mixin cdr-checkbox-medium-mixin($parent-selector, $breakpoint: '') {
+@mixin checkbox-medium-mixin($parent-selector, $breakpoint: '') {
   &--medium#{$breakpoint} {
     @include cdr-text-utility-300;
     padding-left: calc(#{$checkbox-figure-size-medium} + #{$cdr-label-base-spacing});
@@ -61,7 +61,7 @@ $checkbox-focus-outline: 0 0 8px 0 rgb(50, 120, 174);
   }
 }
 
-@mixin cdr-checkbox-large-mixin($parent-selector, $breakpoint: '') {
+@mixin checkbox-large-mixin($parent-selector, $breakpoint: '') {
   &--large#{$breakpoint} {
     @include cdr-text-utility-300;
     padding-left: calc(#{$checkbox-figure-size-large} + #{$cdr-label-base-spacing});

--- a/src/components/checkbox/styles/vars/CdrCheckbox.vars.scss
+++ b/src/components/checkbox/styles/vars/CdrCheckbox.vars.scss
@@ -1,11 +1,13 @@
-$checkbox-figure-size: 16px;
+$checkbox-figure-size-small: 16px;
+$checkbox-figure-size-medium: 16px;
+$checkbox-figure-size-large: 20px;
 $checkbox-figure-border-color: #616161;
 $checkbox-figure-indeterminate-border-radius: $cdr-radius-soft;
 $checkbox-figure-background-color: #ffffff;
 $checkbox-figure-checked-border-color: #3278ae;
 $checkbox-figure-checked-background-color: #3278ae;
 $checkbox-figure-active-border-color: #3278ae;
-$checkbox-figure-space-top: 4px;
+$checkbox-figure-space-top: 50%;
 $checkbox-figure-checked-disabled-background-color: #dadada;
 $checkbox-figure-radius: $cdr-radius-softer;
 $checkbox-figure-indeterminate-size: 8px;
@@ -21,3 +23,39 @@ $checkbox-figure-icon-fill: #ffffff;
 $checkbox-compact-figure-space-top: 2px;
 $checkbox-figure-checked-hover-background-color: #2b6692;
 $checkbox-focus-outline: 0 0 8px 0 rgb(50, 120, 174);
+
+@mixin cdr-checkbox-small-mixin($parent-selector, $breakpoint: '') {
+  &--small#{$breakpoint} {
+    @include cdr-text-utility-200;
+    padding-left: calc(#{$checkbox-figure-size-small} + #{$cdr-label-base-spacing});
+    
+    & > #{$parent-selector}__figure {
+      width: $checkbox-figure-size-small;
+      height: $checkbox-figure-size-small;
+    }
+  }
+}
+
+@mixin cdr-checkbox-medium-mixin($parent-selector, $breakpoint: '') {
+  &--medium#{$breakpoint} {
+    @include cdr-text-utility-300;
+    padding-left: calc(#{$checkbox-figure-size-medium} + #{$cdr-label-base-spacing});
+
+    & > #{$parent-selector}__figure {
+      width: $checkbox-figure-size-medium;
+      height: $checkbox-figure-size-medium;
+    }
+  }
+}
+
+@mixin cdr-checkbox-large-mixin($parent-selector, $breakpoint: '') {
+  &--large#{$breakpoint} {
+    @include cdr-text-utility-300;
+      padding-left: calc(#{$checkbox-figure-size-large} + #{$cdr-label-base-spacing});
+
+    & > #{$parent-selector}__figure {
+      width: $checkbox-figure-size-large;
+      height: $checkbox-figure-size-large;
+    }
+  }
+}

--- a/src/components/checkbox/styles/vars/CdrCheckbox.vars.scss
+++ b/src/components/checkbox/styles/vars/CdrCheckbox.vars.scss
@@ -1,3 +1,14 @@
+@mixin cdr-checkbox-text {
+  @include cdr-text-utility-300;
+  color: $cdr-color-text-form-label-lightmode;
+  display: inline-block;
+  margin: 0;
+}
+
+@mixin cdr-checkbox-text-compact {
+  @include cdr-text-utility-200;
+}
+
 $checkbox-figure-size-small: 16px;
 $checkbox-figure-size-medium: 16px;
 $checkbox-figure-size-large: 20px;
@@ -7,7 +18,7 @@ $checkbox-figure-background-color: #ffffff;
 $checkbox-figure-checked-border-color: #3278ae;
 $checkbox-figure-checked-background-color: #3278ae;
 $checkbox-figure-active-border-color: #3278ae;
-$checkbox-figure-space-top: 50%;
+$checkbox-figure-space-top: calc((#{$cdr-text-utility-300-height} - #{$checkbox-figure-size-medium}) / 2);
 $checkbox-figure-checked-disabled-background-color: #dadada;
 $checkbox-figure-radius: $cdr-radius-softer;
 $checkbox-figure-indeterminate-size: 8px;
@@ -30,6 +41,7 @@ $checkbox-focus-outline: 0 0 8px 0 rgb(50, 120, 174);
     padding-left: calc(#{$checkbox-figure-size-small} + #{$cdr-label-base-spacing});
     
     & > #{$parent-selector}__figure {
+      top: calc((#{$cdr-text-utility-200-height} - #{$checkbox-figure-size-small}) / 2);
       width: $checkbox-figure-size-small;
       height: $checkbox-figure-size-small;
     }
@@ -40,8 +52,9 @@ $checkbox-focus-outline: 0 0 8px 0 rgb(50, 120, 174);
   &--medium#{$breakpoint} {
     @include cdr-text-utility-300;
     padding-left: calc(#{$checkbox-figure-size-medium} + #{$cdr-label-base-spacing});
-
+    
     & > #{$parent-selector}__figure {
+      top: calc((#{$cdr-text-utility-300-height} - #{$checkbox-figure-size-medium}) / 2);
       width: $checkbox-figure-size-medium;
       height: $checkbox-figure-size-medium;
     }
@@ -51,9 +64,10 @@ $checkbox-focus-outline: 0 0 8px 0 rgb(50, 120, 174);
 @mixin cdr-checkbox-large-mixin($parent-selector, $breakpoint: '') {
   &--large#{$breakpoint} {
     @include cdr-text-utility-300;
-      padding-left: calc(#{$checkbox-figure-size-large} + #{$cdr-label-base-spacing});
-
+    padding-left: calc(#{$checkbox-figure-size-large} + #{$cdr-label-base-spacing});
+    
     & > #{$parent-selector}__figure {
+      top: calc((#{$cdr-text-utility-300-height} - #{$checkbox-figure-size-large}) / 2);
       width: $checkbox-figure-size-large;
       height: $checkbox-figure-size-large;
     }

--- a/src/components/cta/CdrCta.jsx
+++ b/src/components/cta/CdrCta.jsx
@@ -47,6 +47,7 @@ export default {
   render() {
     return (<a
       class={clsx(
+        this.style[this.baseClass],
         this.modifierClass,
         this.ctaClass,
         this.fullWidthClass,

--- a/src/components/dataTable/CdrDataTable.jsx
+++ b/src/components/dataTable/CdrDataTable.jsx
@@ -151,6 +151,7 @@ export default {
     return (
       <div
         class={clsx(
+          this.style[this.baseClass],
           this.modifierClass,
           this.space,
         )}

--- a/src/components/icon/CdrIcon.jsx
+++ b/src/components/icon/CdrIcon.jsx
@@ -52,7 +52,12 @@ export default {
     return (<svg
       {...slotDataObj}
       {...defaultDataObj}
-      class={clsx(this.sizeClass, this.inheritColorClass, this.space)}
+      class={clsx(
+        this.style[this.baseClass],
+        this.sizeClass,
+        this.inheritColorClass,
+        this.space,
+      )}
     >
       {this.$slots.default}
       {this.use ? <use

--- a/src/components/icon/__tests__/__snapshots__/CdrIcon.spec.js.snap
+++ b/src/components/icon/__tests__/__snapshots__/CdrIcon.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrIcon accepts full SVG in slot 1`] = `
 <svg
-  class="my-custom-class cdr-icon "
+  class="my-custom-class cdr-icon"
   data-test="testing"
   role="presentation"
   viewBox="0 0 24 24"
@@ -16,7 +16,7 @@ exports[`CdrIcon accepts full SVG in slot 1`] = `
 
 exports[`CdrIcon renders correctly 1`] = `
 <svg
-  class="cdr-icon "
+  class="cdr-icon"
   role="presentation"
   viewBox="0 0 24 24"
   xmlns="http://www.w3.org/2000/svg"

--- a/src/components/image/CdrImg.jsx
+++ b/src/components/image/CdrImg.jsx
@@ -173,6 +173,7 @@ export default {
             class={clsx(
               this.style['cdr-media-frame__image'],
               this.style['cdr-media-frame__image--hidden'],
+              this.style[this.baseClass],
               this.modifierClass,
               this.radiusClass,
             )}
@@ -183,7 +184,10 @@ export default {
       );
     }
     return (<img
-          class={clsx(this.modifierClass, this.radiusClass, this.lazyClass)}
+          class={clsx(this.style[this.baseClass],
+            this.modifierClass,
+            this.radiusClass,
+            this.lazyClass)}
           src={this.src}
           alt={this.alt}
           {...{ attrs: this.lazyAttrs }}

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -125,7 +125,6 @@ export default {
           <textarea
             rows={this.rows}
             class={clsx(
-              this.style[this.baseClass],
               this.inputClass,
               this.sizeClass,
               this.space,
@@ -143,10 +142,11 @@ export default {
       return (
           <input
             type={this.type}
-            class={clsx(this.style[this.baseClass],
+            class={clsx(
               this.inputClass,
               this.sizeClass,
-              this.space,)}
+              this.space,
+            )}
             id={this.inputId}
             disabled={this.disabled}
             required={this.required}

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -124,7 +124,12 @@ export default {
         return (
           <textarea
             rows={this.rows}
-            class={clsx(this.inputClass, this.sizeClass, this.space)}
+            class={clsx(
+              this.style[this.baseClass],
+              this.inputClass,
+              this.sizeClass,
+              this.space,
+            )}
             id={this.inputId}
             disabled={this.disabled}
             required={this.required}
@@ -138,7 +143,10 @@ export default {
       return (
           <input
             type={this.type}
-            class={clsx(this.inputClass, this.sizeClass, this.space)}
+            class={clsx(this.style[this.baseClass],
+              this.inputClass,
+              this.sizeClass,
+              this.space,)}
             id={this.inputId}
             disabled={this.disabled}
             required={this.required}

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -12,7 +12,7 @@ exports[`CdrInput renders a label element 1`] = `
     class="cdr-input-wrap"
   >
     <input
-      class="cdr-input cdr-input "
+      class="cdr-input"
       id="1"
       type="text"
     />
@@ -37,7 +37,7 @@ exports[`CdrInput renders required label correctly 1`] = `
     class="cdr-input-wrap"
   >
     <input
-      class="cdr-input cdr-input "
+      class="cdr-input"
       id="3"
       required="required"
       type="text"

--- a/src/components/link/CdrLink.jsx
+++ b/src/components/link/CdrLink.jsx
@@ -43,6 +43,7 @@ export default {
     const Component = this.tag;
     return (<Component
       class={clsx(
+        this.style[this.baseClass],
         this.modifierClass,
         this.space,
       )}

--- a/src/components/list/CdrList.jsx
+++ b/src/components/list/CdrList.jsx
@@ -35,6 +35,7 @@ export default {
     const Component = this.tag;
     return (<Component
       class={clsx(
+        this.style[this.baseClass],
         this.modifierClass,
         this.space,
         this.contentPriorityClass,

--- a/src/components/list/__tests__/__snapshots__/CdrList.spec.js.snap
+++ b/src/components/list/__tests__/__snapshots__/CdrList.spec.js.snap
@@ -2,12 +2,12 @@
 
 exports[`CdrList renders an ol 1`] = `
 <ol
-  class="cdr-list cdr-list "
+  class="cdr-list"
 />
 `;
 
 exports[`CdrList renders correctly 1`] = `
 <ul
-  class="cdr-list cdr-list "
+  class="cdr-list"
 />
 `;

--- a/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
@@ -14,7 +14,7 @@ exports[`CdrPagination renders correctly 1`] = `
         class="cdr-pagination__link cdr-pagination__prev cdr-pagination__link--disabled"
       >
         <svg
-          class="cdr-icon  cdr-icon--inherit-color cdr-pagination__caret--prev"
+          class="cdr-icon cdr-icon--inherit-color cdr-pagination__caret--prev"
           role="presentation"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -119,7 +119,7 @@ exports[`CdrPagination renders correctly 1`] = `
         >
           <select
             aria-label="Navigate to page"
-            class="cdr-select  cdr-select"
+            class="cdr-select"
             id="select-test1"
           >
             <option
@@ -154,7 +154,7 @@ exports[`CdrPagination renders correctly 1`] = `
             </option>
           </select>
           <svg
-            class="cdr-icon  cdr-select__caret"
+            class="cdr-icon cdr-select__caret"
             role="presentation"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -175,7 +175,7 @@ exports[`CdrPagination renders correctly 1`] = `
       >
         Next
         <svg
-          class="cdr-icon  cdr-pagination__caret--next"
+          class="cdr-icon cdr-pagination__caret--next"
           role="presentation"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -204,7 +204,7 @@ exports[`CdrPagination renders scoped slot correctly 1`] = `
         ref="prev-link-test2"
       >
         <svg
-          class="cdr-icon  cdr-pagination__caret--prev"
+          class="cdr-icon cdr-pagination__caret--prev"
           role="presentation"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
@@ -303,7 +303,7 @@ exports[`CdrPagination renders scoped slot correctly 1`] = `
         >
           <select
             aria-label="Navigate to page"
-            class="cdr-select  cdr-select"
+            class="cdr-select"
             id="select-test2"
           >
             <option
@@ -338,7 +338,7 @@ exports[`CdrPagination renders scoped slot correctly 1`] = `
             </option>
           </select>
           <svg
-            class="cdr-icon  cdr-select__caret"
+            class="cdr-icon cdr-select__caret"
             role="presentation"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -358,7 +358,7 @@ exports[`CdrPagination renders scoped slot correctly 1`] = `
       >
         Next
         <svg
-          class="cdr-icon  cdr-pagination__caret--next"
+          class="cdr-icon cdr-pagination__caret--next"
           role="presentation"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/quote/CdrQuote.jsx
+++ b/src/components/quote/CdrQuote.jsx
@@ -55,7 +55,7 @@ export default {
   render() {
     const Component = this.tag;
     return (<Component
-      class={clsx(this.modifierClass, this.space)}
+      class={clsx(this.style[this.baseClass], this.modifierClass, this.space)}
     >
       {this.summaryBlock}
       {this.$slots.default}

--- a/src/components/radio/CdrRadio.backstop.js
+++ b/src/components/radio/CdrRadio.backstop.js
@@ -3,6 +3,10 @@ module.exports = [
     url: 'http://localhost:3000/#/radios',
     label: 'Radio responsive',
     responsive: true,
+    selectors: [
+      'document',
+      '[data-backstop="radio-responsive"]',
+    ],
   },
   {
     url: 'http://localhost:3000/#/radios',

--- a/src/components/radio/CdrRadio.jsx
+++ b/src/components/radio/CdrRadio.jsx
@@ -79,7 +79,12 @@ export default {
     return (
       <div class={clsx(this.space, this.style['cdr-radio__wrap'])}>
         <label
-          class={clsx(this.style[this.baseClass], this.modifierClass, this.labelClass, this.sizeClass)}
+          class={clsx(
+            this.style[this.baseClass],
+            this.modifierClass,
+            this.labelClass,
+            this.sizeClass,
+          )}
           ref="label"
         >
           <input

--- a/src/components/radio/CdrRadio.jsx
+++ b/src/components/radio/CdrRadio.jsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx';
 import modifier from '../../mixins/modifier';
 import space from '../../mixins/space';
+import size from '../../mixins/size';
 import style from './styles/CdrRadio.scss';
 
 export default {
   name: 'CdrRadio',
-  mixins: [modifier, space],
+  mixins: [modifier, space, size],
   inheritAttrs: false,
   props: {
     /**
@@ -78,7 +79,7 @@ export default {
     return (
       <div class={clsx(this.space, this.style['cdr-radio__wrap'])}>
         <label
-          class={clsx(this.modifierClass, this.labelClass)}
+          class={clsx(this.modifierClass, this.labelClass, this.sizeClass)}
           ref="label"
         >
           <input

--- a/src/components/radio/CdrRadio.jsx
+++ b/src/components/radio/CdrRadio.jsx
@@ -79,7 +79,7 @@ export default {
     return (
       <div class={clsx(this.space, this.style['cdr-radio__wrap'])}>
         <label
-          class={clsx(this.modifierClass, this.labelClass, this.sizeClass)}
+          class={clsx(this.style[this.baseClass], this.modifierClass, this.labelClass, this.sizeClass)}
           ref="label"
         >
           <input

--- a/src/components/radio/__tests__/__snapshots__/CdrRadio.spec.js.snap
+++ b/src/components/radio/__tests__/__snapshots__/CdrRadio.spec.js.snap
@@ -5,7 +5,7 @@ exports[`CdrRadio renders an input 1`] = `
   class="cdr-radio__wrap"
 >
   <label
-    class="cdr-radio cdr-radio cdr-radio--medium"
+    class="cdr-radio cdr-radio--medium"
   >
     <input
       class="cdr-radio__input"

--- a/src/components/radio/__tests__/__snapshots__/CdrRadio.spec.js.snap
+++ b/src/components/radio/__tests__/__snapshots__/CdrRadio.spec.js.snap
@@ -5,7 +5,7 @@ exports[`CdrRadio renders an input 1`] = `
   class="cdr-radio__wrap"
 >
   <label
-    class="cdr-radio"
+    class="cdr-radio cdr-radio cdr-radio--medium"
   >
     <input
       class="cdr-radio__input"

--- a/src/components/radio/examples/Radios.vue
+++ b/src/components/radio/examples/Radios.vue
@@ -11,6 +11,36 @@
         id="test1"
         name="example"
         custom-value="a1"
+        v-model="size"
+        size="small"
+      >small</cdr-radio>
+      <cdr-radio
+        name="example"
+        custom-value="a2"
+        v-model="size"
+        size="medium"
+      >medium</cdr-radio>
+      <cdr-radio
+        name="example"
+        :custom-value="{val:'a3'}"
+        v-model="size"
+        size="large"
+      >large</cdr-radio>
+      <div data-backstop="radio-responsive">
+        <cdr-radio
+          name="example"
+          custom-value="a4"
+          v-model="size"
+          size="small@lg medium@sm large@xs"
+        >responsive</cdr-radio>
+      </div>
+      <cdr-text>Group A Picked: {{ ex1 }}</cdr-text>
+    </div>
+    <div data-backstop="radio-focus">
+      <cdr-radio
+        id="test1"
+        name="example"
+        custom-value="a1"
         v-model="ex1"
       >A1</cdr-radio>
       <cdr-radio
@@ -163,6 +193,7 @@ export default {
   components: Components,
   data() {
     return {
+      size: '',
       ex1: '',
       ex1compact: '',
       ex1spacing: '',

--- a/src/components/radio/examples/Radios.vue
+++ b/src/components/radio/examples/Radios.vue
@@ -8,7 +8,6 @@
     </cdr-text>
     <div data-backstop="radio-focus">
       <cdr-radio
-        id="test1"
         name="example"
         custom-value="a1"
         v-model="size"

--- a/src/components/radio/styles/CdrRadio.scss
+++ b/src/components/radio/styles/CdrRadio.scss
@@ -21,10 +21,10 @@
 ========================================================================== */
 
 .cdr-radio {
-  @include cdr-label-base-mixin;
+  @include radio-text;
 
   position: relative;
-  padding-left: calc(#{$radio-figure-size} + #{$cdr-label-base-spacing});
+  padding-left: calc(#{$radio-figure-size-medium} + #{$cdr-label-base-spacing});
 
   /* Elements
     ========================================================================== */
@@ -34,6 +34,7 @@
   &__wrap {
     /* get rid of inline-block whitespace from label element */
     font-size: 0;
+    line-height: 1;
   }
 
   /* Input
@@ -51,8 +52,8 @@
     position: absolute;
     top: $radio-figure-space-top;
     left: 0;
-    width: $radio-figure-size;
-    height: $radio-figure-size;
+    width: $radio-figure-size-medium;
+    height: $radio-figure-size-medium;
     border-radius: $radio-figure-radius;
     background-color: $radio-figure-background-color;
     border: 1px solid $radio-figure-border-color;
@@ -152,7 +153,7 @@
     ========== */
 
   &--compact {
-    @include cdr-label-compact-mixin;
+    @include radio-text-compact;
 
     & > .cdr-radio__figure {
       top: $radio-compact-figure-space-top;
@@ -169,4 +170,59 @@
       display: none;
     }
   }
+
+  /* Sizes
+    ========================================================================== */
+    @include radio-small-mixin(&);
+
+    @include radio-medium-mixin(&);
+  
+    @include radio-large-mixin(&);
+  
+    /* Breakpoint variants
+  
+    /* @xs
+      0px - 767px
+      ========== */
+    @include xs-mq-only {
+      @include radio-small-mixin(&, \@xs);
+  
+      @include radio-medium-mixin(&, \@xs);
+  
+      @include radio-large-mixin(&, \@xs);
+    }
+  
+    /* @sm
+      768px - 991px
+      ========== */
+    @include sm-mq-only {
+      @include radio-small-mixin(&, \@sm);
+  
+      @include radio-medium-mixin(&, \@sm);
+  
+      @include radio-large-mixin(&, \@sm);
+    }
+  
+    /* @md
+      992px - 1199px
+      ========== */
+    @include md-mq-only {
+      @include radio-small-mixin(&, \@md);
+  
+      @include radio-medium-mixin(&, \@md);
+  
+      @include radio-large-mixin(&, \@md);
+    }
+  
+    /* @lg
+      1200px and up
+      ========== */
+  
+    @include lg-mq-only {
+      @include radio-small-mixin(&, \@lg);
+  
+      @include radio-medium-mixin(&, \@lg);
+  
+      @include radio-large-mixin(&, \@lg);
+    }
 }

--- a/src/components/radio/styles/vars/CdrRadio.vars.scss
+++ b/src/components/radio/styles/vars/CdrRadio.vars.scss
@@ -1,3 +1,14 @@
+@mixin radio-text {
+  @include cdr-text-utility-300;
+  color: $cdr-color-text-form-label-lightmode;
+  display: inline-block;
+  margin: 0;
+}
+
+@mixin radio-text-compact {
+  @include cdr-text-utility-200;
+}
+
 $radio-figure-checked-background-color: #3278ae;
 $radio-compact-figure-space-top: 2px;
 $radio-figure-radius: $cdr-radius-round;
@@ -8,12 +19,59 @@ $radio-figure-checked-hover-border-color: #2b6692;
 $radio-figure-active-border-color: #3278ae;
 $radio-figure-checked-hover-background-color: #2b6692;
 $radio-figure-space-top: 4px;
-$radio-figure-size: 16px;
+$radio-figure-size-small: 16px;
+$radio-figure-size-medium: 16px;
+$radio-figure-size-large: 20px;
 $radio-figure-checked-disabled-background-color: #dadada;
 $radio-figure-border-color: #616161;
 $radio-figure-background-color: #ffffff;
 $radio-focus-outline: 0 0 8px 0 rgb(50, 120, 174);
 $radio-figure-disabled-border-color: #dadada;
 $radio-figure-selected-size: 8px;
+$radio-figure-selected-size-large: 10px;
 $radio-figure-disabled-background-color: #fafafa;
 $radio-figure-checked-border-color: #3278ae;
+
+@mixin radio-small-mixin($parent-selector, $breakpoint: '') {
+  &--small#{$breakpoint} {
+    @include cdr-text-utility-200;
+    padding-left: calc(#{$radio-figure-size-small} + #{$cdr-label-base-spacing});
+    
+    & > #{$parent-selector}__figure {
+      top: calc((#{$cdr-text-utility-200-height} - #{$radio-figure-size-small}) / 2);
+      width: $radio-figure-size-small;
+      height: $radio-figure-size-small;
+    }
+  }
+}
+
+@mixin radio-medium-mixin($parent-selector, $breakpoint: '') {
+  &--medium#{$breakpoint} {
+    @include cdr-text-utility-300;
+    padding-left: calc(#{$radio-figure-size-medium} + #{$cdr-label-base-spacing});
+    
+    & > #{$parent-selector}__figure {
+      top: calc((#{$cdr-text-utility-300-height} - #{$radio-figure-size-medium}) / 2);
+      width: $radio-figure-size-medium;
+      height: $radio-figure-size-medium;
+    }
+  }
+}
+
+@mixin radio-large-mixin($parent-selector, $breakpoint: '') {
+  &--large#{$breakpoint} {
+    @include cdr-text-utility-300;
+    padding-left: calc(#{$radio-figure-size-large} + #{$cdr-label-base-spacing});
+    
+    & > #{$parent-selector}__figure {
+      top: calc((#{$cdr-text-utility-300-height} - #{$radio-figure-size-large}) / 2);
+      width: $radio-figure-size-large;
+      height: $radio-figure-size-large;
+
+      &::after {
+        width: $radio-figure-selected-size-large;
+        height: $radio-figure-selected-size-large;
+      }
+    }
+  }
+}

--- a/src/components/rating/CdrRating.jsx
+++ b/src/components/rating/CdrRating.jsx
@@ -96,6 +96,7 @@ export default {
       <Component
         href={this.href}
         class={clsx(
+          this.style[this.baseClass],
           this.contentPriorityClass,
           this.sizeClass,
           this.space,

--- a/src/components/rating/__tests__/__snapshots__/CdrRating.spec.js.snap
+++ b/src/components/rating/__tests__/__snapshots__/CdrRating.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrRating renders correctly 1`] = `
 <div
-  class="cdr-rating cdr-rating--primary cdr-rating "
+  class="cdr-rating cdr-rating--primary"
 >
   <div
     class="cdr-rating__background"

--- a/src/components/select/CdrSelect.jsx
+++ b/src/components/select/CdrSelect.jsx
@@ -132,7 +132,7 @@ export default {
     selectEl() {
       return (
         <select
-          class={clsx(this.sizeClass, this.selectClass)}
+          class={clsx(this.style[this.baseClass], this.sizeClass, this.selectClass)}
           id={this.selectId}
           multiple={this.multiple}
           disabled={this.disabled}

--- a/src/components/select/CdrSelect.jsx
+++ b/src/components/select/CdrSelect.jsx
@@ -132,7 +132,7 @@ export default {
     selectEl() {
       return (
         <select
-          class={clsx(this.style[this.baseClass], this.sizeClass, this.selectClass)}
+          class={clsx(this.sizeClass, this.selectClass)}
           id={this.selectId}
           multiple={this.multiple}
           disabled={this.disabled}

--- a/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
+++ b/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
@@ -14,11 +14,11 @@ exports[`cdrSelect renders correctly 1`] = `
     class="cdr-select-wrap"
   >
     <select
-      class="cdr-select  cdr-select cdr-select__prompt"
+      class="cdr-select cdr-select__prompt"
       id="renders"
     />
     <svg
-      class="cdr-icon  cdr-select__caret"
+      class="cdr-icon cdr-select__caret"
       role="presentation"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
@@ -45,7 +45,7 @@ exports[`cdrSelect renders helper-text slot 1`] = `
     class="cdr-select-wrap"
   >
     <select
-      class="cdr-select  cdr-select cdr-select__prompt"
+      class="cdr-select cdr-select__prompt"
       id="helper-text"
     />
     <icon-caret-down-stub
@@ -81,7 +81,7 @@ exports[`cdrSelect renders info slot 1`] = `
     class="cdr-select-wrap"
   >
     <select
-      class="cdr-select  cdr-select cdr-select__prompt"
+      class="cdr-select cdr-select__prompt"
       id="info-slot"
     />
     <icon-caret-down-stub
@@ -112,7 +112,7 @@ exports[`cdrSelect renders required label correctly 1`] = `
     class="cdr-select-wrap"
   >
     <select
-      class="cdr-select  cdr-select cdr-select__prompt"
+      class="cdr-select cdr-select__prompt"
       id="required-label"
       required="required"
     />

--- a/src/components/tabs/CdrTabPanel.jsx
+++ b/src/components/tabs/CdrTabPanel.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import modifier from '../../mixins/modifier';
 import style from './styles/CdrTabPanel.scss';
 
@@ -86,7 +87,7 @@ export default {
         <div
           v-show={this.active}
           aria-hidden={!this.active}
-          class={this.modifierClass}
+          class={clsx(this.style[this.baseClass], this.modifierClass)}
           ref="cdrTabPanelContainer"
           tabindex="0"
           role="tabpanel"

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -180,7 +180,7 @@ export default {
   render() {
     return (
       <div
-        class={this.modifierClass}
+        class={clsx(this.style[this.baseClass], this.modifierClass)}
         ref="cdrTabsContainer"
         style={{ height: this.height }}
       >

--- a/src/components/text/CdrText.jsx
+++ b/src/components/text/CdrText.jsx
@@ -25,7 +25,7 @@ export default {
   },
   render() {
     const Component = this.tag;
-    return (<Component class={clsx(this.modifierClass, this.space)}>
+    return (<Component class={clsx(this.baseClass, this.modifierClass, this.space)}>
       {this.$slots.default}
     </Component>);
   },

--- a/src/mixins/buildClass.js
+++ b/src/mixins/buildClass.js
@@ -24,10 +24,8 @@ export default {
       }
 
       if (!this.style) {
-        builtClasses.push(`${base}`);
         builtClasses = builtClasses.concat(propArgsArr.map(mod => this.modifyClassName(base, mod)));
       } else {
-        builtClasses.push(this.moduleClass(base));
         builtClasses = builtClasses.concat(propArgsArr.map(mod => this.modifyClassName(base, mod)));
       }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Checkbox and Radio now accept a size prop.

Other questions:
- Do we want to deprecate 'compact' (in favor of small)?
- I added mixins for the size variants that should make using them via component variables easier but they might be a bit too clever

I'll update radio/checkbox API to show they now support size once this is merged

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that are completed. -->

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- [x] Added/updated backstop tests
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
- [x] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [x] Examples created/updated
