### PR TITLE
fix(css): give hide-figure a higher precedence than size

### DIFF
--- a/src/components/checkbox/styles/CdrCheckbox.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.scss
@@ -166,24 +166,6 @@
     box-shadow: $checkbox-focus-outline;
   }
 
-  /* Modifiers
-    ========================================================================== */
-
-  /* Hide Figure
-    ========== */
-
-  // TODO: remove compact?
-  &--compact {
-    @include checkbox-text-compact;
-  }
-
-  &--hide-figure {
-    padding-left: 0;
-
-    & > .cdr-checkbox__figure {
-      display: none;
-    }
-  }
 
   /* Sizes
     ========================================================================== */
@@ -239,5 +221,25 @@
 
     @include checkbox-large-mixin(&, \@lg);
   }
+
+  /* Modifiers
+    ========================================================================== */
+
+  /* Hide Figure
+    ========== */
+
+  // TODO: remove compact?
+  &--compact {
+    @include checkbox-text-compact;
+  }
+
+  &--hide-figure {
+    padding-left: 0;
+
+    & > .cdr-checkbox__figure {
+      display: none;
+    }
+  }
+
 
 }

--- a/src/components/radio/styles/CdrRadio.scss
+++ b/src/components/radio/styles/CdrRadio.scss
@@ -146,6 +146,62 @@
     box-shadow: $radio-focus-outline;
   }
 
+
+  /* Sizes
+  ========================================================================== */
+  @include radio-small-mixin(&);
+
+  @include radio-medium-mixin(&);
+
+  @include radio-large-mixin(&);
+
+  /* Breakpoint variants
+
+  /* @xs
+    0px - 767px
+    ========== */
+  @include xs-mq-only {
+    @include radio-small-mixin(&, \@xs);
+
+    @include radio-medium-mixin(&, \@xs);
+
+    @include radio-large-mixin(&, \@xs);
+  }
+
+  /* @sm
+    768px - 991px
+    ========== */
+  @include sm-mq-only {
+    @include radio-small-mixin(&, \@sm);
+
+    @include radio-medium-mixin(&, \@sm);
+
+    @include radio-large-mixin(&, \@sm);
+  }
+
+  /* @md
+    992px - 1199px
+    ========== */
+  @include md-mq-only {
+    @include radio-small-mixin(&, \@md);
+
+    @include radio-medium-mixin(&, \@md);
+
+    @include radio-large-mixin(&, \@md);
+  }
+
+  /* @lg
+    1200px and up
+    ========== */
+
+  @include lg-mq-only {
+    @include radio-small-mixin(&, \@lg);
+
+    @include radio-medium-mixin(&, \@lg);
+
+    @include radio-large-mixin(&, \@lg);
+  }
+
   /* Modifiers
     ========================================================================== */
 
@@ -164,65 +220,11 @@
     ========== */
 
   &--hide-figure {
-    padding-left: 0;
+    padding-left: 0 !important;
 
     & > .cdr-radio__figure {
       display: none;
     }
   }
 
-  /* Sizes
-    ========================================================================== */
-    @include radio-small-mixin(&);
-
-    @include radio-medium-mixin(&);
-  
-    @include radio-large-mixin(&);
-  
-    /* Breakpoint variants
-  
-    /* @xs
-      0px - 767px
-      ========== */
-    @include xs-mq-only {
-      @include radio-small-mixin(&, \@xs);
-  
-      @include radio-medium-mixin(&, \@xs);
-  
-      @include radio-large-mixin(&, \@xs);
-    }
-  
-    /* @sm
-      768px - 991px
-      ========== */
-    @include sm-mq-only {
-      @include radio-small-mixin(&, \@sm);
-  
-      @include radio-medium-mixin(&, \@sm);
-  
-      @include radio-large-mixin(&, \@sm);
-    }
-  
-    /* @md
-      992px - 1199px
-      ========== */
-    @include md-mq-only {
-      @include radio-small-mixin(&, \@md);
-  
-      @include radio-medium-mixin(&, \@md);
-  
-      @include radio-large-mixin(&, \@md);
-    }
-  
-    /* @lg
-      1200px and up
-      ========== */
-  
-    @include lg-mq-only {
-      @include radio-small-mixin(&, \@lg);
-  
-      @include radio-medium-mixin(&, \@lg);
-  
-      @include radio-large-mixin(&, \@lg);
-    }
 }


### PR DESCRIPTION
<img width="758" alt="Screen Shot 2020-01-15 at 9 41 16 AM" src="https://user-images.githubusercontent.com/48567940/72457330-3355fd80-377b-11ea-8781-8cf53e39d60b.png">
noticed this on the icons site, checkbox label would still get padding-left even if `hide-figure` was passed because the size styles were lower in the file than the hide-figure styles :laughing: