### PR TITLE
Update color for text-ish components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1392,9 +1392,9 @@
       "dev": true
     },
     "@rei/cdr-tokens": {
-      "version": "4.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-4.0.0-alpha.2.tgz",
-      "integrity": "sha512-REieNA+hNnqF2XCjPbqStUa1vpd8uX1IhMTZ8SFqWp6rNl1F8Fichj+rzU/lohmBNgtj9GO066ohAkh5Y920/w==",
+      "version": "4.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-4.0.0-alpha.3.tgz",
+      "integrity": "sha512-TsxKDiALv6PYIno0qec5kI9HXKDApxqI9/pzYYMU6BEUAH+rYv5RcAggWlpoDwKtBC/J0eWlJb2nWKTJkfYwIA==",
       "dev": true
     },
     "@rei/cedar-icons": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@betit/rollup-plugin-rename-extensions": "0.0.5",
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
-    "@rei/cdr-tokens": "^4.0.0-alpha.2",
+    "@rei/cdr-tokens": "^4.0.0-alpha.3",
     "@rei/cedar-icons": "^1.3.0",
     "@rollup/plugin-alias": "^2.2.0",
     "@vue/babel-preset-jsx": "^1.1.2",

--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -100,7 +100,7 @@ export default {
         return (<li
           class={clsx(
             this.style['cdr-breadcrumb__item'],
-            isLink ? this.style['cdr-breadcrumb__item-linked'] : null
+            isLink ? this.style['cdr-breadcrumb__item-linked'] : null,
           )}
           key={breadcrumb.item.id || breadcrumb.item.name.replace(/ /g, '-').toLowerCase()}
           v-show={!this.truncate || (index >= this.items.length - 2)}

--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -94,10 +94,14 @@ export default {
         </span>) : '';
 
         const ref = index === 0 ? 'firstBreadcrumb' : null;
-        const LinkTag = index < this.items.length - 2 ? 'a' : 'strong';
+        const isLink = index < this.items.length - 1;
+        const LinkTag = isLink ? 'a' : 'strong';
 
         return (<li
-          class={this.style['cdr-breadcrumb__item']}
+          class={clsx(
+            this.style['cdr-breadcrumb__item'],
+            isLink ? this.style['cdr-breadcrumb__item-linked'] : null
+          )}
           key={breadcrumb.item.id || breadcrumb.item.name.replace(/ /g, '-').toLowerCase()}
           v-show={!this.truncate || (index >= this.items.length - 2)}
         >

--- a/src/components/breadcrumb/__tests__/__snapshots__/CdrBreadcrumb.spec.js.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/CdrBreadcrumb.spec.js.snap
@@ -38,7 +38,7 @@ exports[`CdrBreadcrumb renders correctly 1`] = `
       </span>
     </li>
     <li
-      class="cdr-breadcrumb__item"
+      class="cdr-breadcrumb__item cdr-breadcrumb__item-linked"
       style="display: none;"
     >
       <a
@@ -55,14 +55,14 @@ exports[`CdrBreadcrumb renders correctly 1`] = `
       </span>
     </li>
     <li
-      class="cdr-breadcrumb__item"
+      class="cdr-breadcrumb__item cdr-breadcrumb__item-linked"
     >
-      <strong
+      <a
         class="cdr-breadcrumb__link"
         href="http://rei.com"
       >
         Long Breadcrumb Step 2
-      </strong>
+      </a>
       <span
         aria-hidden="true"
         class="cdr-breadcrumb__delimiter"

--- a/src/components/breadcrumb/styles/CdrBreadcrumb.scss
+++ b/src/components/breadcrumb/styles/CdrBreadcrumb.scss
@@ -41,10 +41,6 @@
     padding: 0;
 
     @include cdr-breadcrumb-item-mixin;
-
-    &:last-child {
-      @include cdr-breadcrumb-last-item-mixin;
-    }
   }
 
   /* Link

--- a/src/components/breadcrumb/styles/CdrBreadcrumb.scss
+++ b/src/components/breadcrumb/styles/CdrBreadcrumb.scss
@@ -41,7 +41,12 @@
     padding: 0;
 
     @include cdr-breadcrumb-item-mixin;
+    
+    &-linked {
+      @include cdr-breadcrumb-item-linked-mixin;
+    }
   }
+
 
   /* Link
   ---------- */
@@ -95,7 +100,7 @@
     &:active,
     &:focus {
       .cdr-breadcrumb__ellipses-icon {
-        border-bottom: 1px solid $cdr-color-text-primary-lightmode;
+        border-bottom: 1px solid $cdr-color-text-link-hover;
         fill: inherit;
       }
     }

--- a/src/components/breadcrumb/styles/vars/CdrBreadcrumb.vars.scss
+++ b/src/components/breadcrumb/styles/vars/CdrBreadcrumb.vars.scss
@@ -1,17 +1,18 @@
 @mixin cdr-breadcrumb-item-mixin() {
-  color: $cdr-color-text-secondary-lightmode;
-  fill: $cdr-color-text-secondary-lightmode;
-  &:hover,
+  color: $cdr-color-text-secondary;
+  fill: $cdr-color-text-secondary;
+
+  // TODO: are these applied correctly? 
+  &:hover {
+    color: $cdr-color-text-link-hover;
+    fill: $cdr-color-text-link-hover;
+  }
+
   &:active,
   &:focus {
-    color: $cdr-color-text-primary-lightmode;
-    fill: $cdr-color-text-primary-lightmode;
+    color: $cdr-color-text-link-active;
+    fill: $cdr-color-text-link-active;
   }
-}
-
-@mixin cdr-breadcrumb-last-item-mixin() {
-  color: $cdr-color-text-primary-lightmode;
-  fill: $cdr-color-text-primary-lightmode;
 }
 
 @mixin cdr-breadcrumb-base-text-mixin() {

--- a/src/components/breadcrumb/styles/vars/CdrBreadcrumb.vars.scss
+++ b/src/components/breadcrumb/styles/vars/CdrBreadcrumb.vars.scss
@@ -1,13 +1,10 @@
 @mixin cdr-breadcrumb-item-mixin() {
   color: $cdr-color-text-secondary;
   fill: $cdr-color-text-secondary;
+}
 
-  // TODO: are these applied correctly? 
-  &:hover {
-    color: $cdr-color-text-link-hover;
-    fill: $cdr-color-text-link-hover;
-  }
-
+@mixin cdr-breadcrumb-item-linked-mixin() {
+  &:hover,
   &:active,
   &:focus {
     color: $cdr-color-text-link-active;

--- a/src/components/caption/styles/vars/CdrCaption.vars.scss
+++ b/src/components/caption/styles/vars/CdrCaption.vars.scss
@@ -13,8 +13,7 @@
   line-height: 2.2rem;
 
   margin: 0;
-  color: $cdr-color-text-primary;
-   // TODO: necessary to state primary everywhere?
+  // color: $cdr-color-text-primary; // TODO: inherit or override?
 
   & + cite {
     display: inline-block;

--- a/src/components/caption/styles/vars/CdrCaption.vars.scss
+++ b/src/components/caption/styles/vars/CdrCaption.vars.scss
@@ -13,7 +13,7 @@
   line-height: 2.2rem;
 
   margin: 0;
-  // color: $cdr-color-text-primary; // TODO: inherit or override?
+  color: $cdr-color-text-primary;
 
   & + cite {
     display: inline-block;

--- a/src/components/caption/styles/vars/CdrCaption.vars.scss
+++ b/src/components/caption/styles/vars/CdrCaption.vars.scss
@@ -13,6 +13,8 @@
   line-height: 2.2rem;
 
   margin: 0;
+  color: $cdr-color-text-primary;
+   // TODO: necessary to state primary everywhere?
 
   & + cite {
     display: inline-block;
@@ -28,6 +30,6 @@
   letter-spacing: 0.16px;
   line-height: 1.8rem;
 
-  color: $cdr-color-text-secondary-lightmode;
+  color: $cdr-color-text-secondary;
   font-style: normal;
 }

--- a/src/components/link/styles/CdrLink.scss
+++ b/src/components/link/styles/CdrLink.scss
@@ -23,34 +23,3 @@
 .cdr-link--standalone {
   @include cdr-link-standalone-mixin;
 }
-
-/* Light Theme */
-
-/* Theme via cascade
-
-:global(.cdr-bg--light) .cdr-link {
-  @include cdr-link-lightmode-mixin;
-}
-*/
-
-/* Theme via prop */
-
-:global(.on-light).cdr-link {
-  @include cdr-link-lightmode-mixin;
-}
-
-/* Dark Theme */
-
-/* Theme via cascade
-
-:global(.cdr-bg--dark) .cdr-link {
-
-  @include cdr-link-darkmode-mixin;
-}
-*/
-
-/* Theme via prop */
-
-:global(.on-dark).cdr-link {
-  @include cdr-link-darkmode-mixin;
-}

--- a/src/components/link/styles/vars/CdrLink.vars.scss
+++ b/src/components/link/styles/vars/CdrLink.vars.scss
@@ -6,8 +6,8 @@
   background-color: transparent;
   border: 0;
   margin: 0;
-  color: $cdr-color-text-link-lightmode;
-  fill: $cdr-color-text-link-lightmode;
+  color: $cdr-color-text-link-rest;
+  fill: $cdr-color-text-link-rest;
   cursor: pointer;
   display: inline-flex;
   outline: none;
@@ -21,16 +21,31 @@
   &:hover,
   &:active,
   &:focus {
-    color: $cdr-color-text-link-lightmode;
     outline: none;
     text-decoration: underline;
   }
 
+  &:visited {
+    color: $cdr-color-text-link-visited;
+  }
+
+  &:hover {
+    color: $cdr-color-text-link-hover;
+  }
+
+  &:active,
   &:focus {
+    color: $cdr-color-text-link-active;
+  }
+
+  &:focus {
+    color: $cdr-color-text-link-active;
     outline: $default-outline;
     outline-color: -webkit-focus-ring-color;
     outline-offset: 0;
   }
+
+  // TODO: there's a token for link-disabled, but is that a thing?
 }
 
 @mixin cdr-link-standalone-mixin() {
@@ -44,13 +59,5 @@
   }
 }
 
-@mixin cdr-link-lightmode-mixin() {
-  color: $cdr-color-text-link-lightmode;
-  fill: $cdr-color-text-link-lightmode;
-}
-
-@mixin cdr-link-darkmode-mixin() {
-  color: $cdr-color-text-link-darkmode;
-  fill: $cdr-color-text-link-darkmode;
-
-}
+// TODO: not sure there is a way to gracefully deprecate any of the on-light/on-dark stuff
+// though we also never documented it, and nobody seems to be using it...so...maybe NBD?

--- a/src/components/link/styles/vars/CdrLink.vars.scss
+++ b/src/components/link/styles/vars/CdrLink.vars.scss
@@ -45,7 +45,6 @@
     outline-offset: 0;
   }
 
-  // TODO: there's a token for link-disabled, but is that a thing?
 }
 
 @mixin cdr-link-standalone-mixin() {

--- a/src/components/link/styles/vars/CdrLink.vars.scss
+++ b/src/components/link/styles/vars/CdrLink.vars.scss
@@ -33,8 +33,7 @@
     color: $cdr-color-text-link-hover;
   }
 
-  &:active,
-  &:focus {
+  &:active {
     color: $cdr-color-text-link-active;
   }
 
@@ -57,6 +56,3 @@
     text-decoration: underline;
   }
 }
-
-// TODO: not sure there is a way to gracefully deprecate any of the on-light/on-dark stuff
-// though we also never documented it, and nobody seems to be using it...so...maybe NBD?

--- a/src/components/list/styles/CdrList.scss
+++ b/src/components/list/styles/CdrList.scss
@@ -92,6 +92,7 @@
 
         &::before {
           content: '\2022';
+          color: $cdr-color-text-secondary;
           display: block;
           position: absolute;
           top: 50%;

--- a/src/components/list/styles/vars/CdrList.vars.scss
+++ b/src/components/list/styles/vars/CdrList.vars.scss
@@ -2,7 +2,6 @@
   list-style-type: none;
   padding: 0;
   margin: 0;
-  // color: $cdr-color-text-primary;  // TODO: inherit or override?
 
   /* spacing
     ---------- */

--- a/src/components/list/styles/vars/CdrList.vars.scss
+++ b/src/components/list/styles/vars/CdrList.vars.scss
@@ -2,6 +2,7 @@
   list-style-type: none;
   padding: 0;
   margin: 0;
+  color: $cdr-color-text-primary; // TODO: necessary?
 
   /* spacing
     ---------- */
@@ -51,6 +52,7 @@
     &::before {
       content: '\2013';
       position: absolute;
+      color: $cdr-color-text-secondary;
       left: 0;
     }
   }
@@ -65,6 +67,7 @@
     position: relative;
     margin-left: -1em;
     padding-right: $cdr-space-half-x;
+    color: $cdr-color-text-secondary;
   }
 }
 
@@ -79,6 +82,7 @@
       position: relative;
       margin-left: -1em;
       padding-right: $cdr-space-half-x;
+      color: $cdr-color-text-secondary;
     }
   }
 }

--- a/src/components/list/styles/vars/CdrList.vars.scss
+++ b/src/components/list/styles/vars/CdrList.vars.scss
@@ -2,7 +2,7 @@
   list-style-type: none;
   padding: 0;
   margin: 0;
-  color: $cdr-color-text-primary; // TODO: necessary?
+  // color: $cdr-color-text-primary;  // TODO: inherit or override?
 
   /* spacing
     ---------- */

--- a/src/components/quote/styles/vars/CdrQuote.vars.scss
+++ b/src/components/quote/styles/vars/CdrQuote.vars.scss
@@ -10,7 +10,7 @@
   font-size: 24px;
   line-height: 36px;
   letter-spacing: -.08rem;
-  color: $cdr-color-text-primary; // TODO: necessary?
+  // color: $cdr-color-text-primary;  // TODO: inherit or override?
 
   @include xs-mq-only {
     font-size: 18px;

--- a/src/components/quote/styles/vars/CdrQuote.vars.scss
+++ b/src/components/quote/styles/vars/CdrQuote.vars.scss
@@ -10,6 +10,7 @@
   font-size: 24px;
   line-height: 36px;
   letter-spacing: -.08rem;
+  color: $cdr-color-text-primary; // TODO: necessary?
 
   @include xs-mq-only {
     font-size: 18px;
@@ -20,7 +21,7 @@
 
   & + cite {
     @include cdr-text-utility-sans-100;
-
+    color: $cdr-color-text-secondary;
     display: block;
     padding-top: $cdr-space-one-x;
   }
@@ -28,7 +29,7 @@
 
 @mixin cdr-quote-pull-container() {
   border-style: solid;
-  border-color: #222; // TODO: possible color token?
+  border-color: $cdr-color-border-primary;
 
   @include xs-mq {
     border-width: 0 0 1px 0;

--- a/src/components/quote/styles/vars/CdrQuote.vars.scss
+++ b/src/components/quote/styles/vars/CdrQuote.vars.scss
@@ -10,7 +10,7 @@
   font-size: 24px;
   line-height: 36px;
   letter-spacing: -.08rem;
-  // color: $cdr-color-text-primary;  // TODO: inherit or override?
+  color: $cdr-color-text-primary;
 
   @include xs-mq-only {
     font-size: 18px;

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -83,8 +83,14 @@
       >
         Compact Tabs
       </cdr-text>
-      <cdr-tabs size="small" :active-tab="1">
-        <cdr-tab-panel name="one" :disabled="true">
+      <cdr-tabs
+        size="small"
+        :active-tab="1"
+      >
+        <cdr-tab-panel
+          name="one"
+          :disabled="true"
+        >
           <cdr-text
             tag="strong"
             modifier="subheading"
@@ -92,7 +98,10 @@
             Tab One Content
           </cdr-text>
         </cdr-tab-panel>
-        <cdr-tab-panel name="two" :disabled="true">
+        <cdr-tab-panel
+          name="two"
+          :disabled="true"
+        >
           <cdr-text
             tag="strong"
             modifier="subheading"
@@ -291,26 +300,26 @@
           name="one"
           id="centered-one"
         >
-        <cdr-text
-          tag="strong"
-          modifier="subheading"
-        >
-          <cdr-text>What's a rerun? Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Whoa, whoa, kid, kid, stop, stop, stop, stop. Leave me alone. Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh.
-
-            I have a feeling too. What? Well, I figured, what the hell. Alright, we're the pinheads. C'mon.
-
-            Yeah, well, I still don't understand what Dad was doing in the middle of the street. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Great good, good, Lorraine, I had a feeling about you two. Right. Well, Marty, I want to thank you for all your good advise, I'll never forget it.</cdr-text>
           <cdr-text
-            tag="h1"
-            modifier="display-600 display-700@md display-900@lg"
-          >tab three content</cdr-text>
-          Tab Two Content
-          <cdr-text>What's a rerun? Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Whoa, whoa, kid, kid, stop, stop, stop, stop. Leave me alone. Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh.
+            tag="strong"
+            modifier="subheading"
+          >
+            <cdr-text>What's a rerun? Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Whoa, whoa, kid, kid, stop, stop, stop, stop. Leave me alone. Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh.
 
-            I have a feeling too. What? Well, I figured, what the hell. Alright, we're the pinheads. C'mon.
+              I have a feeling too. What? Well, I figured, what the hell. Alright, we're the pinheads. C'mon.
 
-            Yeah, well, I still don't understand what Dad was doing in the middle of the street. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Great good, good, Lorraine, I had a feeling about you two. Right. Well, Marty, I want to thank you for all your good advise, I'll never forget it.</cdr-text>
-        </cdr-text>
+              Yeah, well, I still don't understand what Dad was doing in the middle of the street. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Great good, good, Lorraine, I had a feeling about you two. Right. Well, Marty, I want to thank you for all your good advise, I'll never forget it.</cdr-text>
+            <cdr-text
+              tag="h1"
+              modifier="display-600 display-700@md display-900@lg"
+            >tab three content</cdr-text>
+            Tab Two Content
+            <cdr-text>What's a rerun? Hey, hey listen guys. Look, I don't wanna mess with no reefer addicts, okay? Whoa, whoa, kid, kid, stop, stop, stop, stop. Leave me alone. Oh, thank you, thank you. Okay now, we run some industrial strength electrical cable from the top of the clocktower down to spreading it over the street between two lamp posts. Meanwhile, we out-fitted the vehicle with this big pole and hook which runs directly into the flux-capacitor. At the calculated moment, you start off from down the street driving toward the cable execrating to eighty-eight miles per hour. According to the flyer, at !0:04 pm lightning will strike the clocktower sending one point twenty-one gigawatts into the flux-capacitor, sending you back to 1985. Alright now, watch this. You wind up the car and release it, I'll simulate the lightening. Ready, set, release. Huhh.
+
+              I have a feeling too. What? Well, I figured, what the hell. Alright, we're the pinheads. C'mon.
+
+              Yeah, well, I still don't understand what Dad was doing in the middle of the street. Right. Lou, gimme a milk, chocolate. Lorraine, my density has popped me to you. Great good, good, Lorraine, I had a feeling about you two. Right. Well, Marty, I want to thank you for all your good advise, I'll never forget it.</cdr-text>
+          </cdr-text>
 
         </cdr-tab-panel>
         <cdr-tab-panel

--- a/src/css/utility/_text.scss
+++ b/src/css/utility/_text.scss
@@ -101,9 +101,6 @@ h6.cdr-text.cdr-text,
 
   &--citation {
     @include cdr-text-utility-sans-strong-100;
-    // color: $cdr-color-text-secondary;
-    // TODO: should all citations be color secondary?
-    // or just the one in CdrQuote?
   }
 
   &--eyebrow-100 {

--- a/src/css/utility/_text.scss
+++ b/src/css/utility/_text.scss
@@ -101,6 +101,9 @@ h6.cdr-text.cdr-text,
 
   &--citation {
     @include cdr-text-utility-sans-strong-100;
+    // color: $cdr-color-text-secondary;
+    // TODO: should all citations be color secondary?
+    // or just the one in CdrQuote?
   }
 
   &--eyebrow-100 {


### PR DESCRIPTION
## Description

These components seemed like the lowest hanging fruit and least likely to change.

Link, List, Breadcrumb, Caption, Quote, CSS Reset

Open Questions:
- we currently do not set color: primary in caption, list, or quote, and just allow them to inherit their color. Should we continue that or explicitly set color: primary on those? **answer: set caption and quote to primary, let list inherit**
- i just deleted the `on-light` and `on-dark` options for cdr-link. I couldn't find any instance of those being used with link in bitbucket, and we don't have it documented anywhere. (there was a single instance of someone using cdr-button on-dark but otherwise i couldn't find any one using those theming classes). **answer: will discuss at dev critique, note in release notes just in case**
- we have designs and tokens for link disabled, but no way to handle it currently unless we break the API or add a new property. (we could say "a link without an href is disabled" but ppl use links for JS triggers, cdr-link href defaults to "#", and tag="button" results in no href being set) **Opening a separate ticket for adding a disabled link feature.**
- i was able to update the unordered list elements to use the secondary color, we can do the same to the ordered numbers as well if we want to, would just require a lil CSS: https://css-tricks.com/custom-list-number-styling/) **answer: Opening a separate PR/ticket for this, as it seems a lil tricky to get it to match the current list styles**


### Design:
- [x] Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- [x] Added/updated backstop tests
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
- n/a Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- [x] API docs created/updated
- n/a Examples created/updated
