### PR TITLE
Fix wonky ratings

### DIFF
--- a/src/components/rating/CdrRating.jsx
+++ b/src/components/rating/CdrRating.jsx
@@ -60,6 +60,9 @@ export default {
     remainder() {
       return this.rounded.toFixed(2).split('.')[1];
     },
+    empties() {
+      return 5 - this.whole - (this.remainder > 0 ? 1 : 0);
+    },
     formattedCount() {
       return this.compact ? `(${this.count})` : `${this.count}`;
     },
@@ -103,30 +106,28 @@ export default {
           this.href ? this.style['cdr-rating--linked'] : '',
         )}
       >
-        <div class={this.style['cdr-rating__background']}>
-          {[...Array(5)].map(n => (
-              <span
-                class={clsx(
-                  this.style['cdr-rating__icon'],
-                  this.count > 0
-                    ? this.style['cdr-rating__placeholder']
-                    : this.style['cdr-rating__placeholder--no-reviews'],
-                )}
-                key={n}
-                aria-hidden="true"
-              />
-          ))}
-        </div>
         <div class={this.style['cdr-rating__ratings']}>
 
-          {[...Array(this.whole)].map(n => (
+          {[...Array(this.whole).keys()].map(n => (
               <span
                 class={clsx(this.style['cdr-rating__icon'], this.style['cdr-rating__100'])}
-                key={n}
+                key={`rating-whole-${n}-${this._uid}`} // eslint-disable-line no-underscore-dangle
                 aria-hidden="true"
               />
           ))}
           {this.remainderEl }
+          {[...Array(this.empties).keys()].map(n => (
+            <span
+              class={clsx(
+                this.style['cdr-rating__icon'],
+                (this.rounded > 0 || this.count > 0)
+                  ? this.style['cdr-rating__placeholder']
+                  : this.style['cdr-rating__placeholder--no-reviews'],
+              )}
+              key={`rating-empty-${n}-${this._uid}`} // eslint-disable-line no-underscore-dangle
+              aria-hidden="true"
+            />
+          ))}
         </div>
         {this.count !== null
           ? <span

--- a/src/components/rating/__tests__/CdrRating.spec.js
+++ b/src/components/rating/__tests__/CdrRating.spec.js
@@ -22,21 +22,25 @@ describe('CdrRating', () => {
     expect(wrapper.vm.whole).toBe(3);
     expect(wrapper.vm.remainder).toBe('50');
     expect(wrapper.vm.rounded).toBe(3.5);
-
+    expect(wrapper.vm.empties).toBe(1);
+    
     wrapper.setProps({rating: 3.122227});
     expect(wrapper.vm.whole).toBe(3);
     expect(wrapper.vm.remainder).toBe('00');
     expect(wrapper.vm.rounded).toBe(3);
-
+    expect(wrapper.vm.empties).toBe(2);
+    
     wrapper.setProps({rating: 3.222227});
     expect(wrapper.vm.whole).toBe(3);
     expect(wrapper.vm.remainder).toBe('25');
     expect(wrapper.vm.rounded).toBe(3.25);
-
+    expect(wrapper.vm.empties).toBe(1);
+    
     wrapper.setProps({rating: 3.673323});
     expect(wrapper.vm.whole).toBe(3);
     expect(wrapper.vm.remainder).toBe('75');
     expect(wrapper.vm.rounded).toBe(3.75);
+    expect(wrapper.vm.empties).toBe(1);
   });
 
   it('computes and rounds rating stars correctly with string input', () => {
@@ -59,52 +63,6 @@ describe('CdrRating', () => {
       }
     });
     expect(wrapper.is('a')).toBeTruthy();
-  });
-
-  it('renders normal placeholder stars when count is > 0', () => {
-    const wrapper = shallowMount(CdrRating, {
-      propsData: {
-        rating: 5,
-        count: 1,
-      }
-    });
-    expect(wrapper.contains('.cdr-rating__placeholder')).toBe(true);
-    expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(false);
-  });
-
-  it('renders custom placeholder stars when count is 0', () => {
-    const wrapper = shallowMount(CdrRating, {
-      propsData: {
-        rating: 5,
-        count: 0,
-        href: 'rei.com'
-      }
-    });
-    expect(wrapper.contains('.cdr-rating__placeholder')).toBe(false);
-    expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(true);
-  });
-
-  it('renders custom placeholder stars when count is "0"', () => {
-    const wrapper = shallowMount(CdrRating, {
-      propsData: {
-        rating: 5,
-        count: "0",
-        href: 'rei.com'
-      }
-    });
-    expect(wrapper.contains('.cdr-rating__placeholder')).toBe(false);
-    expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(true);
-  });
-
-  it('renders custom placeholder stars when count is not passed', () => {
-    const wrapper = shallowMount(CdrRating, {
-      propsData: {
-        rating: 5,
-        href: 'rei.com'
-      }
-    });
-    expect(wrapper.contains('.cdr-rating__placeholder')).toBe(false);
-    expect(wrapper.contains('.cdr-rating__placeholder--no-reviews')).toBe(true);
   });
 
   it('renders review text when count is 0', () => {

--- a/src/components/rating/__tests__/__snapshots__/CdrRating.spec.js.snap
+++ b/src/components/rating/__tests__/__snapshots__/CdrRating.spec.js.snap
@@ -5,30 +5,6 @@ exports[`CdrRating renders correctly 1`] = `
   class="cdr-rating cdr-rating--primary"
 >
   <div
-    class="cdr-rating__background"
-  >
-    <span
-      aria-hidden="true"
-      class="cdr-rating__icon cdr-rating__placeholder"
-    />
-    <span
-      aria-hidden="true"
-      class="cdr-rating__icon cdr-rating__placeholder"
-    />
-    <span
-      aria-hidden="true"
-      class="cdr-rating__icon cdr-rating__placeholder"
-    />
-    <span
-      aria-hidden="true"
-      class="cdr-rating__icon cdr-rating__placeholder"
-    />
-    <span
-      aria-hidden="true"
-      class="cdr-rating__icon cdr-rating__placeholder"
-    />
-  </div>
-  <div
     class="cdr-rating__ratings"
   >
     <span
@@ -46,6 +22,10 @@ exports[`CdrRating renders correctly 1`] = `
     <span
       aria-hidden="true"
       class="cdr-rating__icon cdr-rating__25"
+    />
+    <span
+      aria-hidden="true"
+      class="cdr-rating__icon cdr-rating__placeholder"
     />
   </div>
   <span

--- a/src/components/rating/examples/Ratings.vue
+++ b/src/components/rating/examples/Ratings.vue
@@ -21,6 +21,28 @@
       href="https://www.rei.com"
       data-backstop="rating-primary-linked"
     />
+
+    <cdr-rating
+      rating="0"
+      count="0"
+    />
+    <cdr-rating
+      :rating="0"
+      :count="0"
+    />
+    <cdr-rating
+      :rating="0"
+      :count="10"
+    />
+
+    <cdr-rating
+      rating="3.3"
+      count="48"
+    />
+    <cdr-rating
+      :rating="3.3"
+      :count="48"
+    />
     <!-- Large Size -->
 
 

--- a/src/components/rating/styles/CdrRating.scss
+++ b/src/components/rating/styles/CdrRating.scss
@@ -47,14 +47,6 @@ $rating-color: #2b6692;
 
   &__ratings {
     display: flex;
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    left: 0;
-  }
-
-  &__background {
-    display: flex;
   }
 
   &__caption-sr {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Ratings stars were stacked on each other (empty then filled over top) which caused some rendering issues for some people

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that are completed. -->

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- [ ] Added/updated backstop tests (N/A)
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
Some unit tests that are caught by backstop tests have been removed
- [x] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated (N/A)
- [x] Examples created/updated
