### PR TITLE
fix(breadcrumb): update breadcrumb to properly handle scopedSlot ref/tag

### DIFF
--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -93,7 +93,6 @@ export default {
           /
         </span>) : '';
 
-        const ref = index === 0 ? 'firstBreadcrumb' : null;
         const isLink = index < this.items.length - 1;
         const LinkTag = isLink ? 'a' : 'strong';
 
@@ -109,11 +108,9 @@ export default {
               class: this.style['cdr-breadcrumb__link'],
               href: breadcrumb.item.url,
               content: breadcrumb.item.name,
-              ref,
             })
             : (<LinkTag
               class={this.style['cdr-breadcrumb__link']}
-              ref={ref}
               href={breadcrumb.item.url}
               aria-current={index === this.items.length - 1 ? 'page' : undefined}
             >
@@ -133,7 +130,9 @@ export default {
   methods: {
     handleEllipsisClick() {
       this.truncate = false;
-      this.$nextTick(() => { this.$refs.firstBreadcrumb.focus(); });
+      this.$nextTick(() => {
+        this.$el.querySelector('li *').focus();
+      });
     },
   },
   render() {

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -96,7 +96,7 @@ describe('CdrBreadcrumb', () => {
       }
     });
 
-    
+
     expect(wrapper.vm.truncate).toBe(true);
     wrapper.find({ref: 'ellipse'}).trigger('click');
     await wrapper.vm.$nextTick();
@@ -143,7 +143,7 @@ describe('CdrBreadcrumb', () => {
     });
     wrapper.vm.handleEllipsisClick();
     await wrapper.vm.$nextTick();
-    expect(wrapper.vm.$refs.firstBreadcrumb).toBe(document.activeElement);
+    expect(document.activeElement.textContent).toBe(itemsA[0].item.name);
   });
 
 });

--- a/src/components/breadcrumb/examples/Breadcrumb.vue
+++ b/src/components/breadcrumb/examples/Breadcrumb.vue
@@ -53,9 +53,12 @@
         slot="link"
         slot-scope="link"
       >
-        <div :class="link.class">
-          {{ link.content }} {{ link.href }}
-        </div>
+        <a
+          :class="link.class"
+          :href="link.href"
+        >
+          {{ link.content }}
+        </a>
       </template>
     </cdr-breadcrumb>
   </div>


### PR DESCRIPTION
CUS thread: https://rei.slack.com/archives/CA58YCGN4/p1591310986207800

`$refs` are only available in the scope in which they are rendered. so if you use the scopedSlots option with breadcrumb, then CdrBreadcrumb.jsx does not have access to `$refs.firstBreadcrumb` because that ref is rendered in the consuming component and not in breadcrumb itself. (i get why vue is like this...but, ugh)

In pagination we do this weird little dance to get access to refs rendered in scopedSlots: https://github.com/rei/rei-cedar/blob/next/src/components/pagination/CdrPagination.jsx#L334-L344 BUT for whatever reason similar logic does not seem to be working in breadcrumb to focus the first element.

Gotta use `li *` here since we have no idea what will be passed into the scopedSlot (i.e, a vs. vue-router-link vs. who knows what).


😪 