### PR TITLE
chore(routing): add guard for changing focus when using background color switcher

### DIFF
--- a/src/SinkWrapper.vue
+++ b/src/SinkWrapper.vue
@@ -42,7 +42,7 @@ export default {
   },
   watch: {
     background() {
-      this.$router.push({
+      this.$router.replace({
         path: this.$router.currentRoute.path,
         query: {
           background: this.background,

--- a/src/dev.js
+++ b/src/dev.js
@@ -34,7 +34,10 @@ new Vue({
   },
   watch: {
     // Adapted from https://marcus.io/blog/accessible-routing-vuejs
-    $route(to) {
+    $route(to, from) {
+      // updating query (for background radios) so don't alter focus
+      if (to.hash === '' && to.path === from.path) return;
+
       // Get focus target after nav
       // If not existent, use container so skip link is first again
       const focusTarget = (to.hash)


### PR DESCRIPTION
When changing the background color with the radio the focus logic for the skip link was also being run and moving it to the top of the page. This tries to guard against that scenario