### PR TITLE
Tabs patch fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "4.0.3-beta.0",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "4.0.2",
+  "version": "4.0.3-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "4.0.2",
+  "version": "4.0.3-beta.0",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "4.0.3-beta.0",
+  "version": "4.0.3",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -287,12 +287,27 @@
           name="one"
           id="centered-one"
         >
+        <cdr-text
+          tag="strong"
+          modifier="subheading"
+        >
+          <cdr-text>What's a rerun? Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Whoa, whoa, kid, kid, stop, stop, stop, stop. Leave me alone. Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh.
+
+            I have a feeling too. What? Well, I figured, what the hell. Alright, we're the pinheads. C'mon.
+
+            Yeah, well, I still don't understand what Dad was doing in the middle of the street. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Great good, good, Lorraine, I had a feeling about you two. Right. Well, Marty, I want to thank you for all your good advise, I'll never forget it.</cdr-text>
           <cdr-text
-            tag="strong"
-            modifier="subheading"
-          >
-            Tab One Content
-          </cdr-text>
+            tag="h1"
+            modifier="display-600 display-700@md display-900@lg"
+          >tab three content</cdr-text>
+          Tab Two Content
+          <cdr-text>What's a rerun? Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Whoa, whoa, kid, kid, stop, stop, stop, stop. Leave me alone. Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh.
+
+            I have a feeling too. What? Well, I figured, what the hell. Alright, we're the pinheads. C'mon.
+
+            Yeah, well, I still don't understand what Dad was doing in the middle of the street. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Great good, good, Lorraine, I had a feeling about you two. Right. Well, Marty, I want to thank you for all your good advise, I'll never forget it.</cdr-text>
+        </cdr-text>
+
         </cdr-tab-panel>
         <cdr-tab-panel
           name="two"

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -338,6 +338,42 @@
             Tab Five Content
           </cdr-text>
         </cdr-tab-panel>
+
+        <cdr-tab-panel
+          name="six"
+          id="centered-six"
+        >
+          <cdr-text
+            tag="strong"
+            modifier="subheading"
+          >
+            Tab six Content
+          </cdr-text>
+        </cdr-tab-panel>
+
+        <cdr-tab-panel
+          name="seven"
+          id="centered-seven"
+        >
+          <cdr-text
+            tag="strong"
+            modifier="subheading"
+          >
+            Tab seven Content
+          </cdr-text>
+        </cdr-tab-panel>
+
+        <cdr-tab-panel
+          name="eight"
+          id="centered-eight"
+        >
+          <cdr-text
+            tag="strong"
+            modifier="subheading"
+          >
+            Tab eight Content
+          </cdr-text>
+        </cdr-tab-panel>
       </cdr-tabs>
     </div>
   </div>

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -140,6 +140,7 @@
   }
 
   &__underline {
+    z-index: 1;
     position: absolute;
     width: 30px;
     margin: 0;

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -205,8 +205,11 @@
   /* Centered
     ========== */
   &--centered {
-    .cdr-tabs__header {
-      justify-content: center;
+    .cdr-tabs__header-item:first-of-type {
+      margin-left: auto;
+    }
+    .cdr-tabs__header-item:last-of-type {
+      margin-right: auto;
     }
   }
 }


### PR DESCRIPTION
## Description

3rd try at this PR is a charm 🤞 

This resolves 2 issues reported to us by the Adventures team:

- Switches from using flexbox centering (which does not care if flex content overflows its container) to using auto margins on the outside elements. https://stackoverflow.com/a/33455342
- add z-index to underline so content does not overlap

Also adds more content to the tabs centered example so that this issues are repro-able in the kitchen sink.

Should go to master as a patch release, then sync next with master.

### Design:
- n/a Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
- n/a Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- n/a Meets WCAG AA standards

