### PR TITLE
fix(select): update vmodel logic to not directly modify a prop, emit a different unique event name

### DIFF
--- a/src/components/select/CdrSelect.jsx
+++ b/src/components/select/CdrSelect.jsx
@@ -12,6 +12,10 @@ export default {
   },
   mixins: [size, space],
   inheritAttrs: false,
+  model: {
+    prop: 'value',
+    event: 'update-select',
+  },
   props: {
     /**
      * `id` for the select that is mapped to the label `for` attribute. If one is not provided, it will be generated.
@@ -55,6 +59,14 @@ export default {
     };
   },
   computed: {
+    innerValue: {
+      get() {
+        return this.value;
+      },
+      set(newValue) {
+        this.$emit('update-select', newValue);
+      },
+    },
     // Use given id or generate one
     selectId() {
       return this.id ? this.id : this._uid; // eslint-disable-line no-underscore-dangle
@@ -94,36 +106,24 @@ export default {
         {},
         this.$listeners,
         {
-          input(event) {
+          change(event) {
             if (vm.multiple) {
               const optArr = toArray(event.target.options);
               const selected = optArr.filter(o => o.selected === true).map(o => o.value);
+
+              vm.innerValue = selected;
+              vm.$emit('select-change', selected, event);
+
+              // Deprecated Event
               vm.$emit('input', selected, event);
-
-              // Deprecated Event
               vm.$emit('change', selected, event);
-
-              vm.value = selected;
             } else {
-              vm.$emit('input', event.target.value, event);
+              vm.innerValue = event.target.value;
+              vm.$emit('select-change', event.target.value, event);
 
               // Deprecated Event
+              vm.$emit('input', event.target.value, event);
               vm.$emit('change', event.target.value, event);
-            }
-          },
-          change(event) {
-            // Deprecated event
-            vm.$emit('change', event.target.value, event);
-
-            // Needed for Internet Explorer
-            if (vm.value !== event.target.value) {
-              if (vm.multiple) {
-                const optArr = toArray(event.target.options);
-                const selected = optArr.filter(o => o.selected === true).map(o => o.value);
-                vm.$emit('input', selected, event);
-              } else {
-                vm.$emit('input', event.target.value, event);
-              }
             }
           },
         },
@@ -140,7 +140,7 @@ export default {
           aria-label={this.hideLabel ? this.label : null}
           ref="select"
           {...{ attrs: this.$attrs, on: this.inputListeners }}
-          vModel={this.value}
+          vModel={this.innerValue}
         >
 
           {this.prompt

--- a/src/components/select/__tests__/CdrSelect.spec.js
+++ b/src/components/select/__tests__/CdrSelect.spec.js
@@ -122,22 +122,6 @@ describe('cdrSelect', () => {
     expect(wrapper.vm.$refs.select.hasAttribute('multiple')).toBe(true);
   });
 
-  it('emits input event with correct value', () => {
-    const wrapper = shallowMount(CdrSelect, {
-      propsData: {
-        label: 'test',
-        value: '2',
-        options: ['1', '2'],
-      },
-    });
-    const select = wrapper.find({ ref: 'select'});
-    wrapper.setProps({ value: '1' });
-    select.trigger('input');
-    expect(wrapper.emitted().input[0][0]).toBe('1');
-  });
-
-  // Deprecated event and should be removed
-  // when the change event is removed.
   it('emits change event with correct value', () => {
     const wrapper = shallowMount(CdrSelect, {
       propsData: {
@@ -147,43 +131,13 @@ describe('cdrSelect', () => {
       },
     });
     const select = wrapper.find({ ref: 'select'});
-    wrapper.setProps({ value: '3' });
-    select.trigger('change');
+    const options = select.findAll('option');
+    options.at(0).setSelected();
+    expect(wrapper.emitted().input[0][0]).toBe('3');
     expect(wrapper.emitted().change[0][0]).toBe('3');
+    expect(wrapper.emitted()['select-change'][0][0]).toBe('3');
   });
 
-  it('emits input event with correct value for multiple', () => {
-    const wrapper = shallowMount(CdrSelect, {
-      propsData: {
-        label: 'test',
-        multiple: true,
-        value: ['1', '2'],
-        options: [{
-          value: '1',
-          text: 'one',
-        },
-        {
-          value: '2',
-          text: 'two',
-        },
-        {
-          value: '3',
-          text: 'three',
-        }],
-      },
-    });
-    wrapper.setProps({ value: ['1', '3'] });
-    const propValues = wrapper.vm.value;
-    for(let o of wrapper.vm.$refs.select.options) {
-      propValues.indexOf(o.value) >= 0 ? o.selected = true : o.selected = false;
-    }
-    const select = wrapper.find({ ref: 'select'});
-    select.trigger('input');
-    expect(wrapper.emitted().input[0][0]).toEqual(['1', '3']);
-  });
-
-  // Deprecated event and should be removed
-  // when the change event is removed.
   it('emits change event with correct value for multiple', () => {
     const wrapper = shallowMount(CdrSelect, {
       propsData: {
@@ -204,17 +158,17 @@ describe('cdrSelect', () => {
         }],
       },
     });
-    wrapper.setProps({ value: ['1', '3'] });
-    const propValues = wrapper.vm.value;
-    for(let o of wrapper.vm.$refs.select.options) {
-      propValues.indexOf(o.value) >= 0 ? o.selected = true : o.selected = false;
-    }
-    const select = wrapper.find({ ref: 'select'});
-    select.trigger('input');
+    const select = wrapper.find({ ref: 'select' });
+    const options = select.findAll('option');
+    options.at(0).element.selected = true;
+    options.at(1).element.selected = false;
+    options.at(2).element.selected = true;
+    select.trigger('change');
+    expect(wrapper.emitted().input[0][0]).toEqual(['1', '3']);
     expect(wrapper.emitted().change[0][0]).toEqual(['1', '3']);
+    expect(wrapper.emitted()['select-change'][0][0]).toEqual(['1', '3']);
   });
-
-  // NOTE - can't use v-model directly here, targeting the `data` prop instead
+  
   it('updating v-model data updates the select', () => {
     const wrapper = shallowMount(CdrSelect, {
       propsData: {
@@ -224,8 +178,10 @@ describe('cdrSelect', () => {
       },
     });
     const select = wrapper.find({ ref: 'select' });
+    const options = select.findAll('option');
     wrapper.setProps({value: '3'});
     expect(select.element.value).toBe('3');
+    expect(options.at(0).element.selected).toBeTruthy();
   });
 
   it('renders info slot', () => {

--- a/src/components/select/examples/Selects.vue
+++ b/src/components/select/examples/Selects.vue
@@ -16,6 +16,7 @@
         v-model="selectedA"
         prompt="Choose one"
         space="cdr-my-space-two-x"
+        @select-change="doExternal"
       >
         <option value="1">
           1
@@ -269,6 +270,9 @@ export default {
     },
     inputChange(selectedValue, event) {
       console.log('change Event event = ', event, ' selectedValue = ', selectedValue);
+    },
+    doExternal(v, e) {
+      console.log('EXTERNAL', v, e);
     },
   },
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Updates to avoid double events.

- Emit new event `select-change` (avoids possible collisions with input/change)
    - Old events are still emitted, but considered "deprecated"
- Use computed prop for internal vmodel to avoid mutating value prop
- Update model event to `update-select` to avoid possible collisions

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that are completed. -->

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [ ] iOS
- [ ] Android

### Visual regression testing:
- [ ] Added/updated backstop tests
- [ ] Passes with existing reference images (or failed as expected)

### Unit testing:
- [ ] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [ ] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [ ] Examples created/updated
