### PR TITLE
feat(img): bind listeners to img

### DIFF
--- a/src/components/image/CdrImg.jsx
+++ b/src/components/image/CdrImg.jsx
@@ -179,6 +179,7 @@ export default {
             )}
             src={this.src}
             alt={this.alt}
+            {...{ on: this.$listeners }}
           />
         </div>
       );
@@ -190,7 +191,7 @@ export default {
             this.lazyClass)}
           src={this.src}
           alt={this.alt}
-          {...{ attrs: this.lazyAttrs }}
+          {...{ attrs: this.lazyAttrs, on: this.$listeners }}
         />);
   },
 };

--- a/src/components/image/__tests__/CdrImg.spec.js
+++ b/src/components/image/__tests__/CdrImg.spec.js
@@ -1,8 +1,9 @@
 import { shallowMount, mount } from '@vue/test-utils';
 import CdrImg from 'componentdir/image/CdrImg';
+import sinon from 'sinon';
 
 describe('CdrImg', () => {
-  test('renders correctly', () => {
+  it('renders correctly', () => {
     const wrapper = mount(CdrImg, {
       propsData: {
         src: 'http://via.placeholder.com/350x150',
@@ -12,7 +13,7 @@ describe('CdrImg', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  test('renders crop/ratio correctly', () => {
+  it('renders crop/ratio correctly', () => {
     const wrapper = mount(CdrImg, {
       propsData: {
         ratio: "square",
@@ -59,5 +60,37 @@ describe('CdrImg', () => {
     expect(wrapper.classes()).toContain('lazy-image');
     expect(wrapper.attributes()['data-src-lazy']).toBe('http://via.placeholder.com/350');
   });
+
+
+  it('emits error event for default image', () => {
+    const spy = sinon.spy();
+
+    const wrapper = shallowMount(CdrImg, {
+      propsData: {
+        src: 'localhost:8000/nothing-to-see-here.png',
+      },
+      listeners: {
+        error: spy
+      }
+    });
+    wrapper.find('img').trigger('error');
+    expect(spy.calledOnce).toBeTruthy();
+  })
+
+  it('emits error event for ratio image', () => {
+    const spy = sinon.spy();
+
+    const wrapper = shallowMount(CdrImg, {
+      propsData: {
+        src: 'localhost:8000/nothing-to-see-here.png',
+        ratio: 'square',
+      },
+      listeners: {
+        error: spy
+      }
+    });
+    wrapper.find('img').trigger('error');
+    expect(spy.calledOnce).toBeTruthy();
+  })
 
 });

--- a/src/components/image/examples/Images.vue
+++ b/src/components/image/examples/Images.vue
@@ -25,6 +25,22 @@
       <mods />
     </div>
 
+
+    <div data-backstop="image-error">
+      <cdr-text
+        tag="h3"
+        modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
+      >
+        Image With Error
+      </cdr-text>
+      <cdr-img
+        src="localhost:8000/not-here.png"
+        @error="handleError"
+        alt="im an error!"
+      />
+      Error Handled: {{ hasError }}
+    </div>
+
     <div data-backstop="image-standard">
       <cdr-text
         tag="h3"
@@ -61,6 +77,16 @@ export default {
     ratios,
     cropping,
     mods,
+  },
+  data() {
+    return {
+      hasError: false,
+    };
+  },
+  methods: {
+    handleError() {
+      this.hasError = true;
+    },
   },
 };
 </script>


### PR DESCRIPTION
## Description

binds error handler to images.

per our discussion in dev critique i am binding all listeners here, since people can bind whatever they want to anything manually.

### Design:
- n/a Reviewed with designer and meets expectations

### Cross-browser testing:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] IE11
- [ ] iOS
- [ ] Android

### Visual regression testing:
- [ ] Added/updated backstop tests
- [ ] Passes with existing reference images (or failed as expected)

### Unit testing:
- [ ] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- n/a  Meets WCAG AA standards

### Documentation:
- [ ] API docs created/updated
- [ ] Examples created/updated
