### PR TITLE
chore(examples): update heading modifiers in examples

### DIFF
--- a/src/components/Utilities/demos/align.vue
+++ b/src/components/Utilities/demos/align.vue
@@ -2,7 +2,7 @@
   <div data-backstop="align-utilities">
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Text alignment classes
     </cdr-text>
@@ -13,7 +13,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       left
     </cdr-text>
@@ -33,7 +33,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       center
     </cdr-text>
@@ -57,7 +57,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       right
     </cdr-text>
@@ -80,7 +80,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       justify
     </cdr-text>
@@ -103,7 +103,7 @@
 
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       center-block
     </cdr-text>

--- a/src/components/Utilities/demos/inset.vue
+++ b/src/components/Utilities/demos/inset.vue
@@ -2,7 +2,7 @@
   <div data-backstop="inset-space-utilities">
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Inset space classes for all around padding
     </cdr-text>

--- a/src/components/Utilities/demos/spacing.vue
+++ b/src/components/Utilities/demos/spacing.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Space classes
     </cdr-text>

--- a/src/components/Utilities/demos/visibility.vue
+++ b/src/components/Utilities/demos/visibility.vue
@@ -5,7 +5,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Visibility classes
     </cdr-text>

--- a/src/components/accordion/examples/Accordion.vue
+++ b/src/components/accordion/examples/Accordion.vue
@@ -2,7 +2,7 @@
   <div class="accordion-container">
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Accordion
     </cdr-text>
@@ -10,7 +10,7 @@
     <div class="accordion-group">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Default
       </cdr-text>
@@ -66,7 +66,7 @@
     <div class="accordion-group">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Border-Aligned and data driven
       </cdr-text>
@@ -90,7 +90,7 @@
     <div class="accordion-group">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Compact
       </cdr-text>

--- a/src/components/breadcrumb/examples/Breadcrumb.vue
+++ b/src/components/breadcrumb/examples/Breadcrumb.vue
@@ -5,7 +5,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Breadcrumb
     </cdr-text>

--- a/src/components/button/examples/Buttons.vue
+++ b/src/components/button/examples/Buttons.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Buttons
     </cdr-text>

--- a/src/components/button/examples/demo/Default.vue
+++ b/src/components/button/examples/demo/Default.vue
@@ -8,7 +8,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         {{ section.title }}
       </cdr-text>
@@ -31,7 +31,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Primary Anchor
       </cdr-text>
@@ -56,7 +56,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Primary Responsive
       </cdr-text>

--- a/src/components/button/examples/demo/Icons.vue
+++ b/src/components/button/examples/demo/Icons.vue
@@ -6,7 +6,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading-400"
+        modifier="heading--sans-400"
       >
         CdrButton + CdrIcon Comps
       </cdr-text>
@@ -77,7 +77,7 @@
     <div class="button-example cdr-space-inset-one-x">
       <cdr-text
         tag="h3"
-        modifier="heading-400"
+        modifier="heading--sans-400"
       >
         Using a sprite
       </cdr-text>
@@ -184,7 +184,7 @@
     <div class="button-example cdr-space-inset-one-x">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Icon only button
       </cdr-text>

--- a/src/components/button/examples/demo/Secondary.vue
+++ b/src/components/button/examples/demo/Secondary.vue
@@ -8,7 +8,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         {{ section.title }}
       </cdr-text>
@@ -27,7 +27,7 @@
     <div class="button-example cdr-space-inset-one-x">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Secondary Anchor
       </cdr-text>

--- a/src/components/caption/examples/Caption.vue
+++ b/src/components/caption/examples/Caption.vue
@@ -3,7 +3,7 @@
   <div data-backstop="caption">
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Caption
     </cdr-text>
@@ -15,7 +15,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading-300"
+      modifier="subheading--sans-300"
     >
       Summary only
     </cdr-text>
@@ -25,7 +25,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading-300"
+      modifier="subheading--sans-300"
     >
       Caption only
     </cdr-text>
@@ -35,7 +35,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading-300"
+      modifier="subheading--sans-300"
     >
       In a figure
     </cdr-text>

--- a/src/components/checkbox/examples/checkboxes.vue
+++ b/src/components/checkbox/examples/checkboxes.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Checkboxes
     </cdr-text>

--- a/src/components/cta/examples/Cta.vue
+++ b/src/components/cta/examples/Cta.vue
@@ -2,7 +2,7 @@
   <div data-backstop="cta-links">
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       CTA
     </cdr-text>

--- a/src/components/dataTable/examples/DataTable.vue
+++ b/src/components/dataTable/examples/DataTable.vue
@@ -2,7 +2,7 @@
   <div data-backstop="DataTable">
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Tables
     </cdr-text>

--- a/src/components/grid/examples/Grid.vue
+++ b/src/components/grid/examples/Grid.vue
@@ -4,7 +4,7 @@
     <div class="row-demo-wrapper">
       <cdr-text
         tag="h2"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         The Grid
       </cdr-text>
@@ -12,7 +12,7 @@
       <div data-backstop="row-basic">
         <cdr-text
           tag="h3"
-          modifier="heading-400 heading-500@md heading-500@lg"
+          modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
         >
           cdr-row usage
         </cdr-text>
@@ -873,7 +873,7 @@
 
         <cdr-text
           tag="h3"
-          modifier="heading-400 heading-500@md heading-500@lg"
+          modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
         >
           cdr-col usage
         </cdr-text>
@@ -2271,7 +2271,7 @@
       <div data-backstop="row-responsive">
         <cdr-text
           tag="h4"
-          modifier="heading-400 heading-500@md heading-500@lg"
+          modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
         >
           Mix and match responsive row classes
         </cdr-text>
@@ -2335,7 +2335,7 @@
 
       <cdr-text
         tag="h4"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         cdr-col responsive options
       </cdr-text>

--- a/src/components/icon/examples/Icons.vue
+++ b/src/components/icon/examples/Icons.vue
@@ -5,7 +5,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Icons
     </cdr-text>
@@ -30,7 +30,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Default icon size
     </cdr-text>

--- a/src/components/icon/examples/Icons.vue
+++ b/src/components/icon/examples/Icons.vue
@@ -54,7 +54,7 @@
         :key="key"
       >
         <div>
-          <div class="cdr-text-center">
+          <div class="cdr-align-text-center">
             <cdr-icon :use="`#${getSpriteId(key)}`" />
             <cdr-text>{{ getSpriteId(key) }}</cdr-text>
           </div>
@@ -73,7 +73,7 @@
         :key="key"
       >
         <div>
-          <div class="cdr-text-center">
+          <div class="cdr-align-text-center">
             <component :is="key" />
             <cdr-text>{{ getSpriteId(key) }}</cdr-text>
           </div>

--- a/src/components/image/examples/Images.vue
+++ b/src/components/image/examples/Images.vue
@@ -2,14 +2,14 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Images
     </cdr-text>
     <div data-backstop="image-aspect-ratio">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Aspect Ratios (with landscape images)
       </cdr-text>
@@ -28,7 +28,7 @@
     <div data-backstop="image-standard">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Standard image
       </cdr-text>

--- a/src/components/image/examples/demos/Cropping.vue
+++ b/src/components/image/examples/demos/Cropping.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h3"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Cropping (with landscape images)
     </cdr-text>
@@ -55,7 +55,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Cropping (with portrait images)
     </cdr-text>
@@ -108,7 +108,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Cropping (combinations)
     </cdr-text>

--- a/src/components/image/examples/demos/Mods.vue
+++ b/src/components/image/examples/demos/Mods.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h3"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Image modifiers
     </cdr-text>

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Text Inputs
     </cdr-text>

--- a/src/components/link/examples/Links.vue
+++ b/src/components/link/examples/Links.vue
@@ -6,7 +6,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Links
     </cdr-text>

--- a/src/components/link/examples/demo/Resilience.vue
+++ b/src/components/link/examples/demo/Resilience.vue
@@ -3,7 +3,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Resilience Tests
     </cdr-text>
@@ -109,7 +109,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading-500 heading-600@md heading-600@lg"
+      modifier="heading--serif-500 heading--serif-600@md heading--serif-600@lg"
     >
       Typography validation -
     </cdr-text>

--- a/src/components/link/examples/demo/Standard.vue
+++ b/src/components/link/examples/demo/Standard.vue
@@ -6,14 +6,14 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
     >
       Links
     </cdr-text>
 
     <cdr-text
       tag="h3"
-      modifier="subheading-300"
+      modifier="subheading--sans-300"
     >
       Default Link, No props
     </cdr-text>
@@ -25,7 +25,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading-300"
+      modifier="subheading--sans-300"
     >Link, href set, spacing class applied</cdr-text>
     <cdr-link
       href="https://www.rei.com/"
@@ -47,7 +47,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading-300"
+      modifier="subheading--sans-300"
     >Links, with icon</cdr-text>
 
     <cdr-list

--- a/src/components/list/examples/demo/Bare.vue
+++ b/src/components/list/examples/demo/Bare.vue
@@ -3,7 +3,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Bare list
     </cdr-text>
@@ -44,7 +44,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Compact bare list
     </cdr-text>
@@ -65,7 +65,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Inline bare list
     </cdr-text>
@@ -81,7 +81,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Inline compact bare list
     </cdr-text>

--- a/src/components/list/examples/demo/Ordered.vue
+++ b/src/components/list/examples/demo/Ordered.vue
@@ -3,7 +3,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Ordered list
     </cdr-text>
@@ -38,7 +38,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Compact ordered list
     </cdr-text>

--- a/src/components/list/examples/demo/Resilience.vue
+++ b/src/components/list/examples/demo/Resilience.vue
@@ -3,14 +3,14 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Resilience Tests
     </cdr-text>
 
     <cdr-text
       tag="h4"
-      modifier="heading-500 heading-600@md heading-600@lg"
+      modifier="heading--serif-500 heading--serif-600@md heading--serif-600@lg"
     >
       Typography validation - text wrapping lists
     </cdr-text>

--- a/src/components/list/examples/demo/Unordered.vue
+++ b/src/components/list/examples/demo/Unordered.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h3"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Unordered list
     </cdr-text>
@@ -28,7 +28,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Compact Unordered list
     </cdr-text>
@@ -49,7 +49,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Inline unordered list
     </cdr-text>
@@ -65,7 +65,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Inline compact unordered list
     </cdr-text>

--- a/src/components/modal/examples/Modal.vue
+++ b/src/components/modal/examples/Modal.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Modal
     </cdr-text>
@@ -20,7 +20,7 @@
       <template slot="title">
         <cdr-text
           tag="h1"
-          modifier="heading-600"
+          modifier="heading--serif-600"
         >
           Added to Cart (is a common label) and let's make this longer so it
         </cdr-text>
@@ -42,7 +42,7 @@
     </cdr-button>
 
     <cdr-text
-      modifier="heading-400"
+      modifier="heading--sans-400"
       class="cdr-pt-space-one-x"
     >
       Size
@@ -63,7 +63,7 @@
     </cdr-radio>
 
     <cdr-text
-      modifier="heading-400"
+      modifier="heading--sans-400"
       class="cdr-pt-space-one-x"
     >
       Content Length
@@ -84,7 +84,7 @@
     </cdr-radio>
 
     <cdr-text
-      modifier="heading-400"
+      modifier="heading--sans-400"
       class="cdr-pt-space-one-x"
     >
       Show Title

--- a/src/components/quote/examples/demo/Blockquotes.vue
+++ b/src/components/quote/examples/demo/Blockquotes.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Blockquote
     </cdr-text>

--- a/src/components/quote/examples/demo/Pullquotes.vue
+++ b/src/components/quote/examples/demo/Pullquotes.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Pullquote
     </cdr-text>

--- a/src/components/radio/examples/Radios.vue
+++ b/src/components/radio/examples/Radios.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Radios
     </cdr-text>

--- a/src/components/rating/examples/Ratings.vue
+++ b/src/components/rating/examples/Ratings.vue
@@ -4,7 +4,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading-600 heading-700@md heading-700@lg"
+      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
     >
       Ratings
     </cdr-text>

--- a/src/components/select/examples/Selects.vue
+++ b/src/components/select/examples/Selects.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading-400 heading-500@md heading-500@lg"
+      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       space="cdr-my-space-two-x"
     >
       Selects

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -4,7 +4,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h2"
-        modifier="heading-600 heading-700@md heading-700@lg"
+        modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
       >
         Tabs
       </cdr-text>
@@ -76,7 +76,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Compact Tabs
       </cdr-text>
@@ -127,7 +127,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Full Width Tabs
       </cdr-text>
@@ -211,7 +211,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         No Border Tabs
       </cdr-text>
@@ -278,7 +278,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h3"
-        modifier="heading-400 heading-500@md heading-500@lg"
+        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
       >
         Centered Tabs
       </cdr-text>


### PR DESCRIPTION
re-maps all the deprecated heading modifiers in the kitchen sink.
creating custom classes in kitchen sink for things like "example-header", "example-spacing", etc.  and mapping those to tokens might make it easier to manage this stuff in the future 💡 