### PR TITLE
fix(tabs): add aria-selected specificity

### DIFF
--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -112,7 +112,7 @@
       margin-left: $cdr-space-one-x;
     }
 
-    & [aria-selected].cdr-tabs__header-item-label {
+    & [aria-selected="true"].cdr-tabs__header-item-label {
       color: $cdr-color-text-tab-active;
       font-weight: 500;
     }


### PR DESCRIPTION
`[aria-selected]` selector will still apply to `aria-selected="false"`, this makes it so disabled tabs don't get the active styling