### PR TITLE
fix(modal): ie11 close modal with Esc

### DIFF
--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -96,8 +96,6 @@ export default {
     handleKeyDown({ key }) {
       switch (key) {
         case 'Escape':
-          this.onClick();
-          break;
         case 'Esc':
           this.onClick();
           break;

--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -98,6 +98,9 @@ export default {
         case 'Escape':
           this.onClick();
           break;
+        case 'Esc':
+          this.onClick();
+          break;
         default: break;
       }
     },

--- a/src/components/modal/__tests__/CdrModal.spec.js
+++ b/src/components/modal/__tests__/CdrModal.spec.js
@@ -54,7 +54,7 @@ describe('CdrModal.vue', () => {
     expect(wrapper.vm.handleClosed).toHaveBeenCalled();
   });
 
-  it('handleKeyDown', () => {
+  it('handleKeyDown Escape', () => {
     const wrapper = shallowMount(CdrModal, {
       propsData: {
         opened: true,
@@ -71,6 +71,24 @@ describe('CdrModal.vue', () => {
 
     wrapper.trigger('keydown', {
       key: 'Escape',
+    });
+    expect(wrapper.vm.onClick).toHaveBeenCalled();
+
+    wrapper.destroy();
+  });
+
+  it('handleKeyDown Esc', () => {
+    const wrapper = shallowMount(CdrModal, {
+      propsData: {
+        opened: true,
+        label: "My Modal Label",
+      },
+      attachToDocument: true,
+    });
+    spyOn(wrapper.vm, 'onClick');
+
+    wrapper.trigger('keydown', {
+      key: 'Esc',
     });
     expect(wrapper.vm.onClick).toHaveBeenCalled();
 


### PR DESCRIPTION
fix CDR-1516

## Description
IE11 keyboard event fires 'Esc' instead of 'Escape'

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that are completed. -->

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [x] IE11
- [ ] iOS
- [ ] Android

### Visual regression testing:
- [ ] Added/updated backstop tests
- [ ] Passes with existing reference images (or failed as expected)

### Unit testing:
- [x] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [ ] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [ ] Examples created/updated
