### PR TITLE
fix(build): fix style path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "REI Software Engineering",
   "main": "dist/cedar.js",
   "module": "dist/lib/index.mjs",
-  "style": "dist/style/cdr-full.css",
+  "style": "dist/style/cedar-full.css",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
should go out in the patch, file names got shuffled around before the released and I missed this update. nobody is using this feature AFAIK but good to support just in case