### PR TITLE
fix(breadcrumb): fix styling of last element on <md bp

### DIFF
--- a/src/components/breadcrumb/styles/CdrBreadcrumb.scss
+++ b/src/components/breadcrumb/styles/CdrBreadcrumb.scss
@@ -28,6 +28,7 @@
   /* Link
   ---------- */
   &__link {
+    @include cdr-breadcrumb-xs-text-mixin;
     @include cdr-breadcrumb-item-linked-mixin;
 
     &:hover,


### PR DESCRIPTION
<img width="667" alt="Screen Shot 2020-06-04 at 2 20 56 PM" src="https://user-images.githubusercontent.com/48567940/83811430-a26eb880-a66e-11ea-9840-66af04a395ec.png">

noticed this ⬆️ while updating climbers to the latest beta. breadcrumb still has some responsive logic baked into it, and at XS and SM breakpoints the `strong` tag on the last element was taking precedence.
