### PR TITLE
Accordion bugs

### DIFF
--- a/src/components/accordion/CdrAccordion.jsx
+++ b/src/components/accordion/CdrAccordion.jsx
@@ -84,7 +84,7 @@ export default {
   },
   watch: {
     opened() {
-      this.maxHeight = this.opened ? `${this.$refs['accordion-content'].clientHeight}px` : 0;
+      this.updateHeight();
     },
   },
   mounted() {
@@ -94,7 +94,7 @@ export default {
       nice and smooth the first time they click it.
     */
     if (this.opened && this.$refs['accordion-content']) {
-      this.maxHeight = `${this.$refs['accordion-content'].clientHeight}px`;
+      this.updateHeight();
     }
   },
   methods: {
@@ -107,6 +107,9 @@ export default {
     onBlur() {
       this.focused = false;
     },
+    updateHeight() {
+      this.maxHeight = this.opened ? `${this.$refs['accordion-content'].clientHeight}px` : 0;
+    }
   },
   render() {
     const Heading = `h${this.level}`;

--- a/src/components/accordion/CdrAccordion.jsx
+++ b/src/components/accordion/CdrAccordion.jsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import debounce from 'lodash-es/debounce';
 import IconCaretDown from '../icon/comps/caret-down';
 import modifier from '../../mixins/modifier';
 import style from './styles/CdrAccordion.scss';
@@ -96,6 +97,10 @@ export default {
     if (this.opened && this.$refs['accordion-content']) {
       this.updateHeight();
     }
+
+    window.addEventListener('resize', debounce(() => {
+      this.updateHeight();
+    }, 50));
   },
   methods: {
     onClick(event) {
@@ -109,7 +114,7 @@ export default {
     },
     updateHeight() {
       this.maxHeight = this.opened ? `${this.$refs['accordion-content'].clientHeight}px` : 0;
-    }
+    },
   },
   render() {
     const Heading = `h${this.level}`;


### PR DESCRIPTION
- creates instance method on accordions that can be called to update their height. Will require consumer to attach a `ref` to accordions and call `this.$refs.whateverRefId.updateHeight()` whenever they add or remove content from an open accordion.
- adds debounced resize listener to make accordions responsive 