### PR TITLE
Breadcrumb fixes

### DIFF
--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -68,13 +68,12 @@ export default {
           aria-controls={`${this.componentID}List`}
           aria-label={`show ${this.items.length - 2} more navigation level${(this.items.length - 2) > 1 ? 's' : ''}`} // eslint-disable-line max-len
         >
-          <cdr-icon
+          <span
             class={this.style['cdr-breadcrumb__ellipses-icon']}
             aria-hidden="true"
           >
-            {/* eslint-disable-next-line max-len */}
-            <path d="M17.5 22a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM12 22a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm-5.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z" />
-          </cdr-icon>
+            . . . 
+          </span>
         </button>
         <span
           class={this.style['cdr-breadcrumb__delimiter']}

--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -72,7 +72,7 @@ export default {
             class={this.style['cdr-breadcrumb__ellipses-icon']}
             aria-hidden="true"
           >
-            . . . 
+            . . .
           </span>
         </button>
         <span

--- a/src/components/breadcrumb/__tests__/__snapshots__/CdrBreadcrumb.spec.js.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/CdrBreadcrumb.spec.js.snap
@@ -18,17 +18,12 @@ exports[`CdrBreadcrumb renders correctly 1`] = `
         aria-label="show 1 more navigation level"
         class="cdr-breadcrumb__ellipses"
       >
-        <svg
+        <span
           aria-hidden="true"
-          class="cdr-icon cdr-breadcrumb__ellipses-icon"
-          role="presentation"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+          class="cdr-breadcrumb__ellipses-icon"
         >
-          <path
-            d="M17.5 22a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zM12 22a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm-5.5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
-          />
-        </svg>
+          . . .
+        </span>
       </button>
       <span
         aria-hidden="true"

--- a/src/components/breadcrumb/styles/CdrBreadcrumb.scss
+++ b/src/components/breadcrumb/styles/CdrBreadcrumb.scss
@@ -59,15 +59,13 @@
     cursor: pointer;
     display: inline-block;
     fill: inherit;
-    padding: 6px 11px; /* extend clickable area */
-    margin: -6px -11px; /* preserve layout */
+    padding: 0;
 
     /* Ellipses Icon
     ========== */
     .cdr-breadcrumb__ellipses-icon {
+      color: $cdr-color-text-secondary;
       border-bottom: 1px solid transparent;
-      width: 1.4rem;
-      height: 1.4rem;
       fill: inherit;
     }
 
@@ -75,8 +73,8 @@
     &:active,
     &:focus {
       .cdr-breadcrumb__ellipses-icon {
-        border-bottom: 1px solid $cdr-color-text-link-hover;
-        fill: inherit;
+        color: $cdr-color-text-link-hover;
+        text-decoration: underline;
       }
     }
   }
@@ -86,11 +84,6 @@
     &__delimiter,
     &__ellipses {
       @include cdr-breadcrumb-base-text-mixin;
-    }
-
-    &__ellipses .cdr-breadcrumb__ellipses-icon {
-      width: 1.6rem;
-      height: 1.6rem;
     }
   }
 }

--- a/src/components/breadcrumb/styles/CdrBreadcrumb.scss
+++ b/src/components/breadcrumb/styles/CdrBreadcrumb.scss
@@ -33,7 +33,7 @@
     &:hover,
     &:active,
     &:focus {
-      color: inherit;
+      color: $cdr-color-text-link-hover;
       text-decoration: underline;
     }
   }

--- a/src/components/breadcrumb/styles/CdrBreadcrumb.scss
+++ b/src/components/breadcrumb/styles/CdrBreadcrumb.scss
@@ -43,8 +43,7 @@
   &__delimiter {
     @include cdr-breadcrumb-xs-text-mixin;
     color: inherit;
-    padding-left: $cdr-space-quarter-x;
-    padding-right: $cdr-space-half-x;
+    padding: 0 $cdr-space-half-x;
   }
 
   /* Ellipses

--- a/src/components/breadcrumb/styles/vars/CdrBreadcrumb.vars.scss
+++ b/src/components/breadcrumb/styles/vars/CdrBreadcrumb.vars.scss
@@ -1,6 +1,5 @@
 @mixin cdr-breadcrumb-item-mixin() {
   color: $cdr-color-text-secondary;
-  fill: $cdr-color-text-secondary;
 }
 
 @mixin cdr-breadcrumb-item-linked-mixin() {
@@ -9,8 +8,7 @@
   &:hover,
   &:active,
   &:focus {
-    color: $cdr-color-text-link-active;
-    fill: $cdr-color-text-link-active;
+    color: $cdr-color-text-link-hover;
   }
 }
 


### PR DESCRIPTION
- on actionable elements:
- - use link-hover token on hover 
- - use text-secondary on rest
- makes spacing between delimiters space-half-x
- replaces ellipses SVG icon with spaced periods: `. . .`