### PR TITLE
fix(type): add breakpoint suffixes to responsive heading-serif-strong

### DIFF
--- a/src/css/utility/_text.scss
+++ b/src/css/utility/_text.scss
@@ -166,13 +166,13 @@ h6.cdr-text.cdr-text,
         &-1100\@xs { @include cdr-text-heading-serif-1100; }
         &-1200\@xs { @include cdr-text-heading-serif-1200; }
         &-strong {
-          &-600 { @include cdr-text-heading-serif-strong-600; }
-          &-700 { @include cdr-text-heading-serif-strong-700; }
-          &-800 { @include cdr-text-heading-serif-strong-800; }
-          &-900 { @include cdr-text-heading-serif-strong-900; }
-          &-1000 { @include cdr-text-heading-serif-strong-1000; }
-          &-1100 { @include cdr-text-heading-serif-strong-1100; }
-          &-1200 { @include cdr-text-heading-serif-strong-1200; }
+          &-600\@xs { @include cdr-text-heading-serif-strong-600; }
+          &-700\@xs { @include cdr-text-heading-serif-strong-700; }
+          &-800\@xs { @include cdr-text-heading-serif-strong-800; }
+          &-900\@xs { @include cdr-text-heading-serif-strong-900; }
+          &-1000\@xs { @include cdr-text-heading-serif-strong-1000; }
+          &-1100\@xs { @include cdr-text-heading-serif-strong-1100; }
+          &-1200\@xs { @include cdr-text-heading-serif-strong-1200; }
         }
       }
     }
@@ -209,13 +209,13 @@ h6.cdr-text.cdr-text,
         &-1100\@sm { @include cdr-text-heading-serif-1100; }
         &-1200\@sm { @include cdr-text-heading-serif-1200; }
         &-strong {
-          &-600 { @include cdr-text-heading-serif-strong-600; }
-          &-700 { @include cdr-text-heading-serif-strong-700; }
-          &-800 { @include cdr-text-heading-serif-strong-800; }
-          &-900 { @include cdr-text-heading-serif-strong-900; }
-          &-1000 { @include cdr-text-heading-serif-strong-1000; }
-          &-1100 { @include cdr-text-heading-serif-strong-1100; }
-          &-1200 { @include cdr-text-heading-serif-strong-1200; }
+          &-600\@sm { @include cdr-text-heading-serif-strong-600; }
+          &-700\@sm { @include cdr-text-heading-serif-strong-700; }
+          &-800\@sm { @include cdr-text-heading-serif-strong-800; }
+          &-900\@sm { @include cdr-text-heading-serif-strong-900; }
+          &-1000\@sm { @include cdr-text-heading-serif-strong-1000; }
+          &-1100\@sm { @include cdr-text-heading-serif-strong-1100; }
+          &-1200\@sm { @include cdr-text-heading-serif-strong-1200; }
         }
       }
     }
@@ -252,13 +252,13 @@ h6.cdr-text.cdr-text,
         &-1100\@md { @include cdr-text-heading-serif-1100; }
         &-1200\@md { @include cdr-text-heading-serif-1200; }
         &-strong {
-          &-600 { @include cdr-text-heading-serif-strong-600; }
-          &-700 { @include cdr-text-heading-serif-strong-700; }
-          &-800 { @include cdr-text-heading-serif-strong-800; }
-          &-900 { @include cdr-text-heading-serif-strong-900; }
-          &-1000 { @include cdr-text-heading-serif-strong-1000; }
-          &-1100 { @include cdr-text-heading-serif-strong-1100; }
-          &-1200 { @include cdr-text-heading-serif-strong-1200; }
+          &-600\@md { @include cdr-text-heading-serif-strong-600; }
+          &-700\@md { @include cdr-text-heading-serif-strong-700; }
+          &-800\@md { @include cdr-text-heading-serif-strong-800; }
+          &-900\@md { @include cdr-text-heading-serif-strong-900; }
+          &-1000\@md { @include cdr-text-heading-serif-strong-1000; }
+          &-1100\@md { @include cdr-text-heading-serif-strong-1100; }
+          &-1200\@md { @include cdr-text-heading-serif-strong-1200; }
         }
       }
     }
@@ -295,13 +295,13 @@ h6.cdr-text.cdr-text,
         &-1100\@lg { @include cdr-text-heading-serif-1100; }
         &-1200\@lg { @include cdr-text-heading-serif-1200; }
         &-strong {
-          &-600 { @include cdr-text-heading-serif-strong-600; }
-          &-700 { @include cdr-text-heading-serif-strong-700; }
-          &-800 { @include cdr-text-heading-serif-strong-800; }
-          &-900 { @include cdr-text-heading-serif-strong-900; }
-          &-1000 { @include cdr-text-heading-serif-strong-1000; }
-          &-1100 { @include cdr-text-heading-serif-strong-1100; }
-          &-1200 { @include cdr-text-heading-serif-strong-1200; }
+          &-600\@lg { @include cdr-text-heading-serif-strong-600; }
+          &-700\@lg { @include cdr-text-heading-serif-strong-700; }
+          &-800\@lg { @include cdr-text-heading-serif-strong-800; }
+          &-900\@lg { @include cdr-text-heading-serif-strong-900; }
+          &-1000\@lg { @include cdr-text-heading-serif-strong-1000; }
+          &-1100\@lg { @include cdr-text-heading-serif-strong-1100; }
+          &-1200\@lg { @include cdr-text-heading-serif-strong-1200; }
         }
       }
     }


### PR DESCRIPTION
Bug pointed out by Jake Rohr in user support
For the patch release