### PR TITLE
Drop ie11

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,10 +19,9 @@ module.exports = function (api) {
       'Firefox > 64',
       'iOS > 11',
       'Safari >= 9',
-      'Explorer >= 11',
       'Edge >= 15',
     ],
-  }; // TODO: pull @rei browserslist instead
+  };
 
   const presetEnvConfig = (env === 'prod') ?
   {

--- a/babel.config.js
+++ b/babel.config.js
@@ -15,11 +15,11 @@ module.exports = function (api) {
   } :
   {
     browsers: [
-      'Chrome >= 70',
-      'Firefox > 64',
+      'Chrome >= 77',
+      'Firefox >= 70',
       'iOS > 11',
       'Safari >= 9',
-      'Edge >= 15',
+      'Edge >= 17'
     ],
   };
 

--- a/package.json
+++ b/package.json
@@ -145,8 +145,11 @@
     "npm": ">= 6.0.0"
   },
   "browserslist": [
-   "> 1%",
-   "last 2 versions"
+    "Chrome >= 77",
+    "Firefox >= 70",
+    "iOS > 11",
+    "Safari >= 9",
+    "Edge >= 17"
  ],
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -145,10 +145,9 @@
     "npm": ">= 6.0.0"
   },
   "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "ie >= 11"
-  ],
+   "> 1%",
+   "last 2 versions"
+ ],
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/static/cdr-fonts.css
+++ b/static/cdr-fonts.css
@@ -1,43 +1,18 @@
 @font-face {
   font-family: Stuart;
-  src: url("//satchel.rei.com/media/font/REI_Stuart/REIStuart-Medium-Web.woff2") format("woff2"), url("//satchel.rei.com/media/font/REI_Stuart/REIStuart-Medium-Web.woff") format("woff");
-  font-weight: 500;
-  font-style: normal; }
-
+  font-weight: 1 999;
+  src: url("//satchel.rei.com/media/font/REI_Stuart/REI_Stuart-VF/REIStuart-VF-Web.woff2") format("woff2-variations"), url("//satchel.rei.com/media/font/REI_Stuart/REI_Stuart-VF/REIStuart-VF-Web.woff2") format("woff2"); }
 @font-face {
   font-family: Stuart;
-  src: url("//satchel.rei.com/media/font/REI_Stuart/REIStuart-Semibold-Web.woff2") format("woff2"), url("//satchel.rei.com/media/font/REI_Stuart/REIStuart-Semibold-Web.woff") format("woff");
-  font-weight: 600;
-  font-style: normal; }
-
+  font-weight: 1 999;
+  font-style: italic;
+  src: url("//satchel.rei.com/media/font/REI_Stuart/REI_Stuart-VF/REIStuartWebItalics-VF-Web.woff2") format("woff2-variations"), url("//satchel.rei.com/media/font/REI_Stuart/REI_Stuart-VF/REIStuartWebItalics-VF-Web.woff2") format("woff2"); }
 @font-face {
   font-family: Graphik;
-  src: url("//satchel.rei.com/media/font/Graphik/Graphik/Graphik-Medium-Web.woff2") format("woff2"), url("//satchel.rei.com/media/font/Graphik/Graphik/Graphik-Medium-Web.woff") format("woff");
-  font-weight: 500;
-  font-style: normal; }
-
+  font-weight: 1 999;
+  src: url("//satchel.rei.com/media/font/Graphik/Graphik-VF/Graphik-VF-Web.woff2") format("woff2-variations"), url("//satchel.rei.com/media/font/Graphik/Graphik-VF/Graphik-VF-Web.woff2") format("woff2"); }
 @font-face {
   font-family: Graphik;
-  src: url("//satchel.rei.com/media/font/Graphik/Graphik/Graphik-Semibold-Web.woff2") format("woff2"), url("//satchel.rei.com/media/font/Graphik/Graphik/Graphik-Semibold-Web.woff") format("woff");
-  font-weight: 600;
-  font-style: normal; }
-
-@supports (font-variation-settings: normal) {
-  @font-face {
-    font-family: Stuart;
-    font-weight: 1 999;
-    src: url("//satchel.rei.com/media/font/REI_Stuart/REI_Stuart-VF/REIStuart-VF-Web.woff2") format("woff2-variations"), url("//satchel.rei.com/media/font/REI_Stuart/REI_Stuart-VF/REIStuart-VF-Web.woff2") format("woff2"); }
-  @font-face {
-    font-family: Stuart;
-    font-weight: 1 999;
-    font-style: italic;
-    src: url("//satchel.rei.com/media/font/REI_Stuart/REI_Stuart-VF/REIStuartWebItalics-VF-Web.woff2") format("woff2-variations"), url("//satchel.rei.com/media/font/REI_Stuart/REI_Stuart-VF/REIStuartWebItalics-VF-Web.woff2") format("woff2"); }
-  @font-face {
-    font-family: Graphik;
-    font-weight: 1 999;
-    src: url("//satchel.rei.com/media/font/Graphik/Graphik-VF/Graphik-VF-Web.woff2") format("woff2-variations"), url("//satchel.rei.com/media/font/Graphik/Graphik-VF/Graphik-VF-Web.woff2") format("woff2"); }
-  @font-face {
-    font-family: Graphik;
-    font-weight: 1 999;
-    font-style: italic;
-    src: url("//satchel.rei.com/media/font/Graphik/Graphik-VF/GraphikWebItalic-VF-Web.woff2") format("woff2-variations"), url("//satchel.rei.com/media/font/Graphik/Graphik-VF/GraphikWebItalic-VF-Web.woff2") format("woff2"); } }
+  font-weight: 1 999;
+  font-style: italic;
+  src: url("//satchel.rei.com/media/font/Graphik/Graphik-VF/GraphikWebItalic-VF-Web.woff2") format("woff2-variations"), url("//satchel.rei.com/media/font/Graphik/Graphik-VF/GraphikWebItalic-VF-Web.woff2") format("woff2"); }


### PR DESCRIPTION
- deletes ie11
- updates browserslist config to match febs https://git.rei.com/projects/FEDPACK/repos/rei-front-end-build-configs/browse/shared/index.js#8-15
- deletes nonvariable font fallbacks (looks like our support matrix nicely lines up with variable font support 😹 https://caniuse.com/#feat=variable-fonts)

long term we should refactor our build to pull the browserslist from a single place (and also get the official REI browserslist package updated so we can use that and be sure we are in sync with febs)