### PR TITLE
refactor(text): remove BEM from text modifiers

### DIFF
--- a/src/components/Utilities/demos/align.vue
+++ b/src/components/Utilities/demos/align.vue
@@ -2,7 +2,7 @@
   <div data-backstop="align-utilities">
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Text alignment classes
     </cdr-text>
@@ -13,7 +13,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       left
     </cdr-text>
@@ -33,7 +33,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       center
     </cdr-text>
@@ -57,7 +57,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       right
     </cdr-text>
@@ -80,7 +80,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       justify
     </cdr-text>
@@ -103,7 +103,7 @@
 
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       center-block
     </cdr-text>

--- a/src/components/Utilities/demos/inset.vue
+++ b/src/components/Utilities/demos/inset.vue
@@ -2,7 +2,7 @@
   <div data-backstop="inset-space-utilities">
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Inset space classes for all around padding
     </cdr-text>

--- a/src/components/Utilities/demos/spacing.vue
+++ b/src/components/Utilities/demos/spacing.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Space classes
     </cdr-text>

--- a/src/components/Utilities/demos/visibility.vue
+++ b/src/components/Utilities/demos/visibility.vue
@@ -5,7 +5,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Visibility classes
     </cdr-text>

--- a/src/components/accordion/examples/Accordion.vue
+++ b/src/components/accordion/examples/Accordion.vue
@@ -2,7 +2,7 @@
   <div class="accordion-container">
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Accordion
     </cdr-text>
@@ -10,7 +10,7 @@
     <div class="accordion-group">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Default
       </cdr-text>
@@ -29,7 +29,7 @@
             This is some text. It's in a
             <cdr-text
               tag="strong"
-              modifier="body--strong-300"
+              modifier="body-strong-300"
             >cdr-text paragraph with a modifier of <code>body-300</code></cdr-text> element as
             thats how you assign the correct font and line-height for text dislpay on REI.
             does not include margin or add space to the container. Lorem ipsum dolor
@@ -66,7 +66,7 @@
     <div class="accordion-group">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Border-Aligned and data driven
       </cdr-text>
@@ -90,7 +90,7 @@
     <div class="accordion-group">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Compact
       </cdr-text>

--- a/src/components/breadcrumb/examples/Breadcrumb.vue
+++ b/src/components/breadcrumb/examples/Breadcrumb.vue
@@ -5,7 +5,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Breadcrumb
     </cdr-text>

--- a/src/components/button/examples/Buttons.vue
+++ b/src/components/button/examples/Buttons.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Buttons
     </cdr-text>

--- a/src/components/button/examples/demo/Default.vue
+++ b/src/components/button/examples/demo/Default.vue
@@ -8,7 +8,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         {{ section.title }}
       </cdr-text>
@@ -31,7 +31,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Primary Anchor
       </cdr-text>
@@ -56,7 +56,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Primary Responsive
       </cdr-text>

--- a/src/components/button/examples/demo/Icons.vue
+++ b/src/components/button/examples/demo/Icons.vue
@@ -6,7 +6,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400"
+        modifier="heading-sans-400"
       >
         CdrButton + CdrIcon Comps
       </cdr-text>
@@ -77,7 +77,7 @@
     <div class="button-example cdr-space-inset-one-x">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400"
+        modifier="heading-sans-400"
       >
         Using a sprite
       </cdr-text>
@@ -184,7 +184,7 @@
     <div class="button-example cdr-space-inset-one-x">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Icon only button
       </cdr-text>

--- a/src/components/button/examples/demo/Secondary.vue
+++ b/src/components/button/examples/demo/Secondary.vue
@@ -8,7 +8,7 @@
     >
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         {{ section.title }}
       </cdr-text>
@@ -27,7 +27,7 @@
     <div class="button-example cdr-space-inset-one-x">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Secondary Anchor
       </cdr-text>

--- a/src/components/caption/examples/Caption.vue
+++ b/src/components/caption/examples/Caption.vue
@@ -3,7 +3,7 @@
   <div data-backstop="caption">
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Caption
     </cdr-text>
@@ -15,7 +15,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading--sans-300"
+      modifier="subheading-sans-300"
     >
       Summary only
     </cdr-text>
@@ -25,7 +25,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading--sans-300"
+      modifier="subheading-sans-300"
     >
       Caption only
     </cdr-text>
@@ -35,7 +35,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading--sans-300"
+      modifier="subheading-sans-300"
     >
       In a figure
     </cdr-text>

--- a/src/components/checkbox/examples/checkboxes.vue
+++ b/src/components/checkbox/examples/checkboxes.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Checkboxes
     </cdr-text>

--- a/src/components/cta/examples/Cta.vue
+++ b/src/components/cta/examples/Cta.vue
@@ -2,7 +2,7 @@
   <div data-backstop="cta-links">
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       CTA
     </cdr-text>

--- a/src/components/dataTable/examples/DataTable.vue
+++ b/src/components/dataTable/examples/DataTable.vue
@@ -2,7 +2,7 @@
   <div data-backstop="DataTable">
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Tables
     </cdr-text>

--- a/src/components/grid/examples/Grid.vue
+++ b/src/components/grid/examples/Grid.vue
@@ -4,7 +4,7 @@
     <div class="row-demo-wrapper">
       <cdr-text
         tag="h2"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         The Grid
       </cdr-text>
@@ -12,7 +12,7 @@
       <div data-backstop="row-basic">
         <cdr-text
           tag="h3"
-          modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+          modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
         >
           cdr-row usage
         </cdr-text>
@@ -873,7 +873,7 @@
 
         <cdr-text
           tag="h3"
-          modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+          modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
         >
           cdr-col usage
         </cdr-text>
@@ -2271,7 +2271,7 @@
       <div data-backstop="row-responsive">
         <cdr-text
           tag="h4"
-          modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+          modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
         >
           Mix and match responsive row classes
         </cdr-text>
@@ -2335,7 +2335,7 @@
 
       <cdr-text
         tag="h4"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         cdr-col responsive options
       </cdr-text>

--- a/src/components/icon/examples/Icons.vue
+++ b/src/components/icon/examples/Icons.vue
@@ -5,7 +5,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Icons
     </cdr-text>
@@ -30,7 +30,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Default icon size
     </cdr-text>

--- a/src/components/image/examples/Images.vue
+++ b/src/components/image/examples/Images.vue
@@ -2,14 +2,14 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Images
     </cdr-text>
     <div data-backstop="image-aspect-ratio">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Aspect Ratios (with landscape images)
       </cdr-text>
@@ -28,7 +28,7 @@
     <div data-backstop="image-standard">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Standard image
       </cdr-text>

--- a/src/components/image/examples/demos/Cropping.vue
+++ b/src/components/image/examples/demos/Cropping.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h3"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Cropping (with landscape images)
     </cdr-text>
@@ -55,7 +55,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Cropping (with portrait images)
     </cdr-text>
@@ -108,7 +108,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Cropping (combinations)
     </cdr-text>

--- a/src/components/image/examples/demos/Mods.vue
+++ b/src/components/image/examples/demos/Mods.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h3"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Image modifiers
     </cdr-text>

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Text Inputs
     </cdr-text>

--- a/src/components/link/examples/Links.vue
+++ b/src/components/link/examples/Links.vue
@@ -6,7 +6,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Links
     </cdr-text>

--- a/src/components/link/examples/demo/Resilience.vue
+++ b/src/components/link/examples/demo/Resilience.vue
@@ -3,7 +3,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Resilience Tests
     </cdr-text>
@@ -109,7 +109,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-500 heading--serif-600@md heading--serif-600@lg"
+      modifier="heading-serif-500 heading-serif-600@md heading-serif-600@lg"
     >
       Typography validation -
     </cdr-text>
@@ -123,7 +123,7 @@
         item text
         <cdr-text
           tag="span"
-          :modifier="`body--strong-${p1}`"
+          :modifier="`body-strong-${p1}`"
         >
           sit amet,
         </cdr-text>
@@ -139,7 +139,7 @@
         item text
         <cdr-text
           tag="span"
-          :modifier="`utility--strong-${u1}`"
+          :modifier="`utility-strong-${u1}`"
         >
           sit amet,
         </cdr-text>
@@ -149,7 +149,7 @@
     <cdr-text
       v-for="u2 in utilities"
       :key="u2"
-      :modifier="`utility--strong-${u2}`"
+      :modifier="`utility-strong-${u2}`"
     >
       <cdr-link>
         <cdr-icon
@@ -177,7 +177,7 @@
           />
           <cdr-text
             tag="span"
-            :modifier="`utility--strong-${u1}`"
+            :modifier="`utility-strong-${u1}`"
           >
             Icon on the left
           </cdr-text>
@@ -191,7 +191,7 @@
         <cdr-link>
           <cdr-text
             tag="span"
-            :modifier="`utility--strong-${u1}`"
+            :modifier="`utility-strong-${u1}`"
           >
             Icon on the right
           </cdr-text>
@@ -217,7 +217,7 @@
           />
           <cdr-text
             tag="span"
-            :modifier="`utility--strong-${u1}`"
+            :modifier="`utility-strong-${u1}`"
           >
             Icons on both sides
           </cdr-text>

--- a/src/components/link/examples/demo/Standard.vue
+++ b/src/components/link/examples/demo/Standard.vue
@@ -6,14 +6,14 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
     >
       Links
     </cdr-text>
 
     <cdr-text
       tag="h3"
-      modifier="subheading--sans-300"
+      modifier="subheading-sans-300"
     >
       Default Link, No props
     </cdr-text>
@@ -25,7 +25,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading--sans-300"
+      modifier="subheading-sans-300"
     >Link, href set, spacing class applied</cdr-text>
     <cdr-link
       href="https://www.rei.com/"
@@ -47,7 +47,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="subheading--sans-300"
+      modifier="subheading-sans-300"
     >Links, with icon</cdr-text>
 
     <cdr-list

--- a/src/components/list/examples/demo/Bare.vue
+++ b/src/components/list/examples/demo/Bare.vue
@@ -3,7 +3,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Bare list
     </cdr-text>
@@ -44,7 +44,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Compact bare list
     </cdr-text>
@@ -65,7 +65,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Inline bare list
     </cdr-text>
@@ -81,7 +81,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Inline compact bare list
     </cdr-text>

--- a/src/components/list/examples/demo/Ordered.vue
+++ b/src/components/list/examples/demo/Ordered.vue
@@ -3,7 +3,7 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Ordered list
     </cdr-text>
@@ -38,7 +38,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Compact ordered list
     </cdr-text>

--- a/src/components/list/examples/demo/Resilience.vue
+++ b/src/components/list/examples/demo/Resilience.vue
@@ -3,14 +3,14 @@
 
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Resilience Tests
     </cdr-text>
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-500 heading--serif-600@md heading--serif-600@lg"
+      modifier="heading-serif-500 heading-serif-600@md heading-serif-600@lg"
     >
       Typography validation - text wrapping lists
     </cdr-text>
@@ -25,7 +25,7 @@
         <li>Lorem ipsum dolor
           <cdr-text
             tag="span"
-            :modifier="`body--strong-${p1}`"
+            :modifier="`body-strong-${p1}`"
           >
             sit amet,
           </cdr-text>

--- a/src/components/list/examples/demo/Unordered.vue
+++ b/src/components/list/examples/demo/Unordered.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h3"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Unordered list
     </cdr-text>
@@ -28,7 +28,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Compact Unordered list
     </cdr-text>
@@ -49,7 +49,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Inline unordered list
     </cdr-text>
@@ -65,7 +65,7 @@
 
     <cdr-text
       tag="h4"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Inline compact unordered list
     </cdr-text>

--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -269,7 +269,7 @@ export default {
                         this.showTitle && !this.$slots.title && (
                           <cdr-text
                             tag="h1"
-                            modifier="heading--serif-600"
+                            modifier="heading-serif-600"
                           >
                             {this.label}
                           </cdr-text>

--- a/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
+++ b/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
@@ -36,7 +36,7 @@ exports[`CdrModal.vue renders correctly 1`] = `
                 class="cdr-modal__title"
               >
                 <cdr-text-stub
-                  modifier="heading--serif-600"
+                  modifier="heading-serif-600"
                   space=""
                   tag="h1"
                 >

--- a/src/components/modal/examples/Modal.vue
+++ b/src/components/modal/examples/Modal.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Modal
     </cdr-text>
@@ -20,7 +20,7 @@
       <template slot="title">
         <cdr-text
           tag="h1"
-          modifier="heading--serif-600"
+          modifier="heading-serif-600"
         >
           Added to Cart (is a common label) and let's make this longer so it
         </cdr-text>
@@ -42,7 +42,7 @@
     </cdr-button>
 
     <cdr-text
-      modifier="heading--sans-400"
+      modifier="heading-sans-400"
       class="cdr-pt-space-one-x"
     >
       Size
@@ -63,7 +63,7 @@
     </cdr-radio>
 
     <cdr-text
-      modifier="heading--sans-400"
+      modifier="heading-sans-400"
       class="cdr-pt-space-one-x"
     >
       Content Length
@@ -84,7 +84,7 @@
     </cdr-radio>
 
     <cdr-text
-      modifier="heading--sans-400"
+      modifier="heading-sans-400"
       class="cdr-pt-space-one-x"
     >
       Show Title

--- a/src/components/quote/examples/demo/Blockquotes.vue
+++ b/src/components/quote/examples/demo/Blockquotes.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Blockquote
     </cdr-text>

--- a/src/components/quote/examples/demo/Pullquotes.vue
+++ b/src/components/quote/examples/demo/Pullquotes.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Pullquote
     </cdr-text>

--- a/src/components/radio/examples/Radios.vue
+++ b/src/components/radio/examples/Radios.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Radios
     </cdr-text>

--- a/src/components/rating/examples/Ratings.vue
+++ b/src/components/rating/examples/Ratings.vue
@@ -4,7 +4,7 @@
   >
     <cdr-text
       tag="h2"
-      modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+      modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
     >
       Ratings
     </cdr-text>

--- a/src/components/select/examples/Selects.vue
+++ b/src/components/select/examples/Selects.vue
@@ -2,7 +2,7 @@
   <div>
     <cdr-text
       tag="h2"
-      modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       space="cdr-my-space-two-x"
     >
       Selects

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -4,7 +4,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h2"
-        modifier="heading--serif-600 heading--serif-700@md heading--serif-700@lg"
+        modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"
       >
         Tabs
       </cdr-text>
@@ -76,7 +76,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Compact Tabs
       </cdr-text>
@@ -127,7 +127,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Full Width Tabs
       </cdr-text>
@@ -211,7 +211,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         No Border Tabs
       </cdr-text>
@@ -278,7 +278,7 @@
     <div class="tab-demo-section">
       <cdr-text
         tag="h3"
-        modifier="heading--sans-400 heading--sans-500@md heading--sans-500@lg"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
       >
         Centered Tabs
       </cdr-text>

--- a/src/components/text/examples/demo/Headings.vue
+++ b/src/components/text/examples/demo/Headings.vue
@@ -4,8 +4,8 @@
       <h3>Heading Serif</h3>
       <cdr-text
         v-for="level in heading.serif"
-        :modifier="`heading--serif-${level}`"
-        :key="`heading--serif-${level}`"
+        :modifier="`heading-serif-${level}`"
+        :key="`heading-serif-${level}`"
       >
         Heading Serif {{ level }}
       </cdr-text>
@@ -14,8 +14,8 @@
       <h3>Heading Sans</h3>
       <cdr-text
         v-for="level in heading.sans"
-        :modifier="`heading--sans-${level}`"
-        :key="`heading--sans-${level}`"
+        :modifier="`heading-sans-${level}`"
+        :key="`heading-sans-${level}`"
       >
         Heading Sans {{ level }}
       </cdr-text>
@@ -25,8 +25,8 @@
       <h3>Heading Serif Strong</h3>
       <cdr-text
         v-for="level in heading.serifStrong"
-        :modifier="`heading--serif--strong-${level}`"
-        :key="`heading--serif--strong-${level}`"
+        :modifier="`heading-serif-strong-${level}`"
+        :key="`heading-serif-strong-${level}`"
       >
         Heading Serif Strong {{ level }}
       </cdr-text>
@@ -35,8 +35,8 @@
       <h3>Subheading Sans</h3>
       <cdr-text
         v-for="level in subheading.sans"
-        :modifier="`subheading--sans-${level}`"
-        :key="`subheading--sans-${level}`"
+        :modifier="`subheading-sans-${level}`"
+        :key="`subheading-sans-${level}`"
       >
         Subheading Sans {{ level }}
       </cdr-text>

--- a/src/components/text/examples/demo/Paragraphs.vue
+++ b/src/components/text/examples/demo/Paragraphs.vue
@@ -30,9 +30,9 @@
       <cdr-text
         v-for="strongaragraph in paragraphs"
         :key="strongaragraph"
-        :modifier="`body--strong-${strongaragraph}`"
+        :modifier="`body-strong-${strongaragraph}`"
       >
-        body--strong-{{ paragraph }}: <br> Lorem ipsum dolor sit amet, orci tristique enim condimentum pellentesque amet
+        body-strong-{{ paragraph }}: <br> Lorem ipsum dolor sit amet, orci tristique enim condimentum pellentesque amet
         congue. Suspendisse pulvinar. Consectetuer curabitur id, laoreet dolor sapien libero,
         donec risus magna erat pede massa montes, lacinia pede venenatis luctus, fringilla nulla
         mollis praesent viverra. Ligula ipsum. Integer sed, sem nullam nibh sed suscipit quisque
@@ -61,9 +61,9 @@
       <cdr-text
         v-for="utilitystrong in utilities"
         :key="utilitystrong"
-        :modifier="`utility--strong-${utilitystrong}`"
+        :modifier="`utility-strong-${utilitystrong}`"
       >
-        utility--strong-{{ utilitystrong }}: <br> Lorem ipsum dolor sit amet, orci tristique enim condimentum pellentesque amet
+        utility-strong-{{ utilitystrong }}: <br> Lorem ipsum dolor sit amet, orci tristique enim condimentum pellentesque amet
         congue. Suspendisse pulvinar. Consectetuer curabitur id, laoreet dolor sapien libero,
         donec risus magna erat pede massa montes, lacinia pede venenatis luctus, fringilla nulla
         mollis praesent viverra. Ligula ipsum. Integer sed, sem nullam nibh sed suscipit quisque
@@ -91,9 +91,9 @@
       <cdr-text
         v-for="utilityserifstrong in utilities"
         :key="utilityserifstrong"
-        :modifier="`utility--serif--strong-${utilityserifstrong}`"
+        :modifier="`utility--serif-strong-${utilityserifstrong}`"
       >
-        utility--serif--strong-{{ utilityserifstrong }}: <br> Lorem ipsum dolor sit amet, orci tristique enim condimentum pellentesque amet
+        utility--serif-strong-{{ utilityserifstrong }}: <br> Lorem ipsum dolor sit amet, orci tristique enim condimentum pellentesque amet
         congue. Suspendisse pulvinar. Consectetuer curabitur id, laoreet dolor sapien libero,
         donec risus magna erat pede massa montes, lacinia pede venenatis luctus, fringilla nulla
         mollis praesent viverra. Ligula ipsum. Integer sed, sem nullam nibh sed suscipit quisque
@@ -107,13 +107,13 @@
       <cdr-text
         v-for="utilityserifstrong in utilities"
         :key="utilityserifstrong"
-        :modifier="`utility--serif--strong-${utilityserifstrong}`"
+        :modifier="`utility--serif-strong-${utilityserifstrong}`"
       >
         <cdr-text
           modifier="italic"
           tag="em"
         >
-          cdr-text--italic wrapping utility--serif--strong-{{ utilityserifstrong }}: <br> Lorem ipsum dolor sit amet, orci tristique enim condimentum pellentesque amet
+          cdr-text--italic wrapping utility--serif-strong-{{ utilityserifstrong }}: <br> Lorem ipsum dolor sit amet, orci tristique enim condimentum pellentesque amet
           congue. Suspendisse pulvinar. Consectetuer curabitur id, laoreet dolor sapien libero,
           donec risus magna erat pede massa montes, lacinia pede venenatis luctus, fringilla nulla
           mollis praesent viverra. Ligula ipsum. Integer sed, sem nullam nibh sed suscipit quisque
@@ -132,9 +132,9 @@
         example of
         <cdr-text
           tag="strong"
-          :modifier="`body--strong-${paragraph}`"
+          :modifier="`body-strong-${paragraph}`"
         >
-          body--strong-{{ paragraph }},
+          body-strong-{{ paragraph }},
         </cdr-text>
         <cdr-text
           tag="strong"
@@ -167,9 +167,9 @@
         example of
         <cdr-text
           tag="strong"
-          :modifier="`utility--strong-${utility}`"
+          :modifier="`utility-strong-${utility}`"
         >
-          utility--strong-{{ utility }},
+          utility-strong-{{ utility }},
         </cdr-text>
         <cdr-text
           tag="strong"

--- a/src/css/utility/_text.scss
+++ b/src/css/utility/_text.scss
@@ -50,7 +50,7 @@ h6.cdr-text.cdr-text,
     &-300 { @include cdr-text-body-300; }
     &-400 { @include cdr-text-body-400; }
     &-500 { @include cdr-text-body-500; }
-    &--strong {
+    &-strong {
       &-300 { @include cdr-text-body-strong-300; }
       &-400 { @include cdr-text-body-strong-400; }
       &-500 { @include cdr-text-body-strong-500; }
@@ -65,7 +65,7 @@ h6.cdr-text.cdr-text,
     &-600 { @include cdr-text-utility-600; }
     &-700 { @include cdr-text-utility-700; }
     &-800 { @include cdr-text-utility-800; }
-    &--strong {
+    &-strong {
       &-100 { @include cdr-text-utility-strong-100; }
       &-200 { @include cdr-text-utility-strong-200; }
       &-300 { @include cdr-text-utility-strong-300; }
@@ -75,7 +75,7 @@ h6.cdr-text.cdr-text,
       &-700 { @include cdr-text-utility-strong-700; }
       &-800 { @include cdr-text-utility-strong-800; }
     }
-    &--serif {
+    &-serif {
       &-200 { @include cdr-text-utility-serif-200; }
       &-300 { @include cdr-text-utility-serif-300; }
       &-400 { @include cdr-text-utility-serif-400; }
@@ -83,7 +83,7 @@ h6.cdr-text.cdr-text,
       &-600 { @include cdr-text-utility-serif-600; }
       &-700 { @include cdr-text-utility-serif-700; }
       &-800 { @include cdr-text-utility-serif-800; }
-      &--strong {
+      &-strong {
         &-200 { @include cdr-text-utility-serif-strong-200; }
         &-300 { @include cdr-text-utility-serif-strong-300; }
         &-400 { @include cdr-text-utility-serif-strong-400; }
@@ -104,14 +104,14 @@ h6.cdr-text.cdr-text,
   }
 
   &--heading {
-    &--sans {
+    &-sans {
       &-200 { @include cdr-text-heading-sans-200; }
       &-300 { @include cdr-text-heading-sans-300; }
       &-400 { @include cdr-text-heading-sans-400; }
       &-500 { @include cdr-text-heading-sans-500; }
       &-600 { @include cdr-text-heading-sans-600; }
     }
-    &--serif {
+    &-serif {
       &-200 { @include cdr-text-heading-serif-200; }
       &-300 { @include cdr-text-heading-serif-300; }
       &-400 { @include cdr-text-heading-serif-400; }
@@ -123,7 +123,7 @@ h6.cdr-text.cdr-text,
       &-1000 { @include cdr-text-heading-serif-1000; }
       &-1100 { @include cdr-text-heading-serif-1100; }
       &-1200 { @include cdr-text-heading-serif-1200; }
-      &--strong {
+      &-strong {
         &-600 { @include cdr-text-heading-serif-strong-600; }
         &-700 { @include cdr-text-heading-serif-strong-700; }
         &-800 { @include cdr-text-heading-serif-strong-800; }
@@ -136,7 +136,7 @@ h6.cdr-text.cdr-text,
   }
 
   &--subheading {
-    &--sans {
+    &-sans {
       &-300 { @include cdr-text-subheading-sans-300; }
       &-400 { @include cdr-text-subheading-sans-400; }
       &-500 { @include cdr-text-subheading-sans-500; }
@@ -146,14 +146,14 @@ h6.cdr-text.cdr-text,
 
   @include xs-mq-only {
     &--heading {
-      &--sans {
+      &-sans {
         &-200\@xs { @include cdr-text-heading-sans-200; }
         &-300\@xs { @include cdr-text-heading-sans-300; }
         &-400\@xs { @include cdr-text-heading-sans-400; }
         &-500\@xs { @include cdr-text-heading-sans-500; }
         &-600\@xs { @include cdr-text-heading-sans-600; }
       }
-      &--serif {
+      &-serif {
         &-200\@xs { @include cdr-text-heading-serif-200; }
         &-300\@xs { @include cdr-text-heading-serif-300; }
         &-400\@xs { @include cdr-text-heading-serif-400; }
@@ -165,7 +165,7 @@ h6.cdr-text.cdr-text,
         &-1000\@xs { @include cdr-text-heading-serif-1000; }
         &-1100\@xs { @include cdr-text-heading-serif-1100; }
         &-1200\@xs { @include cdr-text-heading-serif-1200; }
-        &--strong {
+        &-strong {
           &-600 { @include cdr-text-heading-serif-strong-600; }
           &-700 { @include cdr-text-heading-serif-strong-700; }
           &-800 { @include cdr-text-heading-serif-strong-800; }
@@ -178,7 +178,7 @@ h6.cdr-text.cdr-text,
     }
 
     &--subheading {
-      &--sans {
+      &-sans {
         &-300\@xs { @include cdr-text-subheading-sans-300; }
         &-400\@xs { @include cdr-text-subheading-sans-400; }
         &-500\@xs { @include cdr-text-subheading-sans-500; }
@@ -189,14 +189,14 @@ h6.cdr-text.cdr-text,
 
   @include sm-mq-only {
     &--heading {
-      &--sans {
+      &-sans {
         &-200\@sm { @include cdr-text-heading-sans-200; }
         &-300\@sm { @include cdr-text-heading-sans-300; }
         &-400\@sm { @include cdr-text-heading-sans-400; }
         &-500\@sm { @include cdr-text-heading-sans-500; }
         &-600\@sm { @include cdr-text-heading-sans-600; }
       }
-      &--serif {
+      &-serif {
         &-200\@sm { @include cdr-text-heading-serif-200; }
         &-300\@sm { @include cdr-text-heading-serif-300; }
         &-400\@sm { @include cdr-text-heading-serif-400; }
@@ -208,7 +208,7 @@ h6.cdr-text.cdr-text,
         &-1000\@sm { @include cdr-text-heading-serif-1000; }
         &-1100\@sm { @include cdr-text-heading-serif-1100; }
         &-1200\@sm { @include cdr-text-heading-serif-1200; }
-        &--strong {
+        &-strong {
           &-600 { @include cdr-text-heading-serif-strong-600; }
           &-700 { @include cdr-text-heading-serif-strong-700; }
           &-800 { @include cdr-text-heading-serif-strong-800; }
@@ -221,7 +221,7 @@ h6.cdr-text.cdr-text,
     }
 
     &--subheading {
-      &--sans {
+      &-sans {
         &-300\@sm { @include cdr-text-subheading-sans-300; }
         &-400\@sm { @include cdr-text-subheading-sans-400; }
         &-500\@sm { @include cdr-text-subheading-sans-500; }
@@ -232,14 +232,14 @@ h6.cdr-text.cdr-text,
 
   @include md-mq-only {
     &--heading {
-      &--sans {
+      &-sans {
         &-200\@md { @include cdr-text-heading-sans-200; }
         &-300\@md { @include cdr-text-heading-sans-300; }
         &-400\@md { @include cdr-text-heading-sans-400; }
         &-500\@md { @include cdr-text-heading-sans-500; }
         &-600\@md { @include cdr-text-heading-sans-600; }
       }
-      &--serif {
+      &-serif {
         &-200\@md { @include cdr-text-heading-serif-200; }
         &-300\@md { @include cdr-text-heading-serif-300; }
         &-400\@md { @include cdr-text-heading-serif-400; }
@@ -251,7 +251,7 @@ h6.cdr-text.cdr-text,
         &-1000\@md { @include cdr-text-heading-serif-1000; }
         &-1100\@md { @include cdr-text-heading-serif-1100; }
         &-1200\@md { @include cdr-text-heading-serif-1200; }
-        &--strong {
+        &-strong {
           &-600 { @include cdr-text-heading-serif-strong-600; }
           &-700 { @include cdr-text-heading-serif-strong-700; }
           &-800 { @include cdr-text-heading-serif-strong-800; }
@@ -264,7 +264,7 @@ h6.cdr-text.cdr-text,
     }
 
     &--subheading {
-      &--sans {
+      &-sans {
         &-300\@md { @include cdr-text-subheading-sans-300; }
         &-400\@md { @include cdr-text-subheading-sans-400; }
         &-500\@md { @include cdr-text-subheading-sans-500; }
@@ -275,14 +275,14 @@ h6.cdr-text.cdr-text,
 
   @include lg-mq-only {
     &--heading {
-      &--sans {
+      &-sans {
         &-200\@lg { @include cdr-text-heading-sans-200; }
         &-300\@lg { @include cdr-text-heading-sans-300; }
         &-400\@lg { @include cdr-text-heading-sans-400; }
         &-500\@lg { @include cdr-text-heading-sans-500; }
         &-600\@lg { @include cdr-text-heading-sans-600; }
       }
-      &--serif {
+      &-serif {
         &-200\@lg { @include cdr-text-heading-serif-200; }
         &-300\@lg { @include cdr-text-heading-serif-300; }
         &-400\@lg { @include cdr-text-heading-serif-400; }
@@ -294,7 +294,7 @@ h6.cdr-text.cdr-text,
         &-1000\@lg { @include cdr-text-heading-serif-1000; }
         &-1100\@lg { @include cdr-text-heading-serif-1100; }
         &-1200\@lg { @include cdr-text-heading-serif-1200; }
-        &--strong {
+        &-strong {
           &-600 { @include cdr-text-heading-serif-strong-600; }
           &-700 { @include cdr-text-heading-serif-strong-700; }
           &-800 { @include cdr-text-heading-serif-strong-800; }
@@ -307,7 +307,7 @@ h6.cdr-text.cdr-text,
     }
 
     &--subheading {
-      &--sans {
+      &-sans {
         &-300\@lg { @include cdr-text-subheading-sans-300; }
         &-400\@lg { @include cdr-text-subheading-sans-400; }
         &-500\@lg { @include cdr-text-subheading-sans-500; }


### PR DESCRIPTION
updates all the sans/serif/strong modifiers to use single dashes instead of double.
double dashes should only be used at the top level, i.e, `cdr-text--body-strong` NOT `cdr-text--body--strong` 

this matches the pattern we use for every other component