### PR TITLE
fix(build): remove @import url statements from compiled CSS

### DIFF
--- a/build/noop.css
+++ b/build/noop.css
@@ -1,0 +1,1 @@
+/* intentionally empty */

--- a/build/rollup-plugins.js
+++ b/build/rollup-plugins.js
@@ -7,6 +7,7 @@ import postcss from 'rollup-plugin-postcss';
 import copyPlugin from 'rollup-plugin-copy';
 import vue from 'rollup-plugin-vue';
 import babel from 'rollup-plugin-babel';
+import postcssImport from 'postcss-import';
 import packageJson from '../package.json';
 
 const env = process.env.NODE_ENV;
@@ -74,7 +75,13 @@ const plugins = [
   }),
   postcss({
     config: true,
-    plugins: [],
+    plugins: [postcssImport({
+      // For cedar-compiled build, strip out `@import url()`
+      //           as dependencies will already be compiled.
+      resolve: function(id, basedir, importOptions)  {
+        return resolve('build/noop.css');
+      },
+    })],
     extract: postcssExtract,
     extensions: ['.scss', '.css'],
     sourceMap: env === 'dev' ? 'inline' : false,


### PR DESCRIPTION
this is a lil hacky but im not sure there is non hacky way to solve this but i am open to suggestions for alternative hacks 😆 

- we currently are using `@import url()` to handle loading CSS for cedar components that depend on other cedar components (for example, accordion uses icon: https://github.com/rei/rei-cedar/blob/548c3a0f675b29572ecba63cfc38e17424c01a24/src/components/accordion/styles/CdrAccordion.scss#L22)
- this can cause an issue if you are trying to use the `cedar-compiled.css` in an environment that is not set up to resolve those imports. (only popped up in component variables, doesn't seem to be an issue in the sandboxes or docs)
- however, because the cedar-compiled file has all of the cedar CSS in it, we don't have to worry about component dependencies and can just ignore the @import url statements inside cedar (which is what we are functionally doing by forcing all of those imports to load an empty file)