### PR TITLE
fix(input): center placeholder text for large inputs in firefox

### DIFF
--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -1,19 +1,5 @@
 @import '../../../css/settings/index.scss';
 @import './vars/CdrInput.vars.scss';
-/* ==========================================================================
-  # CdrInput
-  All values should map to variables in
-  vars/CdrInput.vars.pcss
-  in order to allow for theming
-  TOC:
-    :Base - Label
-    :Base - Input container
-    :Base - Input
-      :States
-      :Modifiers
-      :Style Variants
-      :Elements
-========================================================================== */
 
 /* ==========================================================================
   # INPUT LABEL

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -69,6 +69,10 @@
   padding-top: $cdr-space-half-x;
   padding-left: $cdr-space-half-x;
   height: 48px;
+  
+  &::placeholder {
+    line-height: $cdr-space-half-x + $cdr-text-utility-sans-400-height;
+  }
 }
 
 @mixin cdr-input-helper-text-mixin() {

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -65,11 +65,9 @@
 
 @mixin cdr-input-large-mixin() {
   @include cdr-text-utility-sans-400;
-
-  padding-top: $cdr-space-half-x;
+  line-height: $cdr-space-half-x + $cdr-text-utility-sans-400-height;
   padding-left: $cdr-space-half-x;
   height: 48px;
-  
   &::placeholder {
     line-height: $cdr-space-half-x + $cdr-text-utility-sans-400-height;
   }


### PR DESCRIPTION
## Description

placeholder text for large inputs in firefox were mis-aligned: https://rei.github.io/rei-cedar/#/inputs

padding-top does not seem to work correctly on placeholder pseudo-elements cross browser, using line-height to effectively center the placeholder/input text appears to be the best cross-browser solution here

### Design:
- n/a Reviewed with designer and meets expectations (will have designers review once on staging, we don't actually have figma specs for large input)

### Cross-browser testing:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
- [x] IE11
- [x] iOS
- [x] Android

### Visual regression testing:
- [x] Passes with existing reference images (or failed as expected)
