### PR TITLE
tabby scrolly grady

### DIFF
--- a/src/components/dataTable/styles/CdrDataTable.scss
+++ b/src/components/dataTable/styles/CdrDataTable.scss
@@ -81,7 +81,7 @@
     td {
       border: 1px solid;
       min-height: 48px;
-      color: $cdr-color-text-primary-lightmode;
+      color: $cdr-color-text-primary;
       padding: $cdr-space-inset-one-x;
       text-align: left;
       min-width: 127px;
@@ -105,7 +105,7 @@
     thead {
       th {
         border-bottom: 2px solid $cdr-color-border-table-head;
-        
+
         /* empty column header, row header column */
         &[class^=empty] {
           border-right: 2px solid $cdr-color-border-table-head;
@@ -124,7 +124,7 @@
         // striping rows
         &:nth-child(even) {
           background-color: $cdr-color-background-table-row-alt;
-          
+
           & > th {
             background-color: $cdr-color-background-table-row-alt;
           }
@@ -133,7 +133,7 @@
         // disabled default
         &:nth-child(odd) {
           background-color: $cdr-color-background-table-row;
-          
+
           & > th {
             background-color: $cdr-color-background-table-row;
           }
@@ -147,17 +147,17 @@
           min-width: 150px;
           border-right: 2px solid $cdr-color-border-table-head;
         }
-        
+
         // striping rows
         &:nth-child(odd) {
           background-color: $cdr-color-background-table-row-alt;
-          
+
           & > th {
             background-color: $cdr-color-background-table-row-alt;
           }
         }
       }
-      
+
       .align-row-header-content {
         display: flex;
         justify-content: center;

--- a/src/components/modal/styles/CdrModal.scss
+++ b/src/components/modal/styles/CdrModal.scss
@@ -39,7 +39,7 @@ $modal-animation-duration: 150ms;
 
   &__contentWrap {
     align-items: flex-start;
-    background-color: $cdr-color-background-lightest;
+    background-color: $cdr-color-background-primary;
     display: flex;
     flex-direction: column;
     margin: auto;

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -21,8 +21,8 @@ export default {
     },
     backgroundColor: {
       type: String,
-      default: CdrColorBackgroundPrimary
-    }
+      default: CdrColorBackgroundPrimary,
+    },
   },
   data() {
     return {
@@ -201,7 +201,9 @@ export default {
       let totalWidth = 0;
       headerElements.forEach((element, i) => {
         // account for margin-left on header elements
-        if (i > 0) totalWidth += this.size === 'small' ? Number(CdrSpaceHalfX) : Number(CdrSpaceOneX);
+        if (i > 0) {
+          totalWidth += this.size === 'small' ? Number(CdrSpaceHalfX) : Number(CdrSpaceOneX);
+        }
         totalWidth += element.offsetWidth || 0;
       });
       return totalWidth;
@@ -254,8 +256,11 @@ export default {
             this.style['cdr-tabs__gradient'],
             this.style['cdr-tabs__gradient--left'],
             this.overflowLeft ? this.style['cdr-tabs__gradient--active'] : '',
-          )} style={ { background: `linear-gradient(to left, transparent, ${this.backgroundColor})`} }>
-          </div>
+          )}
+            style={
+              { background: `linear-gradient(to left, transparent, ${this.backgroundColor})` }
+            }
+          ></div>
           <nav
             class={this.style['cdr-tabs__header-container']}
           >
@@ -286,8 +291,11 @@ export default {
             this.style['cdr-tabs__gradient'],
             this.style['cdr-tabs__gradient--right'],
             this.overflowRight ? this.style['cdr-tabs__gradient--active'] : '',
-          )} style={ { background: `linear-gradient(to right, transparent, ${this.backgroundColor})`} }>
-          </div>
+          )}
+            style={
+              { background: `linear-gradient(to right, transparent, ${this.backgroundColor})` }
+            }
+          ></div>
           <div
             class={this.style['cdr-tabs__underline']}
             style={this.underlineStyle}

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -19,6 +19,10 @@ export default {
       type: Number,
       default: 0,
     },
+    backgroundColor: {
+      type: String,
+      default: CdrColorBackgroundPrimary
+    }
   },
   data() {
     return {
@@ -241,21 +245,19 @@ export default {
         style={{ height: this.height }}
       >
         <div
-          class={clsx(
-            this.overflowLeft ? this.style['cdr-tabs__header-gradient-left'] : '',
-            this.overflowRight ? this.style['cdr-tabs__header-gradient-right'] : '',
-            this.style['cdr-tabs__gradient-container'],
-          )}
+          class={this.style['cdr-tabs__gradient-container']}
           vOn:keyup_right={this.rightArrowNav}
           vOn:keyup_left={this.leftArrowNav}
           vOn:keydown_down_prevent={this.handleDownArrowNav}
         >
+          <div class={clsx(
+            this.style['cdr-tabs__gradient'],
+            this.style['cdr-tabs__gradient--left'],
+            this.overflowLeft ? this.style['cdr-tabs__gradient--active'] : '',
+          )} style={ { background: `linear-gradient(to left, transparent, ${this.backgroundColor})`} }>
+          </div>
           <nav
-            class={clsx(
-              this.overflowLeft ? this.style['cdr-tabs__header-gradient-left'] : '',
-              this.overflowRight ? this.style['cdr-tabs__header-gradient-right'] : '',
-              this.style['cdr-tabs__header-container'],
-            )}
+            class={this.style['cdr-tabs__header-container']}
           >
             <ol
               class={this.style['cdr-tabs__header']}
@@ -280,7 +282,12 @@ export default {
               ))}
             </ol>
           </nav>
-
+          <div class={clsx(
+            this.style['cdr-tabs__gradient'],
+            this.style['cdr-tabs__gradient--right'],
+            this.overflowRight ? this.style['cdr-tabs__gradient--active'] : '',
+          )} style={ { background: `linear-gradient(to right, transparent, ${this.backgroundColor})`} }>
+          </div>
           <div
             class={this.style['cdr-tabs__underline']}
             style={this.underlineStyle}

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -1,5 +1,8 @@
 import debounce from 'lodash-es/debounce';
 import clsx from 'clsx';
+import {
+  CdrColorBackgroundPrimary, CdrSpaceOneX, CdrSpaceHalfX,
+} from '@rei/cdr-tokens/dist/js/cdr-tokens.esm';
 import modifier from '../../mixins/modifier';
 import size from '../../mixins/size';
 import style from './styles/CdrTabs.scss';
@@ -192,7 +195,9 @@ export default {
         headerElements = Array.from(this.$refs.cdrTabsHeader.children);
       }
       let totalWidth = 0;
-      headerElements.forEach((element) => {
+      headerElements.forEach((element, i) => {
+        // account for margin-left on header elements
+        if (i > 0) totalWidth += this.size === 'small' ? Number(CdrSpaceHalfX) : Number(CdrSpaceOneX);
         totalWidth += element.offsetWidth || 0;
       });
       return totalWidth;

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -49,6 +49,18 @@ export default {
         width: `${this.underlineWidth}px`,
       };
     },
+    gradientLeftStyle() {
+      const gradient = `linear-gradient(to left, rgba(255, 255, 255, 0), ${this.backgroundColor})`;
+      return {
+        background: gradient,
+      };
+    },
+    gradientRightStyle() {
+      const gradient = `linear-gradient(to right, rgba(255, 255, 255, 0), ${this.backgroundColor})`;
+      return {
+        background: gradient,
+      };
+    },
   },
   mounted() {
     this.tabs = (this.$slots.default || [])
@@ -257,9 +269,7 @@ export default {
             this.style['cdr-tabs__gradient--left'],
             this.overflowLeft ? this.style['cdr-tabs__gradient--active'] : '',
           )}
-            style={
-              { background: `linear-gradient(to left, transparent, ${this.backgroundColor})` }
-            }
+            style={this.gradientLeftStyle}
           ></div>
           <nav
             class={this.style['cdr-tabs__header-container']}
@@ -292,9 +302,7 @@ export default {
             this.style['cdr-tabs__gradient--right'],
             this.overflowRight ? this.style['cdr-tabs__gradient--active'] : '',
           )}
-            style={
-              { background: `linear-gradient(to right, transparent, ${this.backgroundColor})` }
-            }
+            style={this.gradientRightStyle}
           ></div>
           <div
             class={this.style['cdr-tabs__underline']}

--- a/src/components/tabs/__tests__/CdrTabs.spec.js
+++ b/src/components/tabs/__tests__/CdrTabs.spec.js
@@ -251,7 +251,7 @@ describe('CdrTabs', () => {
       await wrapper.vm.$nextTick();
       wrapper.setData({ overflowLeft: true });
       await wrapper.vm.$nextTick();
-      expect(wrapper.find('.cdr-tabs__header-gradient-left').exists()).toBe(true);
+      expect(wrapper.find('.cdr-tabs__gradient--left.cdr-tabs__gradient--active').exists()).toBe(true);
       wrapper.destroy();
     });
 
@@ -276,7 +276,7 @@ describe('CdrTabs', () => {
       await wrapper.vm.$nextTick();
       wrapper.setData({ overflowRight: true });
       await wrapper.vm.$nextTick();
-      expect(wrapper.find('.cdr-tabs__header-gradient-right').exists()).toBe(true);
+      expect(wrapper.find('.cdr-tabs__gradient--right.cdr-tabs__gradient--active').exists()).toBe(true);
       wrapper.destroy();
     });
   });

--- a/src/components/tabs/__tests__/__snapshots__/CdrTabs.spec.js.snap
+++ b/src/components/tabs/__tests__/__snapshots__/CdrTabs.spec.js.snap
@@ -8,6 +8,9 @@ exports[`CdrTabs mounted mounts tabs 1`] = `
   <div
     class="cdr-tabs__gradient-container"
   >
+    <div
+      class="cdr-tabs__gradient cdr-tabs__gradient--left"
+    />
     <nav
       class="cdr-tabs__header-container"
     >
@@ -16,6 +19,9 @@ exports[`CdrTabs mounted mounts tabs 1`] = `
         role="tablist"
       />
     </nav>
+    <div
+      class="cdr-tabs__gradient cdr-tabs__gradient--right"
+    />
     <div
       class="cdr-tabs__underline"
       style="transform: translateX(0px); width: 0px;"
@@ -35,6 +41,9 @@ exports[`CdrTabs mounted mounts with cdr-tab-panel children 1`] = `
   <div
     class="cdr-tabs__gradient-container"
   >
+    <div
+      class="cdr-tabs__gradient cdr-tabs__gradient--left"
+    />
     <nav
       class="cdr-tabs__header-container"
     >
@@ -75,6 +84,9 @@ exports[`CdrTabs mounted mounts with cdr-tab-panel children 1`] = `
         </li>
       </ol>
     </nav>
+    <div
+      class="cdr-tabs__gradient cdr-tabs__gradient--right"
+    />
     <div
       class="cdr-tabs__underline"
       style="transform: translateX(0px); width: 0px;"

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -9,7 +9,7 @@
       Tabs
     </cdr-text>
 
-    <tabs-default />
+    <tabs-default :backgroundColor="backgroundColor"/>
 
     <!-- small -->
     <div class="tab-demo-secton">
@@ -23,6 +23,7 @@
       <cdr-tabs
         height="100px"
         size="small"
+        :backgroundColor="backgroundColor"
       >
         <cdr-tab-panel
           v-for="tab in tabs.slice(0, 5)"
@@ -52,9 +53,10 @@
       <cdr-tabs
         height="100px"
         modifier="full-width"
+        :backgroundColor="backgroundColor"
       >
         <cdr-tab-panel
-          v-for="tab in tabs.slice(0, 5)"
+          v-for="tab in tabs"
           :key="tab"
           :name="tab"
           :id="'tab-panel-full-width-' + tab"
@@ -81,9 +83,10 @@
       <cdr-tabs
         height="100px"
         modifier="no-border"
+        :backgroundColor="backgroundColor"
       >
         <cdr-tab-panel
-          v-for="tab in tabs.slice(0, 5)"
+          v-for="tab in tabs"
           :key="tab"
           :name="tab"
           :id="'tab-panel-no-border-' + tab"
@@ -110,6 +113,7 @@
       <cdr-tabs
         height="100px"
         modifier="centered"
+        :backgroundColor="backgroundColor"
       >
         <cdr-tab-panel
           v-for="tab in tabs"
@@ -166,8 +170,17 @@
 </template>
 
 <script>
+import {
+  CdrColorBackgroundPrimary,
+  CdrColorBackgroundSecondary,
+  CdrColorBackgroundSuccess,
+  CdrColorBackgroundInfo,
+  CdrColorBackgroundWarning,
+  CdrColorBackgroundError,
+} from '@rei/cdr-tokens';
 import * as Components from 'srcdir/index';
 import tabsDefault from 'componentsdir/tabs/examples/demo/TabsDefault';
+
 
 export default {
   name: 'TabsExample',
@@ -175,8 +188,43 @@ export default {
   data() {
     return {
       tabs: ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight'],
+      backgroundColor: CdrColorBackgroundPrimary,
     };
   },
+  mounted() {
+    this.setBackground(this.$router.currentRoute.query.background);
+  },
+  methods: {
+    setBackground(background) {
+      switch(background) {
+        case 'primary':
+          this.backgroundColor = CdrColorBackgroundPrimary;
+          break;
+        case 'secondary':
+          this.backgroundColor = CdrColorBackgroundSecondary;
+          break;
+        case 'success':
+          this.backgroundColor = CdrColorBackgroundSuccess;
+          break;
+        case 'info':
+          this.backgroundColor = CdrColorBackgroundInfo;
+          break;
+        case 'warning':
+          this.backgroundColor = CdrColorBackgroundWarning;
+          break;
+        case 'error':
+          this.backgroundColor = CdrColorBackgroundError;
+          break;
+        default:
+          this.backgroundColor = CdrColorBackgroundPrimary;
+      }
+    }
+  },
+  watch: {
+    $route(to, from) {
+      this.setBackground(to.query.background)
+    }
+  }
 };
 </script>
 

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -9,7 +9,7 @@
       Tabs
     </cdr-text>
 
-    <tabs-default :backgroundColor="backgroundColor"/>
+    <tabs-default :background-color="backgroundColor" />
 
     <!-- small -->
     <div class="tab-demo-secton">
@@ -23,7 +23,7 @@
       <cdr-tabs
         height="100px"
         size="small"
-        :backgroundColor="backgroundColor"
+        :background-color="backgroundColor"
       >
         <cdr-tab-panel
           v-for="tab in tabs.slice(0, 5)"
@@ -53,7 +53,7 @@
       <cdr-tabs
         height="100px"
         modifier="full-width"
-        :backgroundColor="backgroundColor"
+        :background-color="backgroundColor"
       >
         <cdr-tab-panel
           v-for="tab in tabs"
@@ -83,7 +83,7 @@
       <cdr-tabs
         height="100px"
         modifier="no-border"
-        :backgroundColor="backgroundColor"
+        :background-color="backgroundColor"
       >
         <cdr-tab-panel
           v-for="tab in tabs"
@@ -113,7 +113,7 @@
       <cdr-tabs
         height="100px"
         modifier="centered"
-        :backgroundColor="backgroundColor"
+        :background-color="backgroundColor"
       >
         <cdr-tab-panel
           v-for="tab in tabs"
@@ -191,12 +191,17 @@ export default {
       backgroundColor: CdrColorBackgroundPrimary,
     };
   },
+  watch: {
+    $route(to) {
+      this.setBackground(to.query.background);
+    },
+  },
   mounted() {
     this.setBackground(this.$router.currentRoute.query.background);
   },
   methods: {
     setBackground(background) {
-      switch(background) {
+      switch (background) {
         case 'primary':
           this.backgroundColor = CdrColorBackgroundPrimary;
           break;
@@ -218,13 +223,8 @@ export default {
         default:
           this.backgroundColor = CdrColorBackgroundPrimary;
       }
-    }
+    },
   },
-  watch: {
-    $route(to, from) {
-      this.setBackground(to.query.background)
-    }
-  }
 };
 </script>
 

--- a/src/components/tabs/examples/demo/TabsDefault.vue
+++ b/src/components/tabs/examples/demo/TabsDefault.vue
@@ -4,6 +4,7 @@
     <cdr-tabs
       height="500px"
       data-backstop="tab-default"
+      :background-color="backgroundColor"
     >
       <cdr-tab-panel
         name="Details"
@@ -153,6 +154,12 @@ import * as Components from 'srcdir/index';
 export default {
   name: 'TabsDefault',
   components: { ...Components },
+  props: {
+    backgroundColor: {
+      type: String,
+      default: "#ffffff"
+    }
+  },
   data() {
     return {
       accordion1: false,

--- a/src/components/tabs/examples/demo/TabsDefault.vue
+++ b/src/components/tabs/examples/demo/TabsDefault.vue
@@ -157,8 +157,8 @@ export default {
   props: {
     backgroundColor: {
       type: String,
-      default: "#ffffff"
-    }
+      default: '#ffffff',
+    },
   },
   data() {
     return {

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -61,8 +61,8 @@
       background:
         linear-gradient(
           to left,
-          rgba($cdr-color-background-lightest, 0),
-          $cdr-color-background-lightest
+          rgba($cdr-color-background-primary, 0),
+          $cdr-color-background-primary
         );
       pointer-events: none;
       opacity: 0;
@@ -80,8 +80,8 @@
       background:
         linear-gradient(
           to right,
-          rgba($cdr-color-background-lightest, 0),
-          $cdr-color-background-lightest
+          rgba($cdr-color-background-primary, 0),
+          $cdr-color-background-primary
         );
       pointer-events: none;
       opacity: 0;

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -47,44 +47,29 @@
 
   &__gradient-container {
     position: relative;
+  }
 
-    &::before {
-      transition: opacity 150ms ease;
-      -webkit-transition: opacity 150ms ease;
-      content: '';
-      position: absolute;
-      z-index: 100;
-      top: 0;
-      bottom: 0;
+  &__gradient {
+    transition: opacity $cdr-duration-2-x ease;
+    -webkit-transition: opacity $cdr-duration-2-x ease;
+    position: absolute;
+    z-index: 100;
+    top: 0;
+    bottom: 0;
+    width: $cdr-space-three-x;
+    pointer-events: none;
+    opacity: 0;
+
+    &--left {
       left: 0;
-      width: 36px;
-      background:
-        linear-gradient(
-          to left,
-          rgba($cdr-color-background-primary, 0),
-          $cdr-color-background-primary
-        );
-      pointer-events: none;
-      opacity: 0;
     }
 
-    &::after {
-      transition: opacity 150ms ease;
-      -webkit-transition: opacity 150ms ease;
-      content: '';
-      position: absolute;
-      top: 0;
-      bottom: 0;
+    &--right {
       right: 0;
-      width: 36px;
-      background:
-        linear-gradient(
-          to right,
-          rgba($cdr-color-background-primary, 0),
-          $cdr-color-background-primary
-        );
-      pointer-events: none;
-      opacity: 0;
+    }
+
+    &--active {
+      opacity: 1;
     }
   }
 
@@ -95,14 +80,6 @@
 
     padding: 0;
     position: relative;
-
-    &-gradient-left::before {
-      opacity: 1;
-    }
-
-    &-gradient-right::after {
-      opacity: 1;
-    }
   }
 
   &__header-item {


### PR DESCRIPTION
Some preliminary work to help figure out how to build the scroll gradient component in a re-usable way

- re-maps some deprecated tokens
- updates tabs to use actual elements for gradient rather than before/after (so we can bind the background color to the gradient in the JSX)
- updates tabs to consider margin-left when calculating the width of the header elements
- updates tabs to allow for passing the background-color it is rendered on to ensure the scroll gradients render properly