### PR TITLE
Link button

### DIFF
--- a/src/components/link/CdrLink.jsx
+++ b/src/components/link/CdrLink.jsx
@@ -10,6 +10,10 @@ export default {
     space,
   ],
   props: {
+    inset: {
+      type: Boolean,
+      default: false,
+    },
     tag: {
       type: String,
       default: 'a',
@@ -45,6 +49,9 @@ export default {
     inheritColorClass() {
       return this.inheritColor ? this.style['cdr-link--inherit-color'] : '';
     },
+    insetClass() {
+      return this.tag === 'button' && this.inset ? this.style['cdr-link--inset'] : '';
+    },
   },
   render() {
     const Component = this.tag;
@@ -52,6 +59,7 @@ export default {
       class={clsx(
         this.style[this.baseClass],
         this.modifierClass,
+        this.insetClass,
         this.space,
         this.inheritColorClass,
       )}

--- a/src/components/link/CdrLink.jsx
+++ b/src/components/link/CdrLink.jsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import modifier from '../../mixins/modifier';
 import space from '../../mixins/space';
+import size from '../../mixins/size';
 import style from './styles/CdrLink.scss';
 
 export default {
@@ -8,6 +9,7 @@ export default {
   mixins: [
     modifier,
     space,
+    size,
   ],
   props: {
     inset: {
@@ -50,7 +52,10 @@ export default {
       return this.inheritColor ? this.style['cdr-link--inherit-color'] : '';
     },
     insetClass() {
-      return this.tag === 'button' && this.inset ? this.style['cdr-link--inset'] : '';
+      return this.size && this.inset ? this.style['cdr-link--inset'] : '';
+    },
+    insetSizeClass() {
+      return this.size && this.inset ? this.sizeClass : '';
     },
   },
   render() {
@@ -60,6 +65,7 @@ export default {
         this.style[this.baseClass],
         this.modifierClass,
         this.insetClass,
+        this.insetSizeClass,
         this.space,
         this.inheritColorClass,
       )}

--- a/src/components/link/__tests__/CdrLink.spec.js
+++ b/src/components/link/__tests__/CdrLink.spec.js
@@ -85,4 +85,37 @@ describe('CdrLink', () => {
     wrapper.trigger('click');
     expect(spy.called).toBeTruthy();
   });
+
+  it('renders inset with default medium size', () => {
+    const wrapper = shallowMount(CdrLink, {
+      propsData: {
+        inset: true,
+      },
+    });
+    expect(wrapper.classes()).toContain('cdr-link--inset');
+    expect(wrapper.classes()).toContain('cdr-link--medium');
+  });
+
+  it('renders inset with size prop passed', () => {
+    const wrapper = shallowMount(CdrLink, {
+      propsData: {
+        inset: true,
+        size: 'large'
+      },
+    });
+    expect(wrapper.classes()).toContain('cdr-link--inset');
+    expect(wrapper.classes()).toContain('cdr-link--large');
+  });
+
+
+  it('does not add size class if inset is not present', () => {
+    const wrapper = shallowMount(CdrLink, {
+      propsData: {
+        inset: false,
+        size: 'large'
+      },
+    });
+    expect(wrapper.classes()).not.toContain('cdr-link--inset');
+    expect(wrapper.classes()).not.toContain('cdr-link--large');
+  });
 });

--- a/src/components/link/examples/demo/Resilience.vue
+++ b/src/components/link/examples/demo/Resilience.vue
@@ -51,11 +51,23 @@
     <cdr-text
       tag="h3"
       modifier="subheading"
-    >Link using a &lt;button&gt; element</cdr-text>
+    >Link using a &lt;button&gt; element inline</cdr-text>
+    <div class="anchor-example">
+      hey there <cdr-link
+        tag="button"
+        data-backstop="cdr-link--button"
+        @click="clicked"
+      >I'm a button!</cdr-link> wow!
+    </div>
+
+    <cdr-text
+      tag="h3"
+      modifier="subheading"
+    >Link using a &lt;button&gt; element and inset prop</cdr-text>
     <div class="anchor-example">
       <cdr-link
         tag="button"
-        space="cdr-space-inset-one-x"
+        :inset="true"
         data-backstop="cdr-link--button"
         @click="clicked"
       >I'm a button!</cdr-link>

--- a/src/components/link/examples/demo/Resilience.vue
+++ b/src/components/link/examples/demo/Resilience.vue
@@ -49,32 +49,6 @@
     </div>
 
     <cdr-text
-      tag="h3"
-      modifier="subheading"
-    >Link using a &lt;button&gt; element inline</cdr-text>
-    <div class="anchor-example">
-      hey there <cdr-link
-        tag="button"
-        data-backstop="cdr-link--button"
-        @click="clicked"
-      >I'm a button!</cdr-link> wow!
-    </div>
-
-    <cdr-text
-      tag="h3"
-      modifier="subheading"
-    >Link using a &lt;button&gt; element and inset prop</cdr-text>
-    <div class="anchor-example">
-      <cdr-link
-        tag="button"
-        :inset="true"
-        data-backstop="cdr-link--button"
-        @click="clicked"
-      >I'm a button!</cdr-link>
-    </div>
-
-
-    <cdr-text
       tag="h4"
       modifier="heading-serif-500 heading-serif-600@md heading-serif-600@lg"
     >

--- a/src/components/link/examples/demo/Standard.vue
+++ b/src/components/link/examples/demo/Standard.vue
@@ -48,7 +48,7 @@
     </cdr-link>
     <cdr-text
       tag="h3"
-      modifier="subheading"
+      modifier="subheading-sans-300"
     >Standalone Link (No underline)</cdr-text>
     <cdr-link
       modifier="standalone"
@@ -131,8 +131,128 @@
         cdr-link icon inherit
       </cdr-link>
     </div>
+    <br><br>
+    <cdr-text
+      tag="h3"
+      modifier="subheading-sans-500"
+    >Button Links</cdr-text>
 
+    <cdr-text
+      tag="h4"
+      modifier="subheading-sans-300"
+    >Link using a &lt;button&gt; element inline</cdr-text>
+    <div class="anchor-example cdr-py-space-one-x">
+      hey there <cdr-link
+        tag="button"
+        data-backstop="cdr-link--button"
+        @click="clicked"
+      >I'm a button!</cdr-link> wow!
+    </div>
 
+    <cdr-text
+      tag="h4"
+      modifier="subheading-sans-300"
+    >Link using a &lt;button&gt; element and size prop</cdr-text>
+    <div class="anchor-example">
+
+      <cdr-link
+        tag="button"
+        size="large@xs medium@sm small@md large@lg"
+        :inset="true"
+        @click="clicked"
+      >I'm a responsive button!</cdr-link>
+      <br>
+      <cdr-link
+        tag="button"
+        size="small"
+        :inset="true"
+        @click="clicked"
+      >I'm a small button!</cdr-link>
+
+      <cdr-link
+        tag="button"
+        size="medium"
+        :inset="true"
+        @click="clicked"
+      >I'm a medium button!</cdr-link>
+
+      <cdr-link
+        tag="button"
+        size="large"
+        :inset="true"
+        @click="clicked"
+      >I'm a large button!</cdr-link>
+    </div>
+
+    <cdr-text
+      tag="h4"
+      modifier="subheading-sans-300"
+    >Link using a &lt;button&gt; element and size prop with left/right padding removed</cdr-text>
+    <div class="anchor-example">
+
+      <cdr-link
+        tag="button"
+        size="large@xs medium@sm small@md large@lg"
+        :inset="true"
+        class="button-padding-override"
+        @click="clicked"
+      >I'm a responsive button!</cdr-link>
+      <br>
+      <cdr-link
+        tag="button"
+        size="small"
+        :inset="true"
+        class="button-padding-override"
+        @click="clicked"
+      >I'm a small button!</cdr-link>
+      <br>
+      <cdr-link
+        tag="button"
+        size="medium"
+        :inset="true"
+        class="button-padding-override"
+        @click="clicked"
+      >I'm a medium button!</cdr-link>
+      <br>
+      <cdr-link
+        tag="button"
+        size="large"
+        :inset="true"
+        class="button-padding-override"
+        @click="clicked"
+      >I'm a large button!</cdr-link>
+    </div>
+
+    <cdr-text
+      tag="h4"
+      modifier="subheading-sans-300"
+    >Link using a &lt;button&gt; element and size prop w/ buttons</cdr-text>
+    <div class="anchor-example">
+
+      <cdr-link
+        tag="button"
+        size="small"
+        :inset="true"
+        @click="clicked"
+      >I'm a small button!</cdr-link>
+      <cdr-button size="small">I'm a small button!</cdr-button>
+
+      <cdr-link
+        tag="button"
+        size="medium"
+        :inset="true"
+        @click="clicked"
+      >I'm a medium button!</cdr-link>
+      <cdr-button size="medium">I'm a medium button!</cdr-button>
+
+      <cdr-link
+        tag="button"
+        size="large"
+        :inset="true"
+        @click="clicked"
+      >I'm a large button!</cdr-link>
+      <cdr-button size="large">I'm a large button!</cdr-button>
+    </div>
   </div>
 </template>
 
@@ -158,6 +278,11 @@ export default {
 
 .link-examples {
   line-height: 1;
+}
+
+.button-padding-override {
+  padding-left: 0;
+  padding-right: 0;
 }
 
 </style>

--- a/src/components/link/styles/CdrLink.scss
+++ b/src/components/link/styles/CdrLink.scss
@@ -15,13 +15,6 @@
   @include cdr-link-base-mixin;
 }
 
-/* Style variants
-  ========================================================================== */
-
-.cdr-link--inset {
-  @include cdr-link-inset-mixin;
-}
-
 /* Standalone
     ========== */
 .cdr-link--standalone {
@@ -30,4 +23,94 @@
 
 .cdr-link--inherit-color {
   @include cdr-link-inherit-color-mixin;
+}
+
+
+/* Inset/Sizing
+  ========================================================================== */
+.cdr-link--inset {
+  @include cdr-link-inset-base-text-mixin;
+}
+
+.cdr-link--small {
+  @include cdr-link-inset-small-mixin;
+}
+
+.cdr-link--medium {
+  @include cdr-link-inset-medium-mixin;
+}
+
+.cdr-link--large {
+  @include cdr-link-inset-large-mixin;
+}
+
+/* Breakpoint variants
+
+/* @xs
+  0px - 767px
+  ========== */
+@include cdr-xs-mq-only {
+  .cdr-link--small\@xs {
+    @include cdr-link-inset-small-mixin;
+  }
+
+  .cdr-link--medium\@xs {
+    @include cdr-link-inset-medium-mixin;
+  }
+
+  .cdr-link--large\@xs {
+    @include cdr-link-inset-large-mixin;
+  }
+}
+
+/* @sm
+  768px - 991px
+  ========== */
+@include cdr-sm-mq-only {
+  .cdr-link--small\@sm {
+    @include cdr-link-inset-small-mixin;
+  }
+
+  .cdr-link--medium\@sm {
+    @include cdr-link-inset-medium-mixin;
+  }
+
+  .cdr-link--large\@sm {
+    @include cdr-link-inset-large-mixin;
+  }
+}
+
+/* @md
+  992px - 1199px
+  ========== */
+@include cdr-md-mq-only {
+  .cdr-link--small\@md {
+    @include cdr-link-inset-small-mixin;
+  }
+
+  .cdr-link--medium\@md {
+    @include cdr-link-inset-medium-mixin;
+  }
+
+  .cdr-link--large\@md {
+    @include cdr-link-inset-large-mixin;
+  }
+}
+
+/* @lg
+  1200px and up
+  ========== */
+
+@include cdr-lg-mq-only {
+  .cdr-link--small\@lg {
+    @include cdr-link-inset-small-mixin;
+  }
+
+  .cdr-link--medium\@lg {
+    @include cdr-link-inset-medium-mixin;
+  }
+
+  .cdr-link--large\@lg {
+    @include cdr-link-inset-large-mixin;
+  }
 }

--- a/src/components/link/styles/CdrLink.scss
+++ b/src/components/link/styles/CdrLink.scss
@@ -18,6 +18,10 @@
 /* Style variants
   ========================================================================== */
 
+.cdr-link--inset {
+  @include cdr-link-inset-mixin;
+}
+
 /* Standalone
     ========== */
 .cdr-link--standalone {

--- a/src/components/link/styles/CdrLink.scss
+++ b/src/components/link/styles/CdrLink.scss
@@ -25,13 +25,5 @@
 }
 
 .cdr-link--inherit-color {
-  fill: inherit;
-  color: inherit;
-
-  &:active,
-  &:hover,
-  &:focus {
-    color: inherit;
-    fill: inherit;
-  }
+  @include cdr-link-inherit-color-mixin;
 }

--- a/src/components/link/styles/vars/CdrLink.vars.scss
+++ b/src/components/link/styles/vars/CdrLink.vars.scss
@@ -36,6 +36,18 @@
 
 }
 
+@mixin cdr-link-inherit-color-mixin() {
+  fill: inherit;
+  color: inherit;
+
+  &:active,
+  &:hover,
+  &:focus {
+    color: inherit;
+    fill: inherit;
+  }
+}
+
 @mixin cdr-link-standalone-mixin() {
   text-decoration: none;
 

--- a/src/components/link/styles/vars/CdrLink.vars.scss
+++ b/src/components/link/styles/vars/CdrLink.vars.scss
@@ -36,6 +36,10 @@
 
 }
 
+@mixin cdr-link-inset-mixin() {
+  padding: $cdr-space-inset-one-x-squish;
+}
+
 @mixin cdr-link-inherit-color-mixin() {
   fill: inherit;
   color: inherit;

--- a/src/components/link/styles/vars/CdrLink.vars.scss
+++ b/src/components/link/styles/vars/CdrLink.vars.scss
@@ -36,10 +36,6 @@
 
 }
 
-@mixin cdr-link-inset-mixin() {
-  padding: $cdr-space-inset-one-x-squish;
-}
-
 @mixin cdr-link-inherit-color-mixin() {
   fill: inherit;
   color: inherit;
@@ -61,4 +57,31 @@
   &:visited {
     text-decoration: underline;
   }
+}
+
+@mixin cdr-link-inset-small-mixin() {
+  padding: $cdr-space-inset-three-quarter-x-squish;
+  font-size: 14px;
+  line-height: 18px;
+}
+
+@mixin cdr-link-inset-medium-mixin() {
+  padding: $cdr-space-inset-one-x-squish;
+  font-size: 16px;
+  line-height: 22px;
+}
+
+@mixin cdr-link-inset-large-mixin() {
+  padding: $cdr-space-inset-one-and-a-half-x-squish;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+@mixin cdr-link-inset-base-text-mixin() {
+  font-family: $cdr-font-family-sans;
+  font-style: normal;
+  font-weight: 500;
+  letter-spacing: -.08px;
+  vertical-align: middle;
+  display: inline-flex;
 }


### PR DESCRIPTION
- Added `inset` and `size` props to link. Using `inset` by itself uses default medium size.
- Added responsive size options for button links. Sizing only triggers if `inset="true"` is also passed.
- Added button text styling to inset/size links