### PR TITLE
Tabby fixy

### DIFF
--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -59,7 +59,7 @@ export default {
       this.calculateOverflow();
       setTimeout(() => {
         this.updateUnderline();
-      }, 100);
+      }, 250);
     });
     // Check for header overflow on window resize for gradient behavior.
     window.addEventListener('resize', debounce(() => {

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -4,7 +4,7 @@
 @mixin cdr-tabs-base-header-item-label() {
   font-family: $cdr-font-family-sans;
   font-style: normal;
-  font-weight: 500;
+  font-weight: 300;
   letter-spacing: -.08px;
   font-size: 1.6rem;
   line-height: 2.2rem;
@@ -13,7 +13,7 @@
 @mixin cdr-tabs-small-header-item-label() {
   font-family: $cdr-font-family-sans;
   font-style: normal;
-  font-weight: 500;
+  font-weight: inherit;
   letter-spacing: -.08px;
   font-size: 1.4rem;
   line-height: 1.8rem;

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -4,7 +4,7 @@
 @mixin cdr-tabs-base-header-item-label() {
   font-family: $cdr-font-family-sans;
   font-style: normal;
-  font-weight: 300;
+  font-weight: inherit;
   letter-spacing: -.08px;
   font-size: 1.6rem;
   line-height: 2.2rem;
@@ -109,6 +109,7 @@
     display: block;
     padding: 0;
     color: $cdr-color-text-tab-rest;
+    font-weight: 300;
 
     & + & {
       margin-left: $cdr-space-one-x;

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -108,15 +108,17 @@
   &__header-item {
     display: block;
     padding: 0;
+    color: $cdr-color-text-tab-rest;
 
     & + & {
       margin-left: $cdr-space-one-x;
     }
 
-    & [aria-selected="true"].cdr-tabs__header-item-label {
-      color: $cdr-color-text-tab-active;
-      font-weight: 500;
-    }
+  }
+
+  &__header-item-active {
+    color: $cdr-color-text-tab-active;
+    font-weight: 500;
   }
 
   &__header-item-label {
@@ -125,9 +127,10 @@
     display: block;
     text-decoration: none;
     padding: $cdr-space-inset-half-x-stretch;
-    color: $cdr-color-text-tab-rest;
     white-space: nowrap;
     outline-offset: -3px;
+    color: inherit;
+    font-weight: inherit;
 
     &:active,
     &:hover,

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -162,7 +162,7 @@
     border: none;
 
     /* border: none; */
-    background-color: $cdr-color-text-link-lightmode;
+    background-color: $cdr-color-border-tab-keyline-active;
     transition: $cdr-duration-4-x $cdr-timing-function-ease-out;
   }
 


### PR DESCRIPTION
- using `$cdr-color-text-tab-active` for active tab color
- sets default tab label font-weight to 300, 500 for active tab
- sets timeout for longer as the tabs centered variant underline was not rendering properly on load (probably due to the addition of font-weight variance)

focus clipping seems to be cross-browser, seeing it in edge but not chrome or firefox. will dig into that more separately