### PR TITLE
fix(build): mark CSS files as having sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",
   "private": false,
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
resolves https://github.com/rei/rei-cedar/issues/770

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

By setting `sideEffects: false`, we're basically telling webpack that everything we export is side effect free. However CSS by definition has side effects. In certain situations (such as importing a cedar CSS file inside a JS file) this will result in webpack shaking that CSS file out of the build completely, which results in a confusing error for consumers. 

This issue should be resolved with the move to `@import url()` style CSS imports, but may affect consumers who for whatever reason choose to still load the full compiled Cedar CSS file.



- should be released as a patch to 3.x and 4.x (can just cherry pick this commit into the 3.x tag...should also document that process while we're at it)

- needs testing against febs (why wasn't febs 5 shaking our CSS files out???)

- need to verify that this doesn't cause ALL the css to get bundled in

