### PR TITLE
select multiple

### DIFF
--- a/src/components/select/CdrSelect.jsx
+++ b/src/components/select/CdrSelect.jsx
@@ -50,8 +50,8 @@ export default {
     disabled: Boolean,
     /** @ignore */
     required: Boolean,
-    /** DEPRECATED */
     multiple: Boolean,
+    multipleSize: Number,
   },
   data() {
     return {
@@ -114,6 +114,7 @@ export default {
           class={clsx(this.sizeClass, this.selectClass)}
           id={this.selectId}
           multiple={this.multiple}
+          size={this.multipleSize}
           disabled={this.disabled}
           required={this.required}
           aria-label={this.hideLabel ? this.label : null}

--- a/src/components/select/examples/Selects.vue
+++ b/src/components/select/examples/Selects.vue
@@ -193,16 +193,15 @@
     <cdr-text>Selected Value: {{ dynamic }}</cdr-text>
     <hr class="icon-hr">
 
-    <!-- DEPRECATED MULTIPLE SELECT EXAMPLES -->
     <cdr-text class="cdr-my-space-two-x">
-      DEPRECATED Multiple Select
+       Multiple Select with size
     </cdr-text>
 
     <cdr-select
       label="Multiple Prompt"
       v-model="multiple"
+      multiple-size="6"
       multiple
-      prompt="Choose two"
     >
       <option
         value="1"
@@ -220,13 +219,19 @@
       <option value="4">
         4
       </option>
+      <option value="5">
+        5
+      </option>
+      <option value="6">
+        6
+      </option>
     </cdr-select>
     <cdr-text>Selected Values: {{ multiple }}</cdr-text>
     <hr class="icon-hr">
 
 
     <cdr-text class="cdr-my-space-two-x">
-      DEPRECATED Multiple Select No Prompt
+      Multiple Select
     </cdr-text>
 
     <cdr-select

--- a/src/components/select/styles/CdrSelect.scss
+++ b/src/components/select/styles/CdrSelect.scss
@@ -55,10 +55,13 @@
     @include cdr-select-helper-text-mixin;
   }
 
-  // DEPRICATED STYLE
-  // ========================================================================== */
   &--multiple {
     height: auto;
+    padding: $cdr-space-half-x;
+
+    & + .cdr-select__caret {
+      display: none;
+    }
   }
   // ========================================================================== */
 


### PR DESCRIPTION
- hides the select caret when doing a `multiple` select
- fixes padding on multi-selects
- adds `multipleSize` property for setting the "size" prop on multi-selects https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attr-size