### PR TITLE
fix(button): reset line-height on icon-only buttons

### DIFF
--- a/src/components/button/styles/vars/CdrButton.vars.scss
+++ b/src/components/button/styles/vars/CdrButton.vars.scss
@@ -132,6 +132,7 @@
   border-radius: 50%;
   box-shadow: none;
   display: inline-block;
+  line-height: normal;
   padding: $cdr-space-inset-half-x;
   fill: $cdr-color-icon-default;
 


### PR DESCRIPTION
## Description
The icon-only button had a bit of extra vertical space from line-height, causing them to render at 40x41 instead of 40x40.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that are completed. -->

### Design:
~Reviewed with designer and meets expectations~

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- [x] Added/updated backstop tests
- [x] Passes with existing reference images (or failed as expected)

### Unit testing:
~Sufficient unit test coverage (see unit test best practices for ideas)~

### A11y:
~Meets WCAG AA standards~

### Documentation:
~API docs created/updated~
~Examples created/updated~
