### PR TITLE
fix(list): make inline lists wrap and hide list decorator entirely for first item

### DIFF
--- a/src/components/list/examples/demo/Unordered.vue
+++ b/src/components/list/examples/demo/Unordered.vue
@@ -63,6 +63,27 @@
       <li>List item text</li>
     </cdr-list>
 
+    <cdr-list
+      modifier="inline unordered"
+      space="cdr-mb-space-two-x"
+    >
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+      <li>List item text</li>
+    </cdr-list>
+
     <cdr-text
       tag="h4"
       modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"

--- a/src/components/list/styles/CdrList.scss
+++ b/src/components/list/styles/CdrList.scss
@@ -79,6 +79,7 @@
   ========== */
   &--inline {
     display: flex;
+    flex-wrap: wrap;
     list-style-type: none;
     padding-left: $inline-list-space;
 
@@ -110,7 +111,7 @@
         }
 
         &:first-of-type::before {
-          content: '';
+          display: none;
         }
 
         &::before {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I noticed these issues while using inline list on docs site.

I'll add a note to the release section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that are completed. -->

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- [ ] Added/updated backstop tests
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
- [ ] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [x] Examples created/updated
