### PR TITLE
Form group iteration

### DIFF
--- a/src/components/alert/CdrAlert.jsx
+++ b/src/components/alert/CdrAlert.jsx
@@ -13,6 +13,7 @@ export default {
         value,
         ['info', 'warning', 'success', 'error'],
       ),
+      default: 'info',
     },
   },
   data() {

--- a/src/components/checkbox/examples/checkboxes.vue
+++ b/src/components/checkbox/examples/checkboxes.vue
@@ -173,8 +173,7 @@
       Checkbox group with indeterminate state:
     </cdr-text>
 
-    <fieldset>
-      <legend>Choose your toppings</legend>
+    <cdr-form-group label="Choose your toppings">
       <cdr-checkbox
         v-model="allSelected"
         :indeterminate="isIndeterminate"
@@ -200,7 +199,7 @@
           >{{ c }}</cdr-checkbox>
         </li>
       </cdr-list>
-    </fieldset>
+    </cdr-form-group>
   </div>
 </template>
 

--- a/src/components/formGroup/CdrFormGroup.jsx
+++ b/src/components/formGroup/CdrFormGroup.jsx
@@ -6,6 +6,7 @@ export default {
     label: {
       type: String,
       default: '',
+      required: false,
     },
   },
   data() {
@@ -20,7 +21,7 @@ export default {
   },
   render() {
     return (<fieldset class={this.style[this.baseClass]}>
-      <legend>{this.label}</legend>
+      <legend>{this.$slots.label || this.label}</legend>
       {this.$slots.default}
     </fieldset>);
   },

--- a/src/components/formGroup/examples/demo/Checkboxes.vue
+++ b/src/components/formGroup/examples/demo/Checkboxes.vue
@@ -14,17 +14,37 @@
         v-model="exGroup"
       >C</cdr-checkbox>
     </cdr-form-group>
+
+    <cdr-form-group>
+
+      <template slot="label">
+        <cdr-text modifier="heading-sans-600">Optional Label Override Example</cdr-text>
+      </template>
+      <cdr-checkbox
+        custom-value="A"
+        v-model="exGroup"
+      >A</cdr-checkbox>
+      <cdr-checkbox
+        custom-value="B"
+        v-model="exGroup"
+      >B</cdr-checkbox>
+      <cdr-checkbox
+        custom-value="C"
+        v-model="exGroup"
+      >C</cdr-checkbox>
+    </cdr-form-group>
   </div>
 </template>
 
 <script>
-import { CdrFormGroup, CdrCheckbox } from 'srcdir/index';
+import { CdrFormGroup, CdrCheckbox, CdrText } from 'srcdir/index';
 
 export default {
   name: 'ParagraphsDemo',
   components: {
     CdrFormGroup,
     CdrCheckbox,
+    CdrText,
   },
   data() {
     return {

--- a/src/components/formGroup/styles/CdrFormGroup.vars.scss
+++ b/src/components/formGroup/styles/CdrFormGroup.vars.scss
@@ -1,4 +1,18 @@
 @mixin cdr-form-group-base-mixin() {
-  border: 1px solid $cdr-color-border-primary;
-  // TODO: styling for label text?
+  @include cdr-text-heading-sans-300;
+  border: none;
+
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-block-start: 0;
+  padding-inline-start: 0;
+  padding-inline-end: 0;
+  padding-block-end: 0;
+
+  margin-bottom: $cdr-space-two-x;
+
+  legend {
+    padding-inline-start: 0;
+    margin-bottom: $cdr-space-one-x;
+  }
 }


### PR DESCRIPTION
designs: https://www.figma.com/file/wIdzSDusa2E21U3bhepjV2/Field-Sets?node-id=0%3A1


## formGroups
- adds label slot for override (and example to kitchen sink)
- sets default text styling for legend
- removes fieldset border
- removes default fieldset styling
- adds spacing between legend and content (consumers can override if needed by targeting `legend`)
- adds bottom margin (seems smarter to add this as a default and let consumers override by adding a class to their formGroup, than to require every consumer of formGroup to manually apply spacing)

## misc
- updates checkboxes dev example to use formGroup instead of fieldset
- sets default value for alert type
