### PR TITLE
fix(pagination): fix the aria label text to remove duplicate "navigat…

### DIFF
--- a/src/components/pagination/CdrPagination.jsx
+++ b/src/components/pagination/CdrPagination.jsx
@@ -380,7 +380,7 @@ export default {
   },
   render() {
     return (
-      <nav aria-label="Pagination Navigation">
+      <nav aria-label="Pagination">
         <ul class={this.style['cdr-pagination']}>
           {this.prevEl}
           {this.desktopEl}

--- a/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrPagination renders correctly 1`] = `
 <nav
-  aria-label="Pagination Navigation"
+  aria-label="Pagination"
 >
   <ul
     class="cdr-pagination"
@@ -193,7 +193,7 @@ exports[`CdrPagination renders correctly 1`] = `
 
 exports[`CdrPagination renders scoped slot correctly 1`] = `
 <nav
-  aria-label="Pagination Navigation"
+  aria-label="Pagination"
 >
   <ul
     class="cdr-pagination"


### PR DESCRIPTION
…ion" text being read to screen

## Description
the nav tag will read out to screen readers that they are in navigation - our aria label was causing the pagination to read as "pagination navigation navigation"
will now be "pagination navigation"

### Cross-browser testing:
- [x] Chrome
- [x] Safari

- [x] Meets WCAG AA standards
