### PR TITLE
feat(card): add configurable tag prop defaulting to `article`

### DIFF
--- a/src/components/card/CdrCard.jsx
+++ b/src/components/card/CdrCard.jsx
@@ -7,14 +7,21 @@ export default {
       style,
     };
   },
+  props: {
+    tag: {
+      type: String,
+      default: 'article',
+    },
+  },
   computed: {
     baseClass() {
       return 'cdr-card';
     },
   },
   render() {
-    return (<article class={this.style[this.baseClass]}>
+    const Component = this.tag;
+    return (<Component class={this.style[this.baseClass]}>
       {this.$slots.default}
-    </article>);
+    </Component>);
   },
 };


### PR DESCRIPTION
- should `article` be the default here? or would `div` be "safer"?