### PR TITLE
add postcss-import-able output for deprecated utility classes

### DIFF
--- a/build/extract-css.js
+++ b/build/extract-css.js
@@ -23,6 +23,12 @@ buildCss({
   scopeClasses: false,
 });
 
+buildCss({
+  srcPath: './src/css/deprecated/_index.scss',
+  outPath: './dist/style/deprecated-utilities.css',
+  scopeClasses: false,
+});
+
 // Create individual utility outputs
 const utilities = glob.sync('./src/css/utility/*.scss')
   .map((path) => {

--- a/src/css/deprecated/_index.scss
+++ b/src/css/deprecated/_index.scss
@@ -1,2 +1,3 @@
+@import '../settings/_index';
 @import "./fall2019/_index";
 @import "./winter2019/_index";


### PR DESCRIPTION
currently the deprecated utility classes are not included in the de-composed CSS output. 
adding this output will give consumers a way to manually load these deprecated classes in their project if they need to.