### PR TITLE
feat(list): style ordered cdr list decorator

### DIFF
--- a/src/components/card/CdrCard.jsx
+++ b/src/components/card/CdrCard.jsx
@@ -1,10 +1,8 @@
 import clsx from 'clsx';
-import modifier from '../../mixins/modifier';
 import style from './styles/CdrCard.scss';
 
 export default {
   name: 'CdrCard',
-  mixins: [modifier],
   data() {
     return {
       style,

--- a/src/components/list/CdrList.backstop.js
+++ b/src/components/list/CdrList.backstop.js
@@ -3,7 +3,11 @@ module.exports = [
     url: 'http://localhost:3000/#/lists',
     label: 'Lists',
     selectors: [
-      '[data-backstop="lists"]',
+      'document',
+      '[data-backstop="lists-bare"]',
+      '[data-backstop="lists-ordered"]',
+      '[data-backstop="lists-resilience"]',
+      '[data-backstop="lists-unordered"]',
     ],
   },
 ];

--- a/src/components/list/examples/demo/Bare.vue
+++ b/src/components/list/examples/demo/Bare.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div data-backstop="lists-bare">
 
     <cdr-text
       tag="h3"

--- a/src/components/list/examples/demo/Ordered.vue
+++ b/src/components/list/examples/demo/Ordered.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div data-backstop="lists-ordered">
 
     <cdr-text
       tag="h3"

--- a/src/components/list/examples/demo/Resilience.vue
+++ b/src/components/list/examples/demo/Resilience.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div data-backstop="lists-resilience">
 
     <cdr-text
       tag="h3"

--- a/src/components/list/examples/demo/Unordered.vue
+++ b/src/components/list/examples/demo/Unordered.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div data-backstop="lists-unordered">
     <cdr-text
       tag="h3"
       modifier="heading-serif-600 heading-serif-700@md heading-serif-700@lg"

--- a/src/components/list/styles/vars/CdrList.vars.scss
+++ b/src/components/list/styles/vars/CdrList.vars.scss
@@ -35,13 +35,13 @@
   counter-reset: cdr-list-counter;
   padding-left: 1.5em;
 
-  & li {
+  & > li {
     counter-increment: cdr-list-counter;
     padding: 0 0 0 $cdr-space-quarter-x;
     position: relative;
   }
-  
-  & li::before {
+
+  & > li::before {
     content: counter(cdr-list-counter) ". ";
     color: $cdr-color-text-secondary;
     position: absolute;

--- a/src/components/list/styles/vars/CdrList.vars.scss
+++ b/src/components/list/styles/vars/CdrList.vars.scss
@@ -12,7 +12,7 @@
 
 @mixin cdr-list-base-nested-mixin() {
   margin-top: $cdr-space-half-x;
-  padding-left: 1em; // TODO: is em correct?
+  padding-left: 1em;
   list-style-type: none;
 }
 
@@ -29,15 +29,23 @@
   margin-top: $cdr-space-quarter-x;
 }
 
-
 /* ordered */
 @mixin cdr-list-ordered-mixin() {
-  list-style-type: decimal;
+  list-style: none;
+  counter-reset: cdr-list-counter;
   padding-left: 1.5em;
-  list-style-position: outside;
 
   & li {
+    counter-increment: cdr-list-counter;
     padding: 0 0 0 $cdr-space-quarter-x;
+    position: relative;
+  }
+  
+  & li::before {
+    content: counter(cdr-list-counter) ". ";
+    color: $cdr-color-text-secondary;
+    position: absolute;
+    left: -1em;
   }
 }
 
@@ -47,6 +55,7 @@
 
   & > li {
     padding-left: 0;
+    position: static;
 
     &::before {
       content: '\2013';


### PR DESCRIPTION
## Description

uses this pattern: https://css-tricks.com/custom-list-number-styling/
to style the cedar list ordered decorators/numbers.


### Design:
- [ ] Reviewed with designer and meets expectations

### Cross-browser testing:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] IE11
- [ ] iOS
- [ ] Android

### Visual regression testing:
- [ ] Passes with existing reference images (or failed as expected)

### A11y:
- [ ] Meets WCAG AA standards

