### PR TITLE
fix(tabs): switch from flex center to auto margins for tabs header

### DIFF
--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -201,8 +201,8 @@
   /* Centered
     ========== */
   &--centered {
-    .cdr-tabs__header {
-      justify-content: center;
+    .cdr-tabs__header-item {
+      margin: auto;
     }
   }
 }


### PR DESCRIPTION

## Description

https://stackoverflow.com/a/33455342
if flex item overflows its container,
flex center no longer works and some content
is inaccessible. Using margin: auto on the
flex item should center items and scroll properly

Will discuss this at intake today. Definitely need to test this out a bit but i think this should solve the problem

### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] IE11
- [ ] iOS
- [ ] Android

### Visual regression testing:
- [ ] Added/updated backstop tests
- [ ] Passes with existing reference images (or failed as expected)

### Unit testing:
- [ ] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [ ] Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [ ] Examples created/updated
