### PR TITLE
refactor(select): make select component use change event

### DIFF
--- a/src/components/select/CdrSelect.jsx
+++ b/src/components/select/CdrSelect.jsx
@@ -12,6 +12,10 @@ export default {
   },
   mixins: [size, space],
   inheritAttrs: false,
+  model: {
+    prop: 'value',
+    event: 'change',
+  },
   props: {
     /**
      * `id` for the select that is mapped to the label `for` attribute. If one is not provided, it will be generated.
@@ -94,37 +98,9 @@ export default {
         {},
         this.$listeners,
         {
-          input(event) {
-            if (vm.multiple) {
-              const optArr = toArray(event.target.options);
-              const selected = optArr.filter(o => o.selected === true).map(o => o.value);
-              vm.$emit('input', selected, event);
-
-              // Deprecated Event
-              vm.$emit('change', selected, event);
-
-              vm.value = selected;
-            } else {
-              vm.$emit('input', event.target.value, event);
-
-              // Deprecated Event
-              vm.$emit('change', event.target.value, event);
-            }
-          },
           change(event) {
             // Deprecated event
             vm.$emit('change', event.target.value, event);
-
-            // Needed for Internet Explorer
-            if (vm.value !== event.target.value) {
-              if (vm.multiple) {
-                const optArr = toArray(event.target.options);
-                const selected = optArr.filter(o => o.selected === true).map(o => o.value);
-                vm.$emit('input', selected, event);
-              } else {
-                vm.$emit('input', event.target.value, event);
-              }
-            }
           },
         },
       );


### PR DESCRIPTION
poking around on next, this seems like it stops select from emitting duplicate events, but im not sure of all the cases to test. i suspect that the native select using change and our select using input might have been causing weird behavior. (i.e, the native select would emit an `input` and a `change` and then the opposite listeners would re-emit another one)