### PR TITLE
feat(card): add linked prop to control hover state

### DIFF
--- a/src/components/card/CdrCard.jsx
+++ b/src/components/card/CdrCard.jsx
@@ -1,10 +1,14 @@
 import clsx from 'clsx';
-import modifier from '../../mixins/modifier';
 import style from './styles/CdrCard.scss';
 
 export default {
   name: 'CdrCard',
-  mixins: [modifier],
+  props: {
+    linked: {
+      type: Boolean,
+      default: false,
+    },
+  },
   data() {
     return {
       style,
@@ -14,9 +18,12 @@ export default {
     baseClass() {
       return 'cdr-card';
     },
+    linkedClass() {
+      return this.linked ? `${this.baseClass}--linked` : null;
+    },
   },
   render() {
-    return (<article class={clsx(this.style[this.baseClass], this.modifierClass)}>
+    return (<article class={clsx(this.style[this.baseClass], this.style[this.linkedClass])}>
       {this.$slots.default}
     </article>);
   },

--- a/src/components/card/examples/demo/simpleCard.vue
+++ b/src/components/card/examples/demo/simpleCard.vue
@@ -3,6 +3,15 @@
     <cdr-card class="card-example">
       <cdr-text>A simple card</cdr-text>
     </cdr-card>
+    <hr>
+    <a href="rei.com">
+      <cdr-card
+        class="card-example"
+        :linked="true"
+      >
+        <cdr-text>A linked card</cdr-text>
+      </cdr-card>
+    </a>
   </div>
 </template>
 

--- a/src/components/card/styles/CdrCard.scss
+++ b/src/components/card/styles/CdrCard.scss
@@ -3,3 +3,7 @@
 .cdr-card {
   @include cdr-card-base-mixin;
 }
+
+.cdr-card--linked {
+  @include cdr-card-linked-mixin;
+}

--- a/src/components/card/styles/vars/CdrCard.vars.scss
+++ b/src/components/card/styles/vars/CdrCard.vars.scss
@@ -5,9 +5,12 @@
   box-shadow: $cdr-prominence-raised;
   color: $cdr-color-text-primary;
   width: 100%;
+}
 
-  transition: box-shadow $cdr-duration-1-x $cdr-timing-function-ease;
-
+@mixin cdr-card-linked-mixin() {
+  transition: box-shadow $cdr-duration-2-x $cdr-timing-function-ease;
+  cursor: pointer;
+  
   &:active, &:hover {
     box-shadow: $cdr-prominence-floating;
   }

--- a/src/components/link/examples/demo/Standard.vue
+++ b/src/components/link/examples/demo/Standard.vue
@@ -114,8 +114,13 @@
       modifier="subheading-sans-300"
     >Links, with inherited color</cdr-text>
     <div style="color: darkgreen; fill: darkgreen;">
-      <cdr-link inherit-color href="rei.com">inherit-color plain example</cdr-link>
-      <br/>
+      <cdr-link
+        inherit-color
+        href="rei.com"
+      >
+        inherit-color plain example
+      </cdr-link>
+      <br>
       <cdr-link inherit-color>
         <cdr-icon
           inherit-color


### PR DESCRIPTION
creates a new prop `linked` that adds hover state to card

deletes modifier from card as card has no modifiers