### PR TITLE
Cdr 1603 - Tabs use small, debounce tab click

### DIFF
--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -1,5 +1,4 @@
 import debounce from 'lodash-es/debounce';
-import throttle from 'lodash-es/throttle';
 import delay from 'lodash-es/delay';
 import clsx from 'clsx';
 import modifier from '../../mixins/modifier';

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -1,4 +1,5 @@
 import debounce from 'lodash-es/debounce';
+import throttle from 'lodash-es/throttle';
 import delay from 'lodash-es/delay';
 import clsx from 'clsx';
 import modifier from '../../mixins/modifier';
@@ -69,7 +70,7 @@ export default {
     }, 250));
   },
   methods: {
-    handleClick(tabClicked) {
+    handleClick: debounce(function handleClickCallback(tabClicked) {
       const newSelectedTab = this.tabs.find(tab => tabClicked.name === tab.name);
       this.tabs.forEach((tab, index) => {
         if (newSelectedTab.name === tab.name) {
@@ -88,7 +89,7 @@ export default {
         }
       });
       this.updateUnderline();
-    },
+    }, 500, { leading: true, trailing: false }),
     calculateOverflow() {
       let containerWidth = 0;
       if (this.$refs.cdrTabsContainer) {

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -2,11 +2,12 @@ import debounce from 'lodash-es/debounce';
 import delay from 'lodash-es/delay';
 import clsx from 'clsx';
 import modifier from '../../mixins/modifier';
+import size from '../../mixins/size';
 import style from './styles/CdrTabs.scss';
 
 export default {
   name: 'CdrTabs',
-  mixins: [modifier],
+  mixins: [modifier, size],
   props: {
     height: {
       type: String,
@@ -179,7 +180,7 @@ export default {
   render() {
     return (
       <div
-        class={clsx(this.style[this.baseClass], this.modifierClass)}
+        class={clsx(this.style[this.baseClass], this.modifierClass, this.sizeClass)}
         ref="cdrTabsContainer"
         style={{ height: this.height }}
       >

--- a/src/components/tabs/__tests__/CdrTabs.spec.js
+++ b/src/components/tabs/__tests__/CdrTabs.spec.js
@@ -198,11 +198,13 @@ describe('CdrTabs', () => {
     wrapper.setData({ activeTabIndex: 1 });
 
     Vue.nextTick(() => {
-      wrapper.findAll('a').at(0).trigger('click');
-      expect(wrapper.vm.activeTabIndex).toBe(0);
+      setTimeout(() => {
+        wrapper.findAll('a').at(0).trigger('click');
+        expect(wrapper.vm.activeTabIndex).toBe(0);
 
-      wrapper.findAll('a').at(1).trigger('click');
-      expect(wrapper.vm.activeTabIndex).toBe(1);
+        wrapper.findAll('a').at(1).trigger('click');
+        expect(wrapper.vm.activeTabIndex).toBe(1);
+      }, 500);
 
       done()
     })

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -80,7 +80,7 @@
       >
         Compact Tabs
       </cdr-text>
-      <cdr-tabs modifier="compact">
+      <cdr-tabs size="small">
         <cdr-tab-panel name="one">
           <cdr-text
             tag="strong"

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -171,7 +171,7 @@
 
   /* Compact
     ========== */
-  &--compact {
+  &--compact, &--small {
     .cdr-tabs__header-item-label {
       @include cdr-tabs-compact-header-item-label;
 

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -173,7 +173,7 @@
     ========== */
   &--compact, &--small {
     .cdr-tabs__header-item-label {
-      @include cdr-tabs-compact-header-item-label;
+      @include cdr-tabs-small-header-item-label;
 
       padding: $cdr-space-inset-three-quarter-x-squish;
 

--- a/src/components/tabs/styles/vars/CdrTabs.vars.scss
+++ b/src/components/tabs/styles/vars/CdrTabs.vars.scss
@@ -9,7 +9,7 @@ $cdr-tab-panel-animation-duration: $cdr-duration-5-x;
   line-height: 2.2rem;
 }
 
-@mixin cdr-tabs-compact-header-item-label() {
+@mixin cdr-tabs-small-header-item-label() {
   font-family: $cdr-font-family-sans;
   font-style: normal;
   font-weight: 500;


### PR DESCRIPTION
## Description
I'll wait to make this live until the patch goes out.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that are completed. -->

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] IE11
- [ ] iOS
- [ ] Android

### Visual regression testing:
- [ ] Added/updated backstop tests
- [ ] Passes with existing reference images (or failed as expected)

### Unit testing:
- [ ] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [ ] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [ ] Examples created/updated
