### PR TITLE
Pagination/rating

### DIFF
--- a/src/components/pagination/styles/CdrPagination.scss
+++ b/src/components/pagination/styles/CdrPagination.scss
@@ -37,6 +37,7 @@
     &:focus,
     &:active {
       background-color: $cdr-color-background-pagination-hover;
+      cursor: pointer;
     }
 
     &:global(.current) {

--- a/src/components/rating/styles/CdrRating.scss
+++ b/src/components/rating/styles/CdrRating.scss
@@ -167,8 +167,8 @@ $filled-star: '\2605';
 
       & > .cdr-rating__number {
         border-right: 1px solid $cdr-color-text-rating-separator;
-        padding: 0 $cdr-space-quarter-x;
-        margin-right: $cdr-space-quarter-x;
+        padding: 0 0.6rem;
+        margin-right: 0.6rem;
       }
     }
   }


### PR DESCRIPTION
- set rating separator to have 6px/0.6rem spacing (should be equalized unless there is some cross-browser issue with padding vs. margin calculations)
- update pagination to ensure scoped slot links get proper hover effect