### PR TITLE
Update form component colors

### DIFF
--- a/src/components/checkbox/examples/checkboxes.vue
+++ b/src/components/checkbox/examples/checkboxes.vue
@@ -140,20 +140,20 @@
 
     <cdr-checkbox
       indeterminate
-    >indeterminate</cdr-checkbox>
+    >indeterminate (not functional)</cdr-checkbox>
     <cdr-checkbox
       indeterminate
       disabled
-    >indeterminate</cdr-checkbox>
+    >indeterminate (not functional)</cdr-checkbox>
     <cdr-checkbox
       indeterminate
       modifier="compact"
-    >indeterminate compact</cdr-checkbox>
+    >indeterminate compact (not functional)</cdr-checkbox>
     <cdr-checkbox
       indeterminate
       disabled
       modifier="compact"
-    >indeterminate compact</cdr-checkbox>
+    >indeterminate compact (not functional)</cdr-checkbox>
 
     <cdr-checkbox modifier="hide-figure">
       Hidden box

--- a/src/components/checkbox/styles/CdrCheckbox.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.scss
@@ -39,8 +39,8 @@
     position: absolute;
     left: 0;
     border-radius: $cdr-radius-softer;
-    background-color: $cdr-color-background-form-lightmode;
-    border: 1px solid $cdr-color-border-primary-lightmode;
+    background-color: $cdr-color-background-input-default;
+    border: 1px solid $cdr-color-border-input-default;
   }
 
   /* States
@@ -49,16 +49,16 @@
   /* Checked
   ========== */
   &__input:checked ~ &__figure {
-    border-color: #3278ae;
-    background-color: #3278ae;
-    background-image: svg-load('node_modules/@rei/cedar-icons/dist/icons/check-lg.svg', fill="#fff");
+    border-color: $cdr-color-border-input-default-selected;
+    background-color: $cdr-color-background-input-default-selected;
+    background-image: svg-load('node_modules/@rei/cedar-icons/dist/icons/check-lg.svg', fill="#fff"); // TODO: color checkme
     background-repeat: no-repeat;
   }
 
   /* Indeterminate
   ========== */
   &__input[indeterminate] ~ .cdr-checkbox__figure {
-    border-color: #3278ae;
+    border-color: $cdr-color-border-input-default-selected;
 
     &::after {
       content: '';
@@ -67,8 +67,8 @@
       top: 50%;
       transform: translate(-50%, -50%);
       width: 8px;
-      height: 8px;
-      background-color: #3278ae;
+      height: 8px; // TODO: edit width/height to create "minus" sign
+      background-color: $cdr-color-background-input-default-selected;
       border-radius: $cdr-radius-soft;
     }
   }
@@ -78,8 +78,8 @@
   &:hover {
     & > .cdr-checkbox__figure {
       cursor: pointer;
-      border-color: $cdr-color-border-primary-lightmode;
-      background-color: $cdr-color-background-lighter;
+      border-color: $cdr-color-border-input-default-hover;
+      background-color: $cdr-color-background-input-default-hover;
     }
 
     & > .cdr-checkbox__content {
@@ -90,17 +90,17 @@
       /* Hover + Checked
       ========== */
       &:checked ~ .cdr-checkbox__figure {
-        border-color: #3278ae;
-        background-color: #3278ae;
+        border-color: $cdr-color-border-input-default-selected-hover;
+        background-color: $cdr-color-background-input-default-selected-hover;
       }
 
       /* Hover + Indeterminate
       ========== */
       &[indeterminate] ~ .cdr-checkbox__figure {
-        border-color: #2b6692;
+        border-color: $cdr-color-border-input-default-selected;
 
         &::after {
-          background-color: #2b6692;
+          background-color: $cdr-color-background-input-default-selected;
         }
       }
     }
@@ -114,16 +114,16 @@
     }
 
     & ~ .cdr-checkbox__figure {
-      border-color: $cdr-color-border-disabled-lightmode !important;
-      background-color: $cdr-color-background-lighter !important;
-      cursor: default;
+      border-color: $cdr-color-border-input-default-disabled !important;
+      background-color: $cdr-color-background-input-default-disabled !important;
+      cursor: not-allowed;
     }
 
     /* Disabled + Checked
     ========== */
     &:checked {
       & ~ .cdr-checkbox__figure {
-        background-color: $cdr-color-border-disabled-lightmode !important;
+        background-color: $cdr-color-background-input-default-disabled !important;
       }
     }
 
@@ -131,10 +131,10 @@
     ========== */
     &[indeterminate] {
       & ~ .cdr-checkbox__figure {
-        border-color: $cdr-color-border-disabled-lightmode !important;
+        border-color: $cdr-color-border-input-default-disabled !important;
 
         &::after {
-          background-color: $cdr-color-background-lighter !important;
+          background-color: $cdr-color-background-input-default-disabled !important;
         }
       }
     }
@@ -143,13 +143,13 @@
   /* Active
   ========== */
   &:active > .cdr-checkbox__figure {
-    border-color: #3278ae;
+    border-color: $cdr-color-border-input-default-active;
   }
 
   /* Focus
   ========== */
   &__input:focus ~ .cdr-checkbox__figure {
-    border-color: #3278ae;
+    border-color: $cdr-color-border-input-default-active;
     box-shadow: $cdr-label-figure-box-shadow;
   }
 
@@ -217,6 +217,4 @@
       display: none;
     }
   }
-
-
 }

--- a/src/components/checkbox/styles/CdrCheckbox.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.scss
@@ -51,7 +51,7 @@
   &__input:checked ~ &__figure {
     border-color: $cdr-color-border-input-default-selected;
     background-color: $cdr-color-background-input-default-selected;
-    background-image: svg-load('node_modules/@rei/cedar-icons/dist/icons/check-lg.svg', fill="#fff"); // TODO: color checkme
+    background-image: svg-load('node_modules/@rei/cedar-icons/dist/icons/check-lg.svg', fill="#fff");
     background-repeat: no-repeat;
   }
 
@@ -67,7 +67,7 @@
       top: 50%;
       transform: translate(-50%, -50%);
       width: 8px;
-      height: 8px; // TODO: edit width/height to create "minus" sign
+      height: 2px;
       background-color: $cdr-color-background-input-default-selected;
       border-radius: $cdr-radius-soft;
     }
@@ -97,10 +97,10 @@
       /* Hover + Indeterminate
       ========== */
       &[indeterminate] ~ .cdr-checkbox__figure {
-        border-color: $cdr-color-border-input-default-selected;
+        border-color: $cdr-color-border-input-default-selected-hover;
 
         &::after {
-          background-color: $cdr-color-background-input-default-selected;
+          background-color: $cdr-color-background-input-default-selected-hover;
         }
       }
     }

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -23,7 +23,7 @@
   @include cdr-input-base-label-mixin;
 
   &--disabled {
-  color:  $cdr-color-text-disabled-lightmode;
+    color:  $cdr-color-text-input-disabled;
   }
 }
 

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -1,8 +1,8 @@
 @mixin cdr-input-base-mixin() {
   @include cdr-text-utility-sans-300;
 
-  color: $cdr-color-text-form-label-lightmode;
-  box-shadow: inset 0 0 0 1px $cdr-color-border-primary-lightmode;
+  color: $cdr-color-text-input-default;
+  // box-shadow: inset 0 0 0 1px $cdr-color-border-input-default; // TODO: re-enable once token is added
   border: 0;
   border-radius: $cdr-radius-softer;
   padding: $cdr-space-inset-half-x;
@@ -28,35 +28,34 @@
 
   &:active,
   &:focus {
-    box-shadow: inset 0 0 0 1px $cdr-color-border-selected-lightmode;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-selected;
   }
 
   &::placeholder {
     @include cdr-text-utility-sans-300;
 
-    color: $cdr-color-text-form-placeholder-lightmode;
+    color: $cdr-color-text-input-placeholder;
   }
 
   &[disabled] {
-    background-color: $cdr-color-background-lighter;
-    color: $cdr-color-text-form-disabled-lightmode;
-    box-shadow: inset 0 0 0 1px $cdr-color-border-disabled-lightmode;
+    background-color: $cdr-color-background-input-default-disabled;
+    color: $cdr-color-text-input-disabled;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled;
 
     &:hover {
-      box-shadow: inset 0 0 0 1px $cdr-color-border-disabled-lightmode;
+      box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled;
     }
 
     &::placeholder {
-      color: $cdr-color-text-form-disabled-lightmode;
+      color: $cdr-color-text-input-disabled;
     }
   }
-
 }
 
 @mixin cdr-input-base-label-mixin() {
   @include cdr-text-utility-sans-200;
 
-  color: $cdr-color-text-form-label-lightmode;
+  color: $cdr-color-text-input-label;
   display: inline-block;
   margin: 0;
   margin-bottom: $cdr-space-quarter-x;
@@ -78,7 +77,7 @@
   line-height: 1.8rem;
   letter-spacing: -0.016rem;
 
-  color: $cdr-color-text-secondary-lightmode;
+  color: $cdr-color-text-input-help;
   display: block;
 }
 
@@ -89,6 +88,6 @@
 }
 
 @mixin cdr-input-required-label-mixin() {
-  color: $cdr-color-text-secondary-lightmode;
+  color: $cdr-color-text-input-required;
   margin-left: $cdr-space-inset-quarter-x;
 }

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -2,7 +2,7 @@
   @include cdr-text-utility-sans-300;
 
   color: $cdr-color-text-input-default;
-  // box-shadow: inset 0 0 0 1px $cdr-color-border-input-default; // TODO: re-enable once token is added
+  box-shadow: inset 0 0 0 1px $cdr-color-border-input-default;
   border: 0;
   border-radius: $cdr-radius-softer;
   padding: $cdr-space-inset-half-x;
@@ -54,7 +54,7 @@
 
 @mixin cdr-input-base-label-mixin() {
   @include cdr-text-utility-sans-200;
-
+  font-weight: 500; // TODO: test 600
   color: $cdr-color-text-input-label;
   display: inline-block;
   margin: 0;

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -28,7 +28,7 @@
 
   &:active,
   &:focus {
-    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-selected;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-active;
   }
 
   &::placeholder {
@@ -44,6 +44,7 @@
 
     &:hover {
       box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled;
+      cursor: not-allowed;
     }
 
     &::placeholder {

--- a/src/components/radio/styles/CdrRadio.scss
+++ b/src/components/radio/styles/CdrRadio.scss
@@ -107,7 +107,7 @@
     & ~ .cdr-radio__figure {
       border-color: $cdr-color-border-input-default-disabled !important;
       background-color: $cdr-color-background-input-default-disabled !important;
-      cursor: default;
+      cursor: not-allowed;
     }
 
     /* Disabled + Checked

--- a/src/components/radio/styles/CdrRadio.scss
+++ b/src/components/radio/styles/CdrRadio.scss
@@ -1,24 +1,5 @@
 @import '../../../css/settings/index.scss';
 @import './vars/CdrRadio.vars.scss';
-/* ==========================================================================
-  # CdrRadio
-
-  All values should map to variables in
-  vars/CdrRadio.vars.pcss
-  in order to allow for theming
-
-  TOC:
-
-    :Base - Radio
-      :Elements
-        :wrap
-        :input
-        :figure
-      :States
-      :Modifiers
-        :compact
-        :hide-figure
-========================================================================== */
 
 .cdr-radio {
   @include cdr-label-base-mixin;
@@ -60,8 +41,8 @@
     position: absolute;
     left: 0;
     border-radius: $cdr-radius-round;
-    background-color: $cdr-color-background-form-input-lightmode;
-    border: 1px solid $cdr-color-border-primary-lightmode;
+    background-color: $cdr-color-background-input-default;
+    border: 1px solid $cdr-color-border-input-default;
 
     &::after {
       content: '';
@@ -82,10 +63,12 @@
   /* Checked
   ========== */
   &__input:checked ~ &__figure {
-    border-color: #3278ae;
+    // outer circle
+    border-color: $cdr-color-border-input-default-selected;
 
     &::after {
-      background-color: #3278ae;
+      // inner circle
+      background-color: $cdr-color-background-input-default-selected;
     }
   }
 
@@ -93,8 +76,8 @@
   &:hover {
     & > .cdr-radio__figure {
       cursor: pointer;
-      border-color: $cdr-color-border-primary-lightmode;
-      background-color: $cdr-color-background-lighter;
+      border-color: $cdr-color-border-input-default-hover;
+      background-color: $cdr-color-background-input-default-hover;
     }
 
     & > .cdr-radio__content {
@@ -105,10 +88,10 @@
       /* Hover + Checked
       ========== */
       &:checked ~ .cdr-radio__figure {
-        border-color: #2b6692;
+        border-color: $cdr-color-border-input-default-selected-hover;
 
         &::after {
-          background-color: #2b6692;
+          background-color: $cdr-color-background-input-default-selected-hover;
         }
       }
     }
@@ -122,8 +105,8 @@
     }
 
     & ~ .cdr-radio__figure {
-      border-color: $cdr-color-border-disabled-lightmode !important;
-      background-color: $cdr-color-background-lighter !important;
+      border-color: $cdr-color-border-input-default-disabled !important;
+      background-color: $cdr-color-background-input-default-disabled !important;
       cursor: default;
     }
 
@@ -132,7 +115,7 @@
     &:checked {
       & ~ .cdr-radio__figure {
         &::after {
-          background-color: #dadada !important;
+          background-color: $cdr-color-background-input-default-disabled !important;
         }
       }
     }
@@ -141,14 +124,14 @@
   /* Active
   ========== */
   &:active > .cdr-radio__figure {
-    border-color: #3278ae;
-    background-color: $cdr-color-background-form-input-lightmode;
+    border-color: $cdr-color-border-input-default-active;
+    background-color: $cdr-color-background-input-default;
   }
 
   /* Focus
   ========== */
   &__input:focus ~ .cdr-radio__figure {
-    border-color: #3278ae;
+    border-color: $cdr-color-border-input-default-active;
     box-shadow: $cdr-label-figure-box-shadow;
   }
 

--- a/src/components/select/styles/vars/CdrSelect.vars.scss
+++ b/src/components/select/styles/vars/CdrSelect.vars.scss
@@ -29,7 +29,7 @@
   width: 100%;
   overflow: auto;
   margin: 0;
-  background: $cdr-color-background-lightest;
+  background: $cdr-color-background-input-default;
 
   /* Hide Browser Styled Drowpdown Arrow */
   -webkit-appearance: none;
@@ -56,7 +56,7 @@
       cursor: not-allowed;
     }
   }
-  
+
   &:active,
   &:focus {
     box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-active;
@@ -67,7 +67,7 @@
   @include cdr-text-utility-sans-300;
 
   font-style: normal;
-  color: $cdr-color-text-input-placeholder;
+  color: $cdr-color-text-primary;
 
   &[disabled] {
     color: $cdr-color-text-input-disabled;

--- a/src/components/select/styles/vars/CdrSelect.vars.scss
+++ b/src/components/select/styles/vars/CdrSelect.vars.scss
@@ -1,7 +1,7 @@
 @mixin cdr-select-base-label-mixin() {
   @include cdr-text-utility-sans-200;
 
-  color: $cdr-color-text-form-label-lightmode;
+  color: $cdr-color-text-input-label;
   display: inline-block;
   margin: 0;
   margin-bottom: $cdr-space-quarter-x;
@@ -10,7 +10,7 @@
 
 /* input label disabled */
 @mixin cdr-select-base-label-disabled-mixin() {
-  color: $cdr-color-text-disabled-lightmode;
+  color: $cdr-color-text-input-disabled;
 }
 
 /* select base */
@@ -18,8 +18,8 @@
 @mixin cdr-select-base-mixin() {
   @include cdr-text-utility-sans-300;
 
-  color: $cdr-color-text-form-label-lightmode;
-  box-shadow: inset 0 0 0 1px $cdr-color-border-primary-lightmode;
+  color: $cdr-color-text-input-default;
+  // box-shadow: inset 0 0 0 1px $cdr-color-border-input-default; // TODO: update when token is available
   border: 0;
   border-radius: $cdr-radius-softer;
   padding-left: $cdr-space-half-x;
@@ -47,19 +47,20 @@
   }
 
   &[disabled] {
-    background-color: $cdr-color-background-lighter;
-    color: $cdr-color-text-form-disabled-lightmode;
-    box-shadow: inset 0 0 0 1px $cdr-color-border-disabled-lightmode;
+    background-color: $cdr-color-background-input-default-disabled;
+    color: $cdr-color-text-input-disabled;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled;
 
     &:hover {
-      box-shadow: inset 0 0 0 1px $cdr-color-border-disabled-lightmode;
+      box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled;
     }
   }
 
-  // TODO: should this also have &:hover ?
+  // TODO: should  this also have &:hover ?
+  // is selected correct here? is selected active/hover
   &:active,
   &:focus {
-    box-shadow: inset 0 0 0 1px $cdr-color-border-selected-lightmode;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-selected;
   }
 }
 
@@ -67,10 +68,10 @@
   @include cdr-text-utility-sans-300;
 
   font-style: normal;
-  color: $cdr-color-text-form-placeholder-lightmode;
+  color: $cdr-color-text-input-placeholder;
 
   &[disabled] {
-    color: $cdr-color-text-form-disabled-lightmode;
+    color: $cdr-color-text-input-disabled;
   }
 }
 
@@ -81,7 +82,7 @@
 
 /* required label */
 @mixin cdr-select-required-label-mixin() {
-  color: $cdr-color-text-secondary-lightmode;
+  color: $cdr-color-text-input-required;
 }
 
 /* info container */
@@ -95,12 +96,12 @@
 @mixin cdr-select-helper-text-mixin() {
   @include cdr-text-utility-sans-200;
 
-  color: $cdr-color-text-secondary-lightmode;
+  color: $cdr-color-text-input-help;
 }
 
 /* caret */
 @mixin cdr-select-base-caret-mixin() {
-  fill: $cdr-color-icon-primary-lightmode;
+  fill: $cdr-color-icon-default;
   position: absolute;
   top: 50%;
   right: $cdr-space-half-x;
@@ -109,5 +110,5 @@
 }
 
 @mixin cdr-select-base-caret-disabled-mixin() {
-  fill: $cdr-color-text-disabled-lightmode;
+  fill: $cdr-color-icon-disabled;
 }

--- a/src/components/select/styles/vars/CdrSelect.vars.scss
+++ b/src/components/select/styles/vars/CdrSelect.vars.scss
@@ -1,6 +1,6 @@
 @mixin cdr-select-base-label-mixin() {
   @include cdr-text-utility-sans-200;
-
+  font-weight: 600; // TODO: test 500
   color: $cdr-color-text-input-label;
   display: inline-block;
   margin: 0;
@@ -19,7 +19,7 @@
   @include cdr-text-utility-sans-300;
 
   color: $cdr-color-text-input-default;
-  // box-shadow: inset 0 0 0 1px $cdr-color-border-input-default; // TODO: update when token is available
+  box-shadow: inset 0 0 0 1px $cdr-color-border-input-default;
   border: 0;
   border-radius: $cdr-radius-softer;
   padding-left: $cdr-space-half-x;

--- a/src/components/select/styles/vars/CdrSelect.vars.scss
+++ b/src/components/select/styles/vars/CdrSelect.vars.scss
@@ -53,14 +53,13 @@
 
     &:hover {
       box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled;
+      cursor: not-allowed;
     }
   }
-
-  // TODO: should  this also have &:hover ?
-  // is selected correct here? is selected active/hover
+  
   &:active,
   &:focus {
-    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-selected;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-active;
   }
 }
 

--- a/src/css/settings/_form-label.vars.scss
+++ b/src/css/settings/_form-label.vars.scss
@@ -4,7 +4,7 @@ $cdr-label-base-spacing: $cdr-space-half-x;
 $cdr-label-figure-size-small: 16px;
 $cdr-label-figure-size-medium: 16px;
 $cdr-label-figure-size-large: 20px;
-$cdr-label-figure-box-shadow: 0 0 8px 0 rgb(50, 120, 174);
+$cdr-label-figure-box-shadow: 0 0 8px 0 $cdr-color-border-input-default-active;
 
 $cdr-label-height-medium: $cdr-text-utility-sans-300-height;
 @mixin cdr-label-base-mixin() {


### PR DESCRIPTION
## Description

Updates input, select, radio, and checkbox to pull in new colors.

Note: Currently input label is set to font-weight 500 and select label is set to font-weight 600 so Rebecca can review on the staging server when this hits next.

Noticed the placeholder text is mis-aligned for CdrInput in firefox, opened an intake ticket for that as i couldnt find a quick fix: https://trello.com/c/CRXOdKjr/130-input-placeholder-text-mis-aligned-in-firefox

### Design:
- [x] Reviewed with designer and meets expectations

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- n/a Added/updated backstop tests
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
- n/a Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [x] Meets WCAG AA standards

### Documentation:
- n/a API docs created/updated
- n/a Examples created/updated
