### PR TITLE
fix(accordion): make accordion reflow after opening

### DIFF
--- a/src/components/accordion/CdrAccordion.jsx
+++ b/src/components/accordion/CdrAccordion.jsx
@@ -84,7 +84,17 @@ export default {
   },
   watch: {
     opened() {
-      this.maxHeight = this.opened ? `${this.$refs['accordion-content'].clientHeight}px` : 0;
+      // reset maxHeight before animating
+      this.maxHeight = !this.opened ? `${this.$refs['accordion-content'].clientHeight}px` : 0;
+      // nextTick is not sufficient here, must wait for CSS to re-paint
+      setTimeout(() => {
+        // on next frame, set maxHeight to new value
+        this.maxHeight = this.opened ? `${this.$refs['accordion-content'].clientHeight}px` : 0;
+        setTimeout(() => {
+          // after animation is complete, remove max-height so content can reflow
+          this.maxHeight = this.opened ? 'none' : 0;
+        }, 350); // cdr-duration-3x + 50ms
+      }, 50);
     },
   },
   mounted() {
@@ -94,7 +104,7 @@ export default {
       nice and smooth the first time they click it.
     */
     if (this.opened && this.$refs['accordion-content']) {
-      this.maxHeight = `${this.$refs['accordion-content'].clientHeight}px`;
+      this.maxHeight = 'none';
     }
   },
   methods: {

--- a/src/components/accordion/__tests__/CdrAccordion.spec.js
+++ b/src/components/accordion/__tests__/CdrAccordion.spec.js
@@ -42,7 +42,7 @@ describe('CdrAccordion', () => {
     // closed state
     expect(button.attributes('aria-expanded')).toBe('false');
     expect(button.attributes('aria-controls')).toBe(`${wrapper.vm.id}-collapsible`);
-    
+
     // opened state
     button.trigger('click');
     wrapper.setData({ opened: true }); // fake the opening logic
@@ -63,7 +63,7 @@ describe('CdrAccordion', () => {
           default: 'This is some slot text.'
         },
       });
-      
+
       expect(wrapper.vm.maxHeight).toBe(0);
     });
 
@@ -79,8 +79,8 @@ describe('CdrAccordion', () => {
           default: 'This is some slot text.'
         },
       });
-      
-      expect(wrapper.vm.maxHeight).toBe('0px');
+
+      expect(wrapper.vm.maxHeight).toBe('none');
     });
   });
 
@@ -96,7 +96,7 @@ describe('CdrAccordion', () => {
           default: 'This is some slot text.'
         },
       });
-      
+
       wrapper.find('button').trigger('click');
       expect(wrapper.emitted('accordion-toggle'));
     });
@@ -113,10 +113,10 @@ describe('CdrAccordion', () => {
           default: 'This is some slot text.'
         },
       });
-      
+
       wrapper.setProps({ opened: false });
-      expect(wrapper.vm.maxHeight).toBe(0);
-    });    
+      expect(wrapper.vm.maxHeight).toBe('0px');
+    });
   });
 
   it('isOpenClass computed prop', () => {


### PR DESCRIPTION
does more or less the same thing search is doing in their accordion:
https://git.rei.com/projects/SUI/repos/search-ui/browse/search-express-2/src/components/SearchPage/components/Accordion.jsx#85-104 

in order for max-height transition animations to work we need to give it an explicit value. but in order for reflows to work we need to set max-height to 'none'. here we basically set max-height to none or 0 until an animation is triggered, then we set an explicit height, then set it back to none or 0 once the animation is over.

a lil hacky/messy but so is CSS 😆 
might need to tweak the timeout values based on x-browser testing