### PR TITLE
Fix esm again ugh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "REI Software Engineering",
   "main": "dist/cedar.js",
-  "module": "dist/lib/index.mjs",
+  "module": "dist/lib/src/index.mjs",
   "style": "dist/style/cedar-full.css",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",


### PR DESCRIPTION
module path was pointing to the wrong file somehow? suspect this is either a byproduct of upgrading dependencies OR because we started using cedar tokens in component JS files. 

Confirmed by manually editing stuff in climbers-site that this gets tree-shaking re-enabled

🤦‍♀️ 