### PR TITLE
update generator, refactor examples

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -27,12 +27,6 @@ const CHOICES = [
 // User prompts
 const QUESTIONS = [
   {
-    name: 'type',
-    type: 'list',
-    message: 'What are you making?',
-    choices: CHOICES,
-  },
-  {
     name: 'name',
     type: 'input',
     message: 'What is the component name? (kebab-case without Cdr/Cedar prefix)',
@@ -47,16 +41,13 @@ const QUESTIONS = [
 
 // use answers
 inquirer.prompt(QUESTIONS).then((answers) => {
-  const { type } = answers;
-  const typeCap = _.upperFirst(type);
-  const typeSingle = type.slice(0, -1);
   const { name } = answers; // test-comp
   const camelName = _.camelCase(name); // testComp
   const pascalName = _.upperFirst(camelName); // TestComp
   const compName = `Cdr${pascalName}`; // CdrTestComp
   const tagName = _.kebabCase(compName); // cdr-test-comp
   const fullName = `cedar-${name}`; // cedar-test-comp
-  const outDir = resolve(`src/${type}/${camelName}`);
+  const outDir = resolve(`src/components/${camelName}`);
 
   // exit if the component already exists
   if (fs.existsSync(outDir)) {
@@ -90,8 +81,6 @@ inquirer.prompt(QUESTIONS).then((answers) => {
       if (err) throw err;
 
       const rewrite = contents
-        .replace(/\{TYPE-SINGULAR\}/g, typeSingle)
-        .replace(/\{TYPE-CAPITAL\}/g, typeCap)
         .replace(/\{NAME-PASCAL\}/g, pascalName)
         .replace(/\{NAME-TAGNAME\}/g, tagName)
         .replace(/\{NAME-KEBAB\}/g, name)

--- a/generator.js
+++ b/generator.js
@@ -95,7 +95,7 @@ inquirer.prompt(QUESTIONS).then((answers) => {
   // Done!
   console.log(chalk.green(`Successfuly generated files for '${name}' in ${outDir}`));
   console.log(chalk.white('To complete setup do the following:'));
-  console.log(chalk.white('- Add component to src/index.js'));
-  console.log(chalk.white('- Add component example to src/components/examples.js'));
-  console.log(chalk.white('- Add router path in src/router.js'));
+  console.log(chalk.white('- Export component in src/index.js'));
+  console.log(chalk.white('- Export component example in src/components/examples.js'));
+  console.log(chalk.white('- Add dev router path in src/dev/router.js'));
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,6 @@
 </template>
 
 <script>
-// import examples from 'componentsdir/examples';
 
 export default {
   name: 'App',

--- a/src/components/examples.js
+++ b/src/components/examples.js
@@ -1,54 +1,51 @@
 import accordion from 'componentsdir/accordion/examples/Accordion';
 import breadcrumb from 'componentsdir/breadcrumb/examples/Breadcrumb';
-import buttons from 'componentsdir/button/examples/Buttons';
-import captionExample from 'componentsdir/caption/examples/Caption';
-import cards from 'componentsdir/card/examples/Cards';
-import checkboxes from 'componentsdir/checkbox/examples/checkboxes';
+import button from 'componentsdir/button/examples/Buttons';
+import caption from 'componentsdir/caption/examples/Caption';
+import card from 'componentsdir/card/examples/Cards';
+import checkbox from 'componentsdir/checkbox/examples/checkboxes';
 import cta from 'componentsdir/cta/examples/Cta';
 import dataTable from 'componentsdir/dataTable/examples/DataTable';
 import grid from 'componentsdir/grid/examples/Grid';
-import icons from 'componentsdir/icon/examples/Icons';
-import images from 'componentsdir/image/examples/Images';
-import inputs from 'componentsdir/input/examples/Inputs';
-import links from 'componentsdir/link/examples/Links';
-import lists from 'componentsdir/list/examples/Lists';
-import modals from 'componentsdir/modal/examples/Modal';
+import icon from 'componentsdir/icon/examples/Icons';
+import image from 'componentsdir/image/examples/Images';
+import input from 'componentsdir/input/examples/Inputs';
+import link from 'componentsdir/link/examples/Links';
+import list from 'componentsdir/list/examples/Lists';
+import modal from 'componentsdir/modal/examples/Modal';
 import pagination from 'componentsdir/pagination/examples/Pagination';
-import quoteExample from 'componentsdir/quote/examples/Quote';
-import radios from 'componentsdir/radio/examples/Radios';
-import ratings from 'componentsdir/rating/examples/Ratings';
-import selects from 'componentsdir/select/examples/Selects';
-import tables from 'componentsdir/table/examples/Table';
+import quote from 'componentsdir/quote/examples/Quote';
+import radio from 'componentsdir/radio/examples/Radios';
+import rating from 'componentsdir/rating/examples/Ratings';
+import select from 'componentsdir/select/examples/Selects';
+import table from 'componentsdir/table/examples/Table';
 import tabs from 'componentsdir/tabs/examples/Tabs';
-import texts from 'componentsdir/text/examples/Text';
+import text from 'componentsdir/text/examples/Text';
 import utilities from 'componentsdir/Utilities/Utilities';
-
-// TODO: are we keeping this?
-// import searchbox from 'compositionsdir/search/examples/searchbox';
 
 export default {
   accordion,
   breadcrumb,
-  buttons,
-  captionExample,
-  cards,
-  checkboxes,
+  button,
+  caption,
+  card,
+  checkbox,
   cta,
   dataTable,
   grid,
-  icons,
-  images,
-  inputs,
-  links,
-  lists,
-  modals,
+  icon,
+  image,
+  input,
+  link,
+  list,
+  modal,
   pagination,
-  quoteExample,
-  radios,
-  ratings,
-  selects,
-  tables,
+  quote,
+  radio,
+  rating,
+  select,
+  table,
   tabs,
-  texts,
+  text,
   utilities,
 };

--- a/src/dev/router.js
+++ b/src/dev/router.js
@@ -1,33 +1,15 @@
 import App from 'srcdir/App';
-import Accordions from 'componentsdir/accordion/examples/Accordion';
-import Breadcrumb from 'componentsdir/breadcrumb/examples/Breadcrumb';
-import Buttons from 'componentsdir/button/examples/Buttons';
+import Examples from 'componentsdir/examples';
+
+import KitchenSink from 'srcdir/dev/KitchenSink';
+
+// Extra paths for backstop.
+//  These are smaller sections of larger demo pages to make screenshotting more reliable
 import DefaultButtons from 'componentsdir/button/examples/demo/Default';
 import FullWidthButtons from 'componentsdir/button/examples/demo/FullWidth';
 import IconButtons from 'componentsdir/button/examples/demo/Icons';
 import SecondaryButtons from 'componentsdir/button/examples/demo/Secondary';
-import Captions from 'componentsdir/caption/examples/Caption';
-import Cards from 'componentsdir/card/examples/Cards';
-import CheckBoxes from 'componentsdir/checkbox/examples/checkboxes';
-import Cta from 'componentsdir/cta/examples/Cta';
-import DataTables from 'componentsdir/dataTable/examples/DataTable';
-import Grids from 'componentsdir/grid/examples/Grid';
-import Icons from 'componentsdir/icon/examples/Icons';
-import Images from 'componentsdir/image/examples/Images';
-import Input from 'componentsdir/input/examples/Inputs';
-import KitchenSink from 'srcdir/dev/KitchenSink';
-import Links from 'componentsdir/link/examples/Links';
-import Lists from 'componentsdir/list/examples/Lists';
-import Modals from 'componentsdir/modal/examples/Modal';
-import Pagination from 'componentsdir/pagination/examples/Pagination';
-import Quotes from 'componentsdir/quote/examples/Quote';
-import Radios from 'componentsdir/radio/examples/Radios';
-import Ratings from 'componentsdir/rating/examples/Ratings';
-import Selects from 'componentsdir/select/examples/Selects';
-import Tables from 'componentsdir/table/examples/Table';
-import Tabs from 'componentsdir/tabs/examples/Tabs';
-import Texts from 'componentsdir/text/examples/Text';
-import Utilities from 'componentsdir/Utilities/Utilities';
+
 import InsetUtilities from 'componentsdir/Utilities/demos/inset';
 import PaddingSpacingUtilities from 'componentsdir/Utilities/demos/paddingSpacing';
 import MarginSpacingUtilities from 'componentsdir/Utilities/demos/marginSpacing';
@@ -38,30 +20,31 @@ import VisibilityUtilities from 'componentsdir/Utilities/demos/visibility';
 const routes = [
   { path: '/', name: ' ', component: App },
   { path: '/kitchen-sink', name: 'KitchenSink', component: KitchenSink },
-  { path: '/utilities', name: 'Utilities', component: Utilities },
-  { path: '/accordion', name: 'Accordion', component: Accordions },
-  { path: '/breadcrumbs', name: 'Breadcrumb', component: Breadcrumb },
-  { path: '/buttons', name: 'Buttons', component: Buttons },
-  { path: '/captions', name: 'Captions', component: Captions },
-  { path: '/cards', name: 'Cards', component: Cards },
-  { path: '/checkboxes', name: 'CheckBoxes', component: CheckBoxes },
-  { path: '/cta', name: 'CTA', component: Cta },
-  { path: '/dataTables', name: 'Data Tables', component: DataTables },
-  { path: '/grids', name: 'Grids', component: Grids },
-  { path: '/icons', name: 'Icons', component: Icons },
-  { path: '/images', name: 'Images', component: Images },
-  { path: '/inputs', name: 'Input', component: Input },
-  { path: '/links', name: 'Links', component: Links },
-  { path: '/lists', name: 'Lists', component: Lists },
-  { path: '/modals', name: 'Modals', component: Modals },
-  { path: '/pagination', name: 'Pagination', component: Pagination },
-  { path: '/quotes', name: 'Quotes', component: Quotes },
-  { path: '/radios', name: 'Radios', component: Radios },
-  { path: '/ratings', name: 'Ratings', component: Ratings },
-  { path: '/selects', name: 'Selects', component: Selects },
-  { path: '/tables', name: 'Tables', component: Tables },
-  { path: '/tabs', name: 'Tabs', component: Tabs },
-  { path: '/texts', name: 'Texts', component: Texts },
+  { path: '/utilities', name: 'Utilities', component: Examples.utilities },
+  { path: '/accordion', name: 'Accordion', component: Examples.accordion },
+  { path: '/breadcrumbs', name: 'Breadcrumb', component: Examples.breadcrumb },
+  { path: '/buttons', name: 'Buttons', component: Examples.button },
+  { path: '/captions', name: 'Captions', component: Examples.caption },
+  { path: '/cards', name: 'Cards', component: Examples.card },
+  { path: '/checkboxes', name: 'CheckBoxes', component: Examples.checkbox },
+  { path: '/cta', name: 'CTA', component: Examples.cta },
+  { path: '/dataTables', name: 'Data Tables', component: Examples.dataTable },
+  { path: '/grids', name: 'Grids', component: Examples.grid },
+  { path: '/icons', name: 'Icons', component: Examples.icon },
+  { path: '/images', name: 'Images', component: Examples.image },
+  { path: '/inputs', name: 'Input', component: Examples.input },
+  { path: '/links', name: 'Links', component: Examples.link },
+  { path: '/lists', name: 'Lists', component: Examples.list },
+  { path: '/modals', name: 'Modals', component: Examples.modal },
+  { path: '/pagination', name: 'Pagination', component: Examples.pagination },
+  { path: '/quotes', name: 'Quotes', component: Examples.quote },
+  { path: '/radios', name: 'Radios', component: Examples.radio },
+  { path: '/ratings', name: 'Ratings', component: Examples.rating },
+  { path: '/selects', name: 'Selects', component: Examples.select },
+  { path: '/tables', name: 'Tables', component: Examples.table },
+  { path: '/tabs', name: 'Tabs', component: Examples.tabs },
+  { path: '/texts', name: 'Texts', component: Examples.text },
+
   { path: '/default-buttons', component: DefaultButtons },
   { path: '/secondary-buttons', component: SecondaryButtons },
   { path: '/full-width-buttons', component: FullWidthButtons },


### PR DESCRIPTION
- removes "composition" option from component generator
- renames `examples` exports to match component name pluralization
- update dev router to pull examples from `examples` rather than importing in 2 places

Doing a lil cleanup while scaffolding the alert component 😀 