### PR TITLE
feat(dev): toggle title color when doing local development

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
     <div id="main" class="cdr-container-fluid">
       <!-- NOTE: For dev environment only, do not load icon sprites in JS in production -->
       <div style="display:none" v-html="fullSprite"></div>
-      <h1>REI Cedar</h1>
+      <h1 class="title">REI Cedar</h1>
       <ul style="padding:0">
         <li class="cdr-space-inset-quarter-x" style="display:inline-flex" v-for="route in routes"><router-link v-if="route.name" :key="route.path" :to="route.path">{{ route.name }} *</router-link></li>
       </ul>

--- a/src/dev.js
+++ b/src/dev.js
@@ -32,5 +32,10 @@ new Vue({
   },
   mounted() {
     console.log('BACKSTOP_READY');
+    if (window.location.hostname === 'localhost') {
+      const title = document.querySelector('h1.title');
+      title.classList.add('cdr-color-background-secondary');
+      title.classList.add('cdr-space-inset-one-x');
+    }
   },
 }).$mount('#main');


### PR DESCRIPTION
## Description

i find myself confusedly refreshing the gh-pages kitchen sink wondering why my changes havent been applied a little too often (especially when im trying to compare what i have against whats on next). Thought it might be helpful to do something to distinguish it from the live version. Might wanna do the same to the doc site

Happy to style it differently, or if it bothers anyone to do this i can do the same thing with a browser extension just on my machine

