### PR TITLE
Update test utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5219,9 +5219,9 @@
       }
     },
     "@vue/test-utils": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.33.tgz",
-      "integrity": "sha512-Xzqoe0lTLn3QRWfjhmKPOXYR86l0Y+g/zPHaheJQOkPLj5ojJl3rG0t4F3kXFWuLD88YzUVRMIBWOG7v9KOJQQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.3.tgz",
+      "integrity": "sha512-mmsKXZSGfvd0bH05l4SNuczZ2MqlJH2DWhiul5wJXFxbf/gRRd2UL4QZgozEMQ30mRi9i4/+p4JJat8S4Js64Q==",
       "dev": true,
       "requires": {
         "dom-event-types": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@rei/cdr-tokens": "^4.0.0",
     "@rollup/plugin-alias": "^3.1.0",
     "@vue/babel-preset-jsx": "^1.1.2",
-    "@vue/test-utils": "^1.0.0-beta.33",
+    "@vue/test-utils": "^1.0.0",
     "autoprefixer": "^9.7.6",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.3.0",

--- a/src/components/accordion/__tests__/CdrAccordion.spec.js
+++ b/src/components/accordion/__tests__/CdrAccordion.spec.js
@@ -37,7 +37,7 @@ describe('CdrAccordion', () => {
       },
     });
     const button = wrapper.find('#test');
-    const contentArea = wrapper.find({ ref: 'accordion-content' });
+    const contentArea = wrapper.findComponent({ ref: 'accordion-content' });
     expect(button.classes()).toContain('js-cdr-accordion-button');
     // closed state
     expect(button.attributes('aria-expanded')).toBe('false');

--- a/src/components/accordion/__tests__/CdrAccordionGroup.spec.js
+++ b/src/components/accordion/__tests__/CdrAccordionGroup.spec.js
@@ -26,6 +26,10 @@ describe('CdrAccordionGroup', () => {
   });
 
   it('has correct a11y', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const wrapper = mount(CdrAccordionGroup, {
       stubs: {
         'cdr-accordion': CdrAccordion,
@@ -37,7 +41,7 @@ describe('CdrAccordionGroup', () => {
           '<cdr-accordion id="tab3" label="label3" level="2"/>',
         ]
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     expect(wrapper.element.tagName).toBe('UL');
@@ -76,5 +80,6 @@ describe('CdrAccordionGroup', () => {
     wrapper.setData({ currentIdx: 0 });
     await wrapper.vm.$nextTick();
     expect(buttons[0]).toBe(document.activeElement);
+    wrapper.destroy();
   });
 });

--- a/src/components/accordion/__tests__/CdrAccordionGroup.spec.js
+++ b/src/components/accordion/__tests__/CdrAccordionGroup.spec.js
@@ -24,7 +24,7 @@ describe('CdrAccordionGroup', () => {
     });
     expect(wrapper.element).toMatchSnapshot()
   });
-  
+
   it('has correct a11y', async () => {
     const wrapper = mount(CdrAccordionGroup, {
       stubs: {
@@ -40,7 +40,7 @@ describe('CdrAccordionGroup', () => {
       attachToDocument: true,
     });
 
-    expect(wrapper.is('ul')).toBe(true);
+    expect(wrapper.element.tagName).toBe('UL');
     /* keyboard nav tests
       `focusin` doesn't fire outside of the browser environment so it's faked by just doing the logic
       manually instead with setData. The proper focus logic is still checked via document.activeElement

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -71,7 +71,7 @@ describe('CdrBreadcrumb', () => {
       }
     });
 
-    const ellipse = wrapper.find({ref: 'ellipse'});
+    const ellipse = wrapper.findComponent({ref: 'ellipse'});
     expect(ellipse.attributes()['aria-label']).toBe('show 1 more navigation level');
     expect(ellipse.attributes()['aria-controls']).toBe(`${wrapper.vm.$data.componentID}List`);
     expect(ellipse.attributes()['aria-expanded']).toBe('false');
@@ -97,7 +97,7 @@ describe('CdrBreadcrumb', () => {
 
 
     expect(wrapper.vm.truncate).toBe(true);
-    wrapper.find({ref: 'ellipse'}).trigger('click');
+    wrapper.findComponent({ref: 'ellipse'}).trigger('click');
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.truncate).toBeFalsy();
   });

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -75,7 +75,7 @@ describe('CdrBreadcrumb', () => {
     expect(ellipse.attributes()['aria-label']).toBe('show 1 more navigation level');
     expect(ellipse.attributes()['aria-controls']).toBe(`${wrapper.vm.$data.componentID}List`);
     expect(ellipse.attributes()['aria-expanded']).toBe('false');
-    expect(wrapper.is('nav')).toBe(true);
+    expect(wrapper.element.tagName).toBe('NAV');
     expect(wrapper.attributes()['aria-label']).toBe('breadcrumbs');
   });
 

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -134,15 +134,20 @@ describe('CdrBreadcrumb', () => {
   });
 
   it('applies focus to first breadcrumb on ellipsis click', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const wrapper = mount(CdrBreadcrumb, {
       propsData: {
         items: itemsA,
       },
-      attachToDocument: true, // enables focus testing
+      attachTo: elem, // enables focus testing
     });
     wrapper.vm.handleEllipsisClick();
     await wrapper.vm.$nextTick();
     expect(document.activeElement.textContent).toBe(itemsA[0].item.name);
+    wrapper.destroy();
   });
 
 });

--- a/src/components/button/__tests__/CdrButton.spec.js
+++ b/src/components/button/__tests__/CdrButton.spec.js
@@ -86,6 +86,6 @@ describe('CdrButton', () => {
         tag: 'a',
       },
     });
-    expect(wrapper.is('a')).toBe(true);
+    expect(wrapper.element.tagName).toBe('A');
   });
 });

--- a/src/components/checkbox/__tests__/CdrCheckbox.spec.js
+++ b/src/components/checkbox/__tests__/CdrCheckbox.spec.js
@@ -78,7 +78,7 @@ describe('CdrCheckbox', () => {
         value: false,
       },
     });
-    const cb = wrapper.find({ ref: 'checkbox'});
+    const cb = wrapper.findComponent({ ref: 'checkbox'});
     cb.trigger('click');
     expect(wrapper.emitted().change[0][0]).toBe(true);
     cb.trigger('click');
@@ -93,7 +93,7 @@ describe('CdrCheckbox', () => {
         value: '',
       },
     });
-    const cb = wrapper.find({ ref: 'checkbox'});
+    const cb = wrapper.findComponent({ ref: 'checkbox'});
     cb.trigger('click');
     expect(wrapper.emitted().change[0][0]).toBe('checked');
     cb.trigger('click');
@@ -107,7 +107,7 @@ describe('CdrCheckbox', () => {
         value: ['a'],
       },
     });
-    const cb = wrapper.find({ ref: 'checkbox'});
+    const cb = wrapper.findComponent({ ref: 'checkbox'});
     cb.trigger('click');
     expect(wrapper.emitted().change[0][0]).toEqual(['a', 'b']);
     cb.trigger('click');

--- a/src/components/dataTable/__tests__/CdrDataTable.spec.js
+++ b/src/components/dataTable/__tests__/CdrDataTable.spec.js
@@ -83,6 +83,10 @@ describe('CdrDataTable', () => {
     });
 
     it('adds resize event watcher', async () => {
+      const elem = document.createElement('div')
+      if (document.body) {
+        document.body.appendChild(elem)
+      }
       const wrapper = shallowMount(CdrDataTable, {
         propsData: {
           colHeaders: data.colHeaders,
@@ -95,17 +99,22 @@ describe('CdrDataTable', () => {
         methods: {
           setRowsContentHeight: () => true,
         },
-        attachToDocument: true,
+        attachTo: elem,
       });
-      
+
       const spy = spyOn(wrapper.vm, 'checkScroll');
       window.dispatchEvent(new Event('resize'));
       await wrapper.vm.$nextTick();
-    
+
       expect(spy).toHaveBeenCalled();
+      wrapper.destroy();
     });
 
     it('adds load event watcher', async () => {
+      const elem = document.createElement('div')
+      if (document.body) {
+        document.body.appendChild(elem)
+      }
       const wrapper = shallowMount(CdrDataTable, {
         propsData: {
           colHeaders: data.colHeaders,
@@ -118,14 +127,15 @@ describe('CdrDataTable', () => {
         methods: {
           setRowsContentHeight: () => true,
         },
-        attachToDocument: true,
+        attachTo: elem,
       });
-      
+
       const spy = spyOn(wrapper.vm, 'setRowsContentHeight');
       window.dispatchEvent(new Event('load'));
       await wrapper.vm.$nextTick();
 
       expect(spy).toHaveBeenCalled();
+      wrapper.destroy();
     });
   });
 
@@ -237,7 +247,7 @@ describe('CdrDataTable', () => {
     });
 
     describe('getRowAlignHeight', () => {
-      let wrapper; 
+      let wrapper;
 
       beforeEach(() => {
         wrapper = shallowMount(CdrDataTable, {

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -196,7 +196,7 @@ describe('CdrInput', () => {
         value: 'bar'
       },
     });
-    const input = wrapper.find({ ref: 'input' });
+    const input = wrapper.findComponent({ ref: 'input' });
     input.setValue('foo');
     expect(wrapper.emitted().input[0][0]).toBe('foo');
   });
@@ -211,7 +211,7 @@ describe('CdrInput', () => {
         'blur': spy
       }
     });
-    const input = wrapper.find({ ref: 'input' });
+    const input = wrapper.findComponent({ ref: 'input' });
     input.trigger('blur')
     expect(spy.calledOnce).toBeTruthy();
   });
@@ -226,7 +226,7 @@ describe('CdrInput', () => {
         'focus': spy
       }
     });
-    const input = wrapper.find({ ref: 'input' });
+    const input = wrapper.findComponent({ ref: 'input' });
     input.trigger('focus')
     expect(spy.calledOnce).toBeTruthy();
   });
@@ -241,7 +241,7 @@ describe('CdrInput', () => {
         'paste': spy
       }
     });
-    const input = wrapper.find({ ref: 'input' });
+    const input = wrapper.findComponent({ ref: 'input' });
     input.trigger('paste')
     expect(spy.calledOnce).toBeTruthy();
   });
@@ -256,7 +256,7 @@ describe('CdrInput', () => {
         'keydown': spy
       }
     });
-    const input = wrapper.find({ ref: 'input' });
+    const input = wrapper.findComponent({ ref: 'input' });
     input.trigger('keydown', {
       key: 'a'
     })
@@ -319,7 +319,7 @@ describe('CdrInput', () => {
         value: 'bar'
       },
     });
-    const input = wrapper.find({ ref: 'input' });
+    const input = wrapper.findComponent({ ref: 'input' });
     wrapper.setProps({value: ''});
     await wrapper.vm.$nextTick();
     expect(input.element.value).toBe('');

--- a/src/components/modal/__tests__/CdrModal.spec.js
+++ b/src/components/modal/__tests__/CdrModal.spec.js
@@ -6,6 +6,10 @@ import CdrButton from 'componentdir/button/CdrButton';
 
 describe('CdrModal.vue', () => {
   it('default open, scrolling', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const wrapper = shallowMount(CdrModal, {
       propsData: {
         opened: true,
@@ -17,7 +21,7 @@ describe('CdrModal.vue', () => {
       computed: {
         scrolling: () => true,
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     expect(wrapper.element).toMatchSnapshot();
@@ -33,6 +37,10 @@ describe('CdrModal.vue', () => {
   });
 
   it('leaves optional slots empty, handleOpened', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const mockMeasureContent = jest.fn();
     const wrapper = shallowMount(CdrModal, {
       propsData: {
@@ -45,13 +53,13 @@ describe('CdrModal.vue', () => {
       methods: {
         measureContent: mockMeasureContent
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     wrapper.setProps({ opened: true });
     await wrapper.vm.$nextTick();
     expect(wrapper.element).toMatchSnapshot();
-    
+
     setTimeout(() => {
       expect(mockMeasureContent).toHaveBeenCalled();
       wrapper.destroy();
@@ -59,6 +67,10 @@ describe('CdrModal.vue', () => {
   });
 
   it('handleKeyDown', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const mockMeasureContent = jest.fn();
     const wrapper = shallowMount(CdrModal, {
       propsData: {
@@ -71,7 +83,7 @@ describe('CdrModal.vue', () => {
       methods: {
         measureContent: mockMeasureContent,
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     wrapper.trigger('keydown', {
@@ -94,6 +106,10 @@ describe('CdrModal.vue', () => {
   });
 
   it('scrolling and fullscreen snapshot', () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const mockMeasureContent = jest.fn();
     const wrapper = shallowMount(CdrModal, {
       propsData: {
@@ -113,7 +129,7 @@ describe('CdrModal.vue', () => {
       slots: {
         scrollingContentSlot: 'Main content',
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     expect(wrapper.vm.scrolling).toBe(true);
@@ -122,6 +138,10 @@ describe('CdrModal.vue', () => {
   });
 
   it('removeNoScroll', () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const mockMeasureContent = jest.fn();
     const wrapper = shallowMount(CdrModal, {
       propsData: {
@@ -134,7 +154,7 @@ describe('CdrModal.vue', () => {
       slots: {
         scrollingContentSlot: 'Main content',
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
     const { documentElement, body } = document;
     wrapper.vm.removeNoScroll();
@@ -146,6 +166,10 @@ describe('CdrModal.vue', () => {
   });
 
   it('handleFocus', () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const mockMeasureContent = jest.fn();
     const wrapper = mount(CdrModal, {
       propsData: {
@@ -155,7 +179,7 @@ describe('CdrModal.vue', () => {
       methods: {
         measureContent: mockMeasureContent,
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     const button = wrapper.find('button').element;
@@ -169,13 +193,17 @@ describe('CdrModal.vue', () => {
   });
 
   it('handleClosed', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     global.scrollTo = jest.fn();
     const spyMeasureContent = jest.fn();
     const spyHandleOpened = jest.fn();
-    
+
     const wrapper = shallowMount(CdrModal, {
       propsData: {
-        opened: true, 
+        opened: true,
         label: "My Modal Label",
       },
       data() {
@@ -187,7 +215,7 @@ describe('CdrModal.vue', () => {
         measureContent: spyMeasureContent,
         handleOpened: spyHandleOpened,
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     wrapper.vm.handleClosed();
@@ -196,10 +224,15 @@ describe('CdrModal.vue', () => {
     setTimeout(() => {
       expect(wrapper.vm.reallyClosed).toBe(true);
       expect(wrapper.vm.unsubscribe).toBe(null);
+      wrapper.destroy();
     }, 500);
   });
 
   it('resize event', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const spyMeasureContent = jest.fn();
     const wrapper = shallowMount(CdrModal, {
       propsData: {
@@ -212,7 +245,7 @@ describe('CdrModal.vue', () => {
       methods: {
         measureContent: spyMeasureContent,
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     window.dispatchEvent(new Event('resize'));

--- a/src/components/pagination/__tests__/CdrPagination.spec.js
+++ b/src/components/pagination/__tests__/CdrPagination.spec.js
@@ -98,7 +98,7 @@ describe('CdrPagination', () => {
         value: 1,
       },
     });
-    expect(wrapper.is('nav')).toBe(true);
+    expect(wrapper.element.tagName).toBe('NAV');
   });
 
   it('sorts 20 pages correctly', async () => {
@@ -247,7 +247,7 @@ describe('CdrPagination', () => {
     expect(wrapper.emitted().navigate[1][0]).toBe(7);
     expect(wrapper.emitted().navigate[1][1]).toBe('?page=7');
     expect(wrapper.emitted().navigate[1][2] instanceof Event).toBeTruthy();
-    
+
     // previous clicks
     prev.trigger('click'); // 7 -> 6
     await wrapper.vm.$nextTick();
@@ -259,7 +259,7 @@ describe('CdrPagination', () => {
     expect(wrapper.emitted().navigate[3][0]).toBe(5);
     expect(wrapper.emitted().navigate[3][1]).toBe('?page=5');
     expect(wrapper.emitted().navigate[3][2] instanceof Event).toBeTruthy();
-    
+
     // individual links
     let link = wrapper.findAll('ol > li > a').at(1);
     link.trigger('click'); // 5 -> 1
@@ -277,7 +277,7 @@ describe('CdrPagination', () => {
     link2.trigger('click'); // 2 -> 2
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().navigate[6]).toBeUndefined();
-    
+
     // use select
     let options = wrapper.find({ ref: `select-${wrapper.vm.componentID}` }).findAll('option')
     options.at(2).setSelected(); // 2 -> 3
@@ -319,7 +319,7 @@ describe('CdrPagination', () => {
     expect(wrapper.emitted().navigate[1][0]).toBe(7);
     expect(wrapper.emitted().navigate[1][1]).toBe('?page=7');
     expect(wrapper.emitted().navigate[1][2] instanceof Event).toBeTruthy();
-    
+
     // previous clicks
     prev.click(); // 7 -> 6
     await wrapper.vm.$nextTick();
@@ -396,7 +396,7 @@ describe('CdrPagination', () => {
     expect(wrapper.emitted().navigate[1][0]).toBe(7);
     expect(wrapper.emitted().navigate[1][1]).toBe('?page=7');
     expect(wrapper.emitted().navigate[1][2] instanceof Event).toBeTruthy();
-    
+
     // previous clicks
     prev.click(); // 7 -> 6
     await wrapper.vm.$nextTick();

--- a/src/components/pagination/__tests__/CdrPagination.spec.js
+++ b/src/components/pagination/__tests__/CdrPagination.spec.js
@@ -108,8 +108,8 @@ describe('CdrPagination', () => {
         value: 1,
       },
     });
-    let prev = wrapper.find({ref: `prev-link-${wrapper.vm.componentID}`});
-    let next = wrapper.find({ref: `next-link-${wrapper.vm.componentID}`});
+    let prev = wrapper.findComponent({ref: `prev-link-${wrapper.vm.componentID}`});
+    let next = wrapper.findComponent({ref: `next-link-${wrapper.vm.componentID}`});
 
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5,'...',20]);
     expect(prev.exists()).toBeFalsy();
@@ -118,24 +118,24 @@ describe('CdrPagination', () => {
     wrapper.setProps({ value: 4 });
     await wrapper.vm.$nextTick();
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5,'...',20]);
-    prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
-    next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
+    prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
+    next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
 
     wrapper.setProps({ value: 20 });
     await wrapper.vm.$nextTick();
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,'...',16,17,18,19,20]);
-    prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
-    next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
+    prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
+    next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeFalsy();
 
     wrapper.setProps({ value: 17 });
     await wrapper.vm.$nextTick();
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,'...',16,17,18,19,20]);
-    prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
-    next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
+    prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
+    next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
   });
@@ -147,8 +147,8 @@ describe('CdrPagination', () => {
         value: 1,
       },
     });
-    let prev = wrapper.find({ref: `prev-link-${wrapper.vm.componentID}`});
-    let next = wrapper.find({ref: `next-link-${wrapper.vm.componentID}`});
+    let prev = wrapper.findComponent({ref: `prev-link-${wrapper.vm.componentID}`});
+    let next = wrapper.findComponent({ref: `next-link-${wrapper.vm.componentID}`});
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5]);
     expect(prev.exists()).toBeFalsy();
     expect(next.exists()).toBeTruthy();
@@ -156,16 +156,16 @@ describe('CdrPagination', () => {
     wrapper.setProps({ value: 4 });
     await wrapper.vm.$nextTick();
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5]);
-    prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
-    next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
+    prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
+    next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
 
     wrapper.setProps({ value: 5 });
     await wrapper.vm.$nextTick();
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1,2,3,4,5]);
-    prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
-    next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
+    prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
+    next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeFalsy();
   });
@@ -179,8 +179,8 @@ describe('CdrPagination', () => {
     });
 
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([4, 5, 6]);
-    let prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
-    let next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
+    let prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
+    let next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
     expect(prev.exists()).toBeTruthy();
     expect(next.exists()).toBeTruthy();
   });
@@ -194,8 +194,8 @@ describe('CdrPagination', () => {
     });
 
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([1, 2]);
-    const prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
-    const next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
+    const prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
+    const next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
     const disabledPrev = wrapper.find('li');
     expect(disabledPrev.text()).toBe('Prev');
     expect(prev.exists()).toBeFalsy();
@@ -211,8 +211,8 @@ describe('CdrPagination', () => {
     });
 
     expect(getPageNumArray(wrapper.vm.paginationData)).toEqual([9, 10]);
-    const prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
-    const next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
+    const prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
+    const next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
     const allLinks = wrapper.findAll('li');
     const disabledNext = allLinks.at(allLinks.length-1);
     expect(disabledNext.text()).toBe('Next');
@@ -233,8 +233,8 @@ describe('CdrPagination', () => {
         }
       }
     });
-    let next = wrapper.find({ ref: `next-link-${wrapper.vm.componentID}` });
-    let prev = wrapper.find({ ref: `prev-link-${wrapper.vm.componentID}` });
+    let next = wrapper.findComponent({ ref: `next-link-${wrapper.vm.componentID}` });
+    let prev = wrapper.findComponent({ ref: `prev-link-${wrapper.vm.componentID}` });
 
     // next clicks
     next.trigger('click'); // 5 -> 6
@@ -279,7 +279,7 @@ describe('CdrPagination', () => {
     expect(wrapper.emitted().navigate[6]).toBeUndefined();
 
     // use select
-    let options = wrapper.find({ ref: `select-${wrapper.vm.componentID}` }).findAll('option')
+    let options = wrapper.findComponent({ ref: `select-${wrapper.vm.componentID}` }).findAll('option')
     options.at(2).setSelected(); // 2 -> 3
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().navigate[6][0]).toBe(3);
@@ -351,7 +351,7 @@ describe('CdrPagination', () => {
     expect(wrapper.emitted().navigate[6]).toBeUndefined();
 
     // use select
-    let select = wrapper.find({ ref: `select-${wrapper.vm.componentID}` })
+    let select = wrapper.findComponent({ ref: `select-${wrapper.vm.componentID}` })
     let options = select.findAll('option')
     options.at(2).setSelected();
     await wrapper.vm.$nextTick();
@@ -428,7 +428,7 @@ describe('CdrPagination', () => {
     expect(wrapper.emitted().navigate[6]).toBeUndefined();
 
     // use select
-    let options = wrapper.find({ ref: `select-${wrapper.vm.componentID}` }).findAll('option')
+    let options = wrapper.findComponent({ ref: `select-${wrapper.vm.componentID}` }).findAll('option')
     options.at(2).setSelected();
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().navigate[6][0]).toBe(3);
@@ -444,12 +444,12 @@ describe('CdrPagination', () => {
       },
     });
 
-    let option = wrapper.find({ ref: `select-${wrapper.vm.componentID}` }).findAll('option').at(0);
+    let option = wrapper.findComponent({ ref: `select-${wrapper.vm.componentID}` }).findAll('option').at(0);
     expect(option.text()).toBe('Page 1');
 
     wrapper.setProps({ totalPages: 20 });
     await wrapper.vm.$nextTick();
-    option = wrapper.find({ ref: `select-${wrapper.vm.componentID}` }).findAll('option').at(0);
+    option = wrapper.findComponent({ ref: `select-${wrapper.vm.componentID}` }).findAll('option').at(0);
     expect(option.text()).toBe('Page 1 of 20');
   });
 

--- a/src/components/radio/__tests__/CdrRadio.spec.js
+++ b/src/components/radio/__tests__/CdrRadio.spec.js
@@ -127,7 +127,7 @@ describe('CdrRadio', () => {
       },
     });
 
-    const rb = wrapper.find({ ref: 'radio'});
+    const rb = wrapper.findComponent({ ref: 'radio'});
     rb.trigger('click')
     expect(wrapper.emitted().change[0][0]).toBe('A');
   });

--- a/src/components/rating/__tests__/CdrRating.spec.js
+++ b/src/components/rating/__tests__/CdrRating.spec.js
@@ -23,21 +23,21 @@ describe('CdrRating', () => {
     expect(wrapper.vm.remainder).toBe('50');
     expect(wrapper.vm.rounded).toBe(3.5);
     expect(wrapper.vm.empties).toBe(1);
-    
+
     wrapper.setProps({rating: 3.122227});
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.whole).toBe(3);
     expect(wrapper.vm.remainder).toBe('00');
     expect(wrapper.vm.rounded).toBe(3);
     expect(wrapper.vm.empties).toBe(2);
-    
+
     wrapper.setProps({rating: 3.222227});
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.whole).toBe(3);
     expect(wrapper.vm.remainder).toBe('25');
     expect(wrapper.vm.rounded).toBe(3.25);
     expect(wrapper.vm.empties).toBe(1);
-    
+
     wrapper.setProps({rating: 3.673323});
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.whole).toBe(3);
@@ -65,7 +65,7 @@ describe('CdrRating', () => {
         href: 'rei.com'
       }
     });
-    expect(wrapper.is('a')).toBeTruthy();
+    expect(wrapper.element.tagName).toBe('A');
   });
 
   it('has correct screen reader text when linked', async () => {
@@ -92,7 +92,7 @@ describe('CdrRating', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.srText).toBe('View the 100 reviews with an average rating of 3 out of 5 stars');
   });
-  
+
   it('has correct screen reader text', async () => {
     const wrapper = shallowMount(CdrRating, {
       propsData: {

--- a/src/components/select/__tests__/CdrSelect.spec.js
+++ b/src/components/select/__tests__/CdrSelect.spec.js
@@ -130,7 +130,7 @@ describe('cdrSelect', () => {
         options: ['3', '4'],
       },
     });
-    const select = wrapper.find({ ref: 'select'});
+    const select = wrapper.findComponent({ ref: 'select'});
     const options = select.findAll('option');
     options.at(0).setSelected();
     await wrapper.vm.$nextTick();
@@ -158,7 +158,7 @@ describe('cdrSelect', () => {
         }],
       },
     });
-    const select = wrapper.find({ ref: 'select' });
+    const select = wrapper.findComponent({ ref: 'select' });
     const options = select.findAll('option');
     options.at(0).element.selected = true;
     options.at(1).element.selected = false;
@@ -176,7 +176,7 @@ describe('cdrSelect', () => {
         options: ['3', '4'],
       },
     });
-    const select = wrapper.find({ ref: 'select' });
+    const select = wrapper.findComponent({ ref: 'select' });
     const options = select.findAll('option');
     wrapper.setProps({value: '3'});
     await wrapper.vm.$nextTick();

--- a/src/components/tabs/__tests__/CdrTabPanel.spec.js
+++ b/src/components/tabs/__tests__/CdrTabPanel.spec.js
@@ -110,7 +110,7 @@ describe('CdrTabPanel', () => {
     });
     await wrapper.vm.$nextTick();
 
-    wrapper.find(CdrTabPanel).trigger('keydown.up');
+    wrapper.findComponent(CdrTabPanel).trigger('keydown.up');
     expect(spySetFocusToActiveTabHeader).toHaveBeenCalled();
   })
 });

--- a/src/components/tabs/__tests__/CdrTabPanel.spec.js
+++ b/src/components/tabs/__tests__/CdrTabPanel.spec.js
@@ -92,13 +92,11 @@ describe('CdrTabPanel', () => {
     expect(wrapper.vm.animationDirection).toBe(null);
   });
 
-  it('handleUpArrowNav', async () => {
+  it('handleUpArrowNav', async (done) => {
     const elem = document.createElement('div')
     if (document.body) {
       document.body.appendChild(elem)
     }
-    const spyUpdateUnderline = jest.fn();
-    const spySetFocusToActiveTabHeader = jest.fn();
     const wrapper = mount(CdrTabs, {
       stubs: {
         'cdr-tab-panel': CdrTabPanel,
@@ -106,16 +104,19 @@ describe('CdrTabPanel', () => {
       slots: {
         default: ['<cdr-tab-panel name="tab1" id="tab1" aria-labelledby="tab1" />', '<cdr-tab-panel name="tab2" id="tab2" aria-labelledby="tab2" />']
       },
-      methods: {
-        updateUnderline: spyUpdateUnderline,
-        setFocusToActiveTabHeader: spySetFocusToActiveTabHeader,
-      },
       attachTo: elem,
     });
+
+    const spyUpdateUnderline = spyOn(wrapper.vm, 'updateUnderline');
+    const spySetFocusToActiveTabHeader = spyOn(wrapper.vm, 'setFocusToActiveTabHeader');
     await wrapper.vm.$nextTick();
 
     wrapper.findComponent(CdrTabPanel).trigger('keydown.up');
     expect(spySetFocusToActiveTabHeader).toHaveBeenCalled();
-    wrapper.destroy();
+    setTimeout(() => {
+      expect(spyUpdateUnderline).toHaveBeenCalled();
+      wrapper.destroy();
+      done();
+    }, 550)
   })
 });

--- a/src/components/tabs/__tests__/CdrTabPanel.spec.js
+++ b/src/components/tabs/__tests__/CdrTabPanel.spec.js
@@ -93,6 +93,10 @@ describe('CdrTabPanel', () => {
   });
 
   it('handleUpArrowNav', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const spyUpdateUnderline = jest.fn();
     const spySetFocusToActiveTabHeader = jest.fn();
     const wrapper = mount(CdrTabs, {
@@ -106,11 +110,12 @@ describe('CdrTabPanel', () => {
         updateUnderline: spyUpdateUnderline,
         setFocusToActiveTabHeader: spySetFocusToActiveTabHeader,
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
     await wrapper.vm.$nextTick();
 
     wrapper.findComponent(CdrTabPanel).trigger('keydown.up');
     expect(spySetFocusToActiveTabHeader).toHaveBeenCalled();
+    wrapper.destroy();
   })
 });

--- a/src/components/tabs/__tests__/CdrTabs.spec.js
+++ b/src/components/tabs/__tests__/CdrTabs.spec.js
@@ -12,11 +12,7 @@ describe('CdrTabs', () => {
       expect(wrapper.element).toMatchSnapshot();
     });
 
-    it('mounts with cdr-tab-panel children', async () => {
-      const spyGetNextTab = jest.fn();
-      const spyGetHeaderWidth = jest.fn();
-      const spyCalculateOverflow = jest.fn();
-      const spyUpdateUnderline = jest.fn();
+    it('mounts with cdr-tab-panel children', async (done) => {
 
       const wrapper = mount(CdrTabs, {
         stubs: {
@@ -28,25 +24,28 @@ describe('CdrTabs', () => {
             '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />'
           ],
         },
-        methods: {
-          getNextTab: spyGetNextTab,
-          getHeaderWidth: spyGetHeaderWidth,
-          calculateOverflow: spyCalculateOverflow,
-          updateUnderline: spyUpdateUnderline,
+        propsData: {
+          activeTab: 1,
         },
       });
 
+      const spyGetHeaderWidth = spyOn(wrapper.vm, 'getHeaderWidth');
+      const spyCalculateOverflow = spyOn(wrapper.vm, 'calculateOverflow');
+      const spyUpdateUnderline = spyOn(wrapper.vm, 'updateUnderline');
+
       await wrapper.vm.$nextTick();
+
+      expect(wrapper.element).toMatchSnapshot();
 
       expect(wrapper.vm.tabs.length).toBe(2);
       expect(wrapper.findAll('li').length).toBe(2);
-      expect(wrapper.element).toMatchSnapshot();
-      expect(spyGetNextTab).toHaveBeenCalled();
-      expect(spyGetHeaderWidth).toHaveBeenCalled();
-      expect(spyCalculateOverflow).toHaveBeenCalled();
+      expect(wrapper.vm.activeTabIndex).toBe(1);
       setTimeout(() => { // for debounce
+        expect(spyGetHeaderWidth).toHaveBeenCalled();
+        expect(spyCalculateOverflow).toHaveBeenCalled();
         expect(spyUpdateUnderline).toHaveBeenCalled();
         wrapper.destroy();
+        done();
       }, 600);
     });
   });
@@ -57,8 +56,6 @@ describe('CdrTabs', () => {
       if (document.body) {
         document.body.appendChild(elem)
       }
-      const spyCalculateOverflow = jest.fn();
-      const spyUpdateUnderline = jest.fn();
 
       const wrapper = mount(CdrTabs, {
         stubs: {
@@ -70,22 +67,21 @@ describe('CdrTabs', () => {
             '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />'
           ],
         },
-        methods: {
-          calculateOverflow: spyCalculateOverflow,
-          updateUnderline: spyUpdateUnderline,
-        },
         attachTo: elem,
       });
 
-        wrapper.vm.$refs.cdrTabsHeader.parentElement.dispatchEvent(new Event('scroll'));
-        await wrapper.vm.$nextTick();
+      const spyCalculateOverflow = spyOn(wrapper.vm, 'calculateOverflow');
+      const spyUpdateUnderline = spyOn(wrapper.vm, 'updateUnderline');
 
-        setTimeout(() => { // for debounce
-          expect(wrapper.vm.overflowLeft).toBe(false);
-          expect(spyCalculateOverflow).toHaveBeenCalled();
-          expect(spyUpdateUnderline).toHaveBeenCalled();
-          wrapper.destroy();
-        }, 600);
+      wrapper.vm.$refs.cdrTabsHeader.parentElement.dispatchEvent(new Event('scroll'));
+      await wrapper.vm.$nextTick();
+
+      setTimeout(() => { // for debounce
+        expect(wrapper.vm.overflowLeft).toBe(false);
+        expect(spyCalculateOverflow).toHaveBeenCalled();
+        expect(spyUpdateUnderline).toHaveBeenCalled();
+        wrapper.destroy();
+      }, 600);
     });
 
     it('handles resize event', async () => {
@@ -93,9 +89,6 @@ describe('CdrTabs', () => {
       if (document.body) {
         document.body.appendChild(elem)
       }
-      const spyCalculateOverflow = jest.fn();
-      const spyUpdateUnderline = jest.fn();
-      const spyGetHeaderWidth = jest.fn();
 
       const wrapper = mount(CdrTabs, {
         stubs: {
@@ -107,14 +100,12 @@ describe('CdrTabs', () => {
             '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />'
           ],
         },
-        methods: {
-          calculateOverflow: spyCalculateOverflow,
-          updateUnderline: spyUpdateUnderline,
-          getHeaderWidth: spyGetHeaderWidth,
-        },
         attachTo: elem,
       });
 
+      const spyCalculateOverflow = spyOn(wrapper.vm, 'calculateOverflow');
+      const spyUpdateUnderline = spyOn(wrapper.vm, 'updateUnderline');
+      const spyGetHeaderWidth = spyOn(wrapper.vm, 'getHeaderWidth');
       window.dispatchEvent(new Event('resize'));
       await wrapper.vm.$nextTick();
 
@@ -244,7 +235,6 @@ describe('CdrTabs', () => {
       if (document.body) {
         document.body.appendChild(elem)
       }
-      const spyUpdateUnderline = jest.fn();
       const wrapper = mount(CdrTabs, {
         stubs: {
           'cdr-tab-panel': CdrTabPanel,
@@ -254,9 +244,6 @@ describe('CdrTabs', () => {
             '<cdr-tab-panel name="tab1" id="tab-panel-1" aria-labelledby="tab-1" />',
             '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />'
           ],
-        },
-        methods: {
-          updateUnderline: spyUpdateUnderline,
         },
         attachTo: elem,
       });
@@ -295,7 +282,6 @@ describe('CdrTabs', () => {
   });
 
   it('accessibility', async () => {
-    const spyUpdateUnderline = jest.fn();
     const wrapper = mount(CdrTabs, {
       stubs: {
         'cdr-tab-panel': CdrTabPanel,
@@ -305,9 +291,6 @@ describe('CdrTabs', () => {
           '<cdr-tab-panel name="tab1" id="tab-panel-1"  aria-labelledby="tab-1" />',
           '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />',
           '<cdr-tab-panel name="tab3" :disabled="true" id="tab-panel-3" aria-labelledby="tab-3" />']
-      },
-      methods: {
-        updateUnderline: spyUpdateUnderline,
       },
     });
 
@@ -328,7 +311,6 @@ describe('CdrTabs', () => {
     if (document.body) {
       document.body.appendChild(elem)
     }
-    const spyUpdateUnderline = jest.fn();
     const wrapper = mount(CdrTabs, {
       stubs: {
         'cdr-tab-panel': CdrTabPanel,
@@ -338,9 +320,6 @@ describe('CdrTabs', () => {
           '<cdr-tab-panel name="tab1" id="tab-panel-1" aria-labelledby="tab-1" />',
           '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />'
         ],
-      },
-      methods: {
-        updateUnderline: spyUpdateUnderline,
       },
       attachTo: elem,
     });
@@ -357,7 +336,6 @@ describe('CdrTabs', () => {
     if (document.body) {
       document.body.appendChild(elem)
     }
-    const spyUpdateUnderline = jest.fn();
     const wrapper = mount(CdrTabs, {
       stubs: {
         'cdr-tab-panel': CdrTabPanel,
@@ -367,9 +345,6 @@ describe('CdrTabs', () => {
           '<cdr-tab-panel name="tab1" id="tab-panel-1" aria-labelledby="tab-1" />',
           '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />'
         ],
-      },
-      methods: {
-        updateUnderline: spyUpdateUnderline,
       },
       attachTo: elem,
     });

--- a/src/components/tabs/__tests__/CdrTabs.spec.js
+++ b/src/components/tabs/__tests__/CdrTabs.spec.js
@@ -302,7 +302,7 @@ describe('CdrTabs', () => {
     expect(tab1.attributes()['aria-disabled']).toBe('false');
 
     // tablist role
-    expect(wrapper.find({ref: 'cdrTabsHeader'}).attributes()['role']).toBe('tablist');
+    expect(wrapper.findComponent({ref: 'cdrTabsHeader'}).attributes()['role']).toBe('tablist');
   });
 
   it('handleDownArrowNav', async () => {

--- a/src/components/tabs/__tests__/CdrTabs.spec.js
+++ b/src/components/tabs/__tests__/CdrTabs.spec.js
@@ -53,6 +53,10 @@ describe('CdrTabs', () => {
 
   describe('event listeners', () => {
     it('handles scroll event', async () => {
+      const elem = document.createElement('div')
+      if (document.body) {
+        document.body.appendChild(elem)
+      }
       const spyCalculateOverflow = jest.fn();
       const spyUpdateUnderline = jest.fn();
 
@@ -70,7 +74,7 @@ describe('CdrTabs', () => {
           calculateOverflow: spyCalculateOverflow,
           updateUnderline: spyUpdateUnderline,
         },
-        attachToDocument: true,
+        attachTo: elem,
       });
 
         wrapper.vm.$refs.cdrTabsHeader.parentElement.dispatchEvent(new Event('scroll'));
@@ -85,6 +89,10 @@ describe('CdrTabs', () => {
     });
 
     it('handles resize event', async () => {
+      const elem = document.createElement('div')
+      if (document.body) {
+        document.body.appendChild(elem)
+      }
       const spyCalculateOverflow = jest.fn();
       const spyUpdateUnderline = jest.fn();
       const spyGetHeaderWidth = jest.fn();
@@ -104,7 +112,7 @@ describe('CdrTabs', () => {
           updateUnderline: spyUpdateUnderline,
           getHeaderWidth: spyGetHeaderWidth,
         },
-        attachToDocument: true,
+        attachTo: elem,
       });
 
       window.dispatchEvent(new Event('resize'));
@@ -201,7 +209,7 @@ describe('CdrTabs', () => {
         ],
       }
     });
-    
+
     await wrapper.vm.$nextTick();
     // Trigger right arrow keyup event
     wrapper.findAll('div').at(1).trigger('keyup.right');
@@ -221,7 +229,7 @@ describe('CdrTabs', () => {
         ],
       }
     });
-    
+
     wrapper.setData({ activeTabIndex: 1 });
     await wrapper.vm.$nextTick();
     // Trigger left arrow keyup event
@@ -232,6 +240,10 @@ describe('CdrTabs', () => {
 
   describe('overflow classes', () => {
     it('adds gradient-left class', async () => {
+      const elem = document.createElement('div')
+      if (document.body) {
+        document.body.appendChild(elem)
+      }
       const spyUpdateUnderline = jest.fn();
       const wrapper = mount(CdrTabs, {
         stubs: {
@@ -246,16 +258,21 @@ describe('CdrTabs', () => {
         methods: {
           updateUnderline: spyUpdateUnderline,
         },
-        attachToDocument: true,
+        attachTo: elem,
       });
 
       await wrapper.vm.$nextTick();
       wrapper.setData({ overflowLeft: true });
       await wrapper.vm.$nextTick();
       expect(wrapper.find('.cdr-tabs__header-gradient-left').exists()).toBe(true);
+      wrapper.destroy();
     });
 
     it('adds gradient-right class', async () => {
+      const elem = document.createElement('div')
+      if (document.body) {
+        document.body.appendChild(elem)
+      }
       const wrapper = mount(CdrTabs, {
         stubs: {
           'cdr-tab-panel': CdrTabPanel,
@@ -266,13 +283,14 @@ describe('CdrTabs', () => {
             '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />'
           ]
         },
-        attachToDocument: true,
+        attachTo: elem,
       });
 
       await wrapper.vm.$nextTick();
       wrapper.setData({ overflowRight: true });
       await wrapper.vm.$nextTick();
       expect(wrapper.find('.cdr-tabs__header-gradient-right').exists()).toBe(true);
+      wrapper.destroy();
     });
   });
 
@@ -306,6 +324,10 @@ describe('CdrTabs', () => {
   });
 
   it('handleDownArrowNav', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const spyUpdateUnderline = jest.fn();
     const wrapper = mount(CdrTabs, {
       stubs: {
@@ -320,16 +342,21 @@ describe('CdrTabs', () => {
       methods: {
         updateUnderline: spyUpdateUnderline,
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     await wrapper.vm.$nextTick();
     wrapper.vm.handleDownArrowNav();
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.$el.lastElementChild.children[wrapper.vm.activeTabIndex]).toBe(document.activeElement);
+    wrapper.destroy();
   });
 
   it('setFocusToActiveTabHeader', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const spyUpdateUnderline = jest.fn();
     const wrapper = mount(CdrTabs, {
       stubs: {
@@ -344,16 +371,21 @@ describe('CdrTabs', () => {
       methods: {
         updateUnderline: spyUpdateUnderline,
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
 
     await wrapper.vm.$nextTick();
     wrapper.vm.setFocusToActiveTabHeader();
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.$refs.cdrTabsHeader.children[wrapper.vm.activeTabIndex].children[0]).toBe(document.activeElement);
+    wrapper.destroy();
   });
 
   it('scrollbar is hidden properly', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
     const wrapper = mount(CdrTabs, {
       stubs: {
         'cdr-tab-panel': CdrTabPanel,
@@ -364,9 +396,9 @@ describe('CdrTabs', () => {
           '<cdr-tab-panel name="tab2" id="tab-panel-2" aria-labelledby="tab-2" />'
         ],
       },
-      attachToDocument: true,
+      attachTo: elem,
     });
-    
+
     wrapper.setData({ widthInitialized: true});
     await wrapper.vm.$nextTick();
     wrapper.setData({ underlineWidth: -1});

--- a/src/components/tabs/__tests__/__snapshots__/CdrTabs.spec.js.snap
+++ b/src/components/tabs/__tests__/__snapshots__/CdrTabs.spec.js.snap
@@ -60,14 +60,15 @@ exports[`CdrTabs mounted mounts with cdr-tab-panel children 1`] = `
         <li
           aria-controls="tab-panel-2"
           aria-disabled="false"
-          class="cdr-tabs__header-item"
+          aria-selected="true"
+          class="cdr-tabs__header-item-active cdr-tabs__header-item"
           id="tab-2"
           role="tab"
         >
           <a
             class="cdr-tabs__header-item-label"
             href="#tab-panel-2"
-            tabindex="-1"
+            tabindex="0"
           >
             tab2
           </a>
@@ -92,10 +93,8 @@ exports[`CdrTabs mounted mounts with cdr-tab-panel children 1`] = `
       tabindex="0"
     />
     <div
-      aria-hidden="true"
       aria-labelledby="tab-2"
       class="cdr-tab-panel"
-      hidden="hidden"
       id="tab-panel-2"
       role="tabpanel"
       tabindex="0"


### PR DESCRIPTION
vue-test-utils released 1.0.0 a few weeks ago so we can finally get off the beta version 🎉 

There was a bunch of deprecation warnings for stuff that will eventually be removed in 2.0.0 which i fixed. 

The one deprecation warning remaining is this: 

```[vue-test-utils]: overwriting methods via the `methods` property is deprecated and will be removed in the next major version. There is no clear migration path for the `methods` property - Vue does not support arbitrarily replacement of methods, nor should VTU. To stub a complex method extract it from the component and test it in isolation. Otherwise, the suggestion is to rethink those tests.```

https://vue-test-utils.vuejs.org/upgrading-to-v1/#setmethods-and-mountingoptions-methods

There was an easy fix for the `methods` usage in tabs/tabPanel, but we also use this feature in dataTable (which will hopefully be deleted before 2.0.0 is released) and modal which will be a bit harder to address. 