### PR TITLE
A11y modal fix

### DIFF
--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -265,7 +265,6 @@ export default {
           },
         )}
         ref="wrapper"
-        role="presentation"
       >
         <div class={clsx(this.style['cdr-modal__outerWrap'], wrapperClass)}>
           <div

--- a/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
+++ b/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`CdrModal.vue default open, scrolling 1`] = `
 <div
   class="cdr-modal"
-  role="presentation"
 >
   <div
     class="cdr-modal__outerWrap"
@@ -90,7 +89,6 @@ exports[`CdrModal.vue default open, scrolling 1`] = `
 exports[`CdrModal.vue leaves optional slots empty, handleOpened 1`] = `
 <div
   class="cdr-modal"
-  role="presentation"
 >
   <div
     class="cdr-modal__outerWrap"
@@ -175,7 +173,6 @@ exports[`CdrModal.vue leaves optional slots empty, handleOpened 1`] = `
 exports[`CdrModal.vue scrolling and fullscreen snapshot 1`] = `
 <div
   class="cdr-modal"
-  role="presentation"
 >
   <div
     class="cdr-modal__outerWrap"


### PR DESCRIPTION
- removes role='presentation' from modal (https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html)
- changes role='presentation' to role='img' for icon (https://www.deque.com/blog/creating-accessible-svgs/)