### PR TITLE
fix(tabs): handle tab scrolling offscreen on mobile

### DIFF
--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -71,7 +71,7 @@ export default {
     this.$refs.cdrTabsHeader.parentElement.addEventListener('scroll', debounce(() => {
       this.calculateOverflow();
       this.updateUnderline();
-    }, 250));
+    }, 50));
   },
   methods: {
     getNextTab(startIndex) {
@@ -170,6 +170,12 @@ export default {
         this.underlineOffsetX = activeTab.offsetLeft
           - this.$refs.cdrTabsHeader.parentElement.scrollLeft;
         this.underlineWidth = activeTab.firstChild.offsetWidth;
+
+        // mobile fix, hide the underline if it scrolls outside the container
+        if (this.underlineOffsetX > this.$refs.cdrTabsContainer.offsetWidth) {
+          this.underlineOffsetX = this.$refs.cdrTabsContainer.offsetWidth;
+          this.underlineWidth = 0;
+        }
       }
     },
     handleDownArrowNav() {

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -24,6 +24,7 @@
   display: flex;
   flex-flow: column;
   height: 500px;
+  overflow-x: hidden;
 
   // https://davidwalsh.name/osx-overflow
   ::-webkit-scrollbar {


### PR DESCRIPTION
fixes issue on mobile where the underline would expand the window width if it was scrolled offscreen