### PR TITLE
feat(popover): initial popover imported from fedpack

### DIFF
--- a/src/components/examples.js
+++ b/src/components/examples.js
@@ -24,6 +24,7 @@ import select from 'componentsdir/select/examples/Selects';
 import table from 'componentsdir/table/examples/Table';
 import tabs from 'componentsdir/tabs/examples/Tabs';
 import text from 'componentsdir/text/examples/Text';
+import tooltip from 'componentsdir/tooltip/examples/Tooltip';
 import utilities from 'componentsdir/Utilities/Utilities';
 
 export default {
@@ -53,5 +54,6 @@ export default {
   table,
   tabs,
   text,
+  tooltip,
   utilities,
 };

--- a/src/components/examples.js
+++ b/src/components/examples.js
@@ -16,6 +16,7 @@ import link from 'componentsdir/link/examples/Links';
 import list from 'componentsdir/list/examples/Lists';
 import modal from 'componentsdir/modal/examples/Modal';
 import pagination from 'componentsdir/pagination/examples/Pagination';
+import popover from 'componentsdir/popover/examples/Popover';
 import quote from 'componentsdir/quote/examples/Quote';
 import radio from 'componentsdir/radio/examples/Radios';
 import rating from 'componentsdir/rating/examples/Ratings';
@@ -44,6 +45,7 @@ export default {
   list,
   modal,
   pagination,
+  popover,
   quote,
   radio,
   rating,

--- a/src/components/popover/CdrPopover.backstop.js
+++ b/src/components/popover/CdrPopover.backstop.js
@@ -1,0 +1,5 @@
+module.exports = [{
+  url: 'http://localhost:3000/#/popover',
+  label: 'Popover',
+  responsive: true,
+}];

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -50,7 +50,7 @@ export default {
   },
   computed: {
     positionClass() {
-      return this.style[`cdr-popover__${this.pos}`];
+      return this.style[`cdr-popover__wrapper--${this.pos}`];
     },
     cornerClass() {
       if (this.corner) return this.style[`cdr-popover__corner--${this.corner}`];
@@ -157,7 +157,12 @@ export default {
   },
   render() {
     return this.opened ? (
-      <div class={clsx(this.positionClass, this.cornerClass, this.triggerClass)}>
+      <div class={clsx(
+        this.style['cdr-popover__wrapper'],
+        this.positionClass,
+        this.cornerClass,
+        this.triggerClass)}
+      >
         <div
           class={this.style['cdr-popover']}
           role="dialog"

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -166,6 +166,7 @@ export default {
           class={this.style['cdr-popover']}
           role="dialog"
           ref="popover"
+          {... { attrs: this.$attrs } }
         >
           <div class={this.style['cdr-popover__container']}>
             <div class={this.style['cdr-popover__content']}>

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx';
+import style from './styles/CdrPopover.scss';
+import propValidator from '../../utils/propValidator';
+
+export default {
+  name: 'CdrPopover',
+  props: {
+    open: {
+      type: Boolean,
+      default: false,
+    },
+    arrowDirection: {
+      type: String,
+      required: false,
+      default: 'up',
+      validator: (value) => propValidator(
+        value,
+        ['up', 'down', 'left', 'right'],
+      ),
+    },
+  },
+  data() {
+    return {
+      style,
+    };
+  },
+  computed: {
+    arrowDirectionClass() {
+      return this.arrowDirection ? this.style[`cdr-popover__arrow--${this.arrowDirection}`] : '';
+    },
+  },
+  render() {
+    return this.open ? (
+      <div
+        class={clsx(this.style['cdr-popover'], this.arrowDirectionClass)}
+        role="dialog"
+      >
+        {this.$slots.default}
+      </div>
+    ) : undefined;
+  }
+};

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import tabbable from 'tabbable';
 import style from './styles/CdrPopover.scss';
 import propValidator from '../../utils/propValidator';
 import IconXSm from  '../icon/comps/x-sm';
@@ -74,6 +75,9 @@ export default {
       this.lastActive = activeElement;
       setTimeout(() => {
         this.addHandlers();
+
+        const tabbables = tabbable(this.$refs.popover);
+        if (tabbables[0]) tabbables[0].focus();
       }, 1);
     },
     handleClosed() {

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -1,6 +1,9 @@
 import clsx from 'clsx';
 import style from './styles/CdrPopover.scss';
 import propValidator from '../../utils/propValidator';
+import IconXSm from  '../icon/comps/x-sm';
+import CdrText from '../text/CdrText';
+import CdrButton from '../button/CdrButton';
 
 export default {
   name: 'CdrPopover',
@@ -18,6 +21,15 @@ export default {
         ['up', 'down', 'left', 'right'],
       ),
     },
+    title: {
+      type: String,
+      default: ''
+    }
+  },
+  components: {
+    IconXSm,
+    CdrText,
+    CdrButton,
   },
   data() {
     return {
@@ -29,12 +41,59 @@ export default {
       return this.arrowDirection ? this.style[`cdr-popover__arrow--${this.arrowDirection}`] : '';
     },
   },
+  methods: {
+    closePopover(e) {
+      this.$emit('closed', e);
+    },
+    handleKeyDown({ key }) {
+      switch (key) {
+        case 'Escape':
+        case 'Esc':
+          this.closePopover();
+          break;
+        default: break;
+      }
+    },
+  },
+  // TODO: add watcher for opened, focus the popover?
+  // TODO: esc key closes popover (emits closed? i guess?)
   render() {
+    // TODO: make props/events match whatever modal does?
+    // TODO: what should title tag be????
     return this.open ? (
       <div
         class={clsx(this.style['cdr-popover'], this.arrowDirectionClass)}
         role="dialog"
       >
+        <div class={this.style['cdr-popover__header']}>
+          <div class={this.style['cdr-popover__title']}>
+            {
+              this.$slots.title
+            }
+            {
+              !this.$slots.title && (
+                <cdr-text
+                  tag="h1"
+                  modifier="heading-serif-400"
+                >
+                  {this.title}
+                </cdr-text>
+              )
+            }
+          </div>
+          <cdr-button
+            class={this.style['cdr-popover__close-button']}
+            icon-only
+            on-click={this.closePopover}
+            aria-label="Close"
+            size="small"
+          >
+            <icon-x-sm
+              slot="icon"
+              inherit-color
+            />
+          </cdr-button>
+        </div>
         {this.$slots.default}
       </div>
     ) : undefined;

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -2,14 +2,17 @@ import clsx from 'clsx';
 import tabbable from 'tabbable';
 import style from './styles/CdrPopover.scss';
 import propValidator from '../../utils/propValidator';
-import IconXSm from  '../icon/comps/x-sm';
-import CdrText from '../text/CdrText';
+import IconXSm from '../icon/comps/x-sm';
 import CdrButton from '../button/CdrButton';
 
 export default {
   name: 'CdrPopover',
+  components: {
+    IconXSm,
+    CdrButton,
+  },
   props: {
-    open: {
+    opened: {
       type: Boolean,
       default: false,
     },
@@ -22,15 +25,10 @@ export default {
         ['up', 'down', 'left', 'right'],
       ),
     },
-    title: {
+    label: {
       type: String,
-      default: ''
-    }
-  },
-  components: {
-    IconXSm,
-    CdrText,
-    CdrButton,
+      default: '',
+    },
   },
   data() {
     return {
@@ -43,6 +41,16 @@ export default {
   computed: {
     arrowDirectionClass() {
       return this.arrowDirection ? this.style[`cdr-popover__arrow--${this.arrowDirection}`] : '';
+    },
+  },
+  watch: {
+    opened(newValue, oldValue) {
+      if (!!newValue === !!oldValue) return;
+      if (newValue) {
+        this.handleOpened();
+      } else {
+        this.handleClosed();
+      }
     },
   },
   methods: {
@@ -86,20 +94,8 @@ export default {
       if (this.lastActive) this.lastActive.focus();
     },
   },
-  watch: {
-    open(newValue, oldValue) {
-      if (!!newValue === !!oldValue) return;
-      if (newValue) {
-        this.handleOpened();
-      } else {
-        this.handleClosed();
-      }
-    }
-  },
   render() {
-    // TODO: make props/events match whatever modal does?
-    // TODO: what h level should title tag be???? should it have one?
-    return this.open ? (
+    return this.opened ? (
       <div
         class={clsx(this.style['cdr-popover'], this.arrowDirectionClass)}
         role="dialog"
@@ -112,12 +108,9 @@ export default {
             }
             {
               !this.$slots.title && (
-                <cdr-text
-                  tag="h1"
-                  modifier="heading-serif-400"
-                >
-                  {this.title}
-                </cdr-text>
+                <span>
+                  {this.label}
+                </span>
               )
             }
           </div>
@@ -137,5 +130,5 @@ export default {
         {this.$slots.default}
       </div>
     ) : undefined;
-  }
+  },
 };

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -5,18 +5,6 @@ import propValidator from '../../utils/propValidator';
 import IconXSm from '../icon/comps/x-sm';
 import CdrButton from '../button/CdrButton';
 
-// for corner cases, im centering the arrow and aligning the popup to the container edge.
-// - Can offset pretty easily if desired
-
-// do we need to handle hovering over an opened tooltip? c1 popover doesn't do that http://patterns.rei.com/modules/tool-tips/
-
-// CSS arrows don't get box-shadow
-// - could theoretically drop in a double arrow SVG instead of the CSS arrows
-
-// need to create a token or value for "tooltip" background,
-// - currently using cta/button-dark for background, text-inverse for color
-
-// binding a tooltip is funky. vue directive?
 
 export default {
   name: 'CdrPopover',
@@ -177,7 +165,7 @@ export default {
       >
         <div
           class={this.style['cdr-popover']}
-          role="dialog"
+          role={this.trigger === 'tooltip' ? 'tooltip' : 'dialog'}
           ref="popover"
           {... { attrs: this.$attrs } }
         >

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -101,18 +101,28 @@ export default {
         role="dialog"
         ref="popover"
       >
-        <div class={this.style['cdr-popover__header']}>
-          <div class={this.style['cdr-popover__title']}>
+        <div class={this.style['cdr-popover__container']}>
+          <div class={this.style['cdr-popover__content']}>
             {
-              this.$slots.title
-            }
-            {
-              !this.$slots.title && (
-                <span>
-                  {this.label}
-                </span>
+              (this.$slots.title || this.label) && (
+                <div class={this.style['cdr-popover__title']}>
+                  {
+                    this.$slots.title
+                  }
+                  {
+                    !this.$slots.title && this.label && (
+                      <span>
+                        {this.label}
+                      </span>
+                    )
+                  }
+                </div>
               )
             }
+
+            <div class={this.style['cdr-popover__slot']}>
+              {this.$slots.default}
+            </div>
           </div>
           <cdr-button
             class={this.style['cdr-popover__close-button']}
@@ -127,7 +137,6 @@ export default {
             />
           </cdr-button>
         </div>
-        {this.$slots.default}
       </div>
     ) : undefined;
   },

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -54,6 +54,9 @@ export default {
     },
     cornerClass() {
       if (this.corner) return this.style[`cdr-popover__corner--${this.corner}`];
+    },
+    triggerClass() {
+      return this.style[`cdr-popover--${this.trigger}`]
     }
   },
   watch: {
@@ -154,7 +157,7 @@ export default {
   },
   render() {
     return this.opened ? (
-      <div class={clsx(this.positionClass, this.cornerClass)}>
+      <div class={clsx(this.positionClass, this.cornerClass, this.triggerClass)}>
         <div
           class={this.style['cdr-popover']}
           role="dialog"

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -89,42 +89,37 @@ export default {
       document.addEventListener('click', this.clickHandler);
     },
     calculatePlacement() {
-      // Reset pos so size/position is calculated correctly
       this.pos = this.position;
+      this.corner = undefined;
+      this.$nextTick(() => {
+        const rect = this.$refs.popover.getBoundingClientRect();
+        if (this.pos === 'down' && rect.bottom >= window.innerHeight) {
+          this.pos = 'up';
+        } else if (this.pos === 'up' && rect.top <= 0) {
+          this.pos = 'down';
+        } else if (this.pos === 'left' && rect.left <= 0) {
+          this.pos = 'right';
+        } else if (this.pos === 'right' && rect.right >= window.innerWidth) {
+          this.pos = 'left';
+        }
 
-      const rect = this.$el.getBoundingClientRect()
-      if (this.pos === 'down' && rect.bottom >= window.innerHeight) {
-        this.pos = 'up';
-      } else if (this.pos === 'up' && rect.top <= 0) {
-        this.pos = 'down';
-      } else if (this.pos === 'left' && rect.left <= 0) {
-        this.pos = 'right';
-      } else if (this.pos === 'right' && rect.right >= window.innerWidth) {
-        this.pos = 'left';
-      }
+        const orientation = this.pos === 'down' || this.pos === 'up' ? 'vertical' : 'horizontal';
 
-      const orientation = this.pos === 'down' || this.pos === 'up' ? 'vertical' : 'horizontal';
-
-      if (orientation === 'vertical' && rect.left <= 0) {
-        this.corner = 'left'
-        console.log('left corner')
-      } else if (orientation === 'vertical' && rect.right >= window.innerWidth) {
-        this.corner = 'right'
-        console.log('right corner')
-      } else if (orientation === 'horizontal' && rect.top <= 0) {
-        this.corner = 'top'
-        console.log('top corner')
-      } else if (orientation === 'horizontal' && rect.bottom >= window.innerHeight) {
-        this.corner = 'bottom'
-        console.log('bottom corner')
-      }
-
+        if (orientation === 'vertical' && rect.left <= 0) {
+          this.corner = 'left'
+        } else if (orientation === 'vertical' && rect.right >= window.innerWidth) {
+          this.corner = 'right'
+        } else if (orientation === 'horizontal' && rect.top <= 0) {
+          this.corner = 'top'
+        } else if (orientation === 'horizontal' && rect.bottom >= window.innerHeight) {
+          this.corner = 'bottom'
+        }
+      })
     },
     handleOpened() {
       const { activeElement } = document;
 
       this.lastActive = activeElement;
-      // need setTimeout, otherwise the initial click on the trigger element gets handled by the clickHandler?!?!?!?
       this.$nextTick(() => {
         if (this.autoPosition) {
           this.calculatePlacement();
@@ -147,47 +142,50 @@ export default {
   },
   render() {
     return this.opened ? (
-      <div
-        class={clsx(this.style['cdr-popover'], this.positionClass, this.cornerClass)}
-        role="dialog"
-        ref="popover"
-      >
-        <div class={this.style['cdr-popover__container']}>
-          <div class={this.style['cdr-popover__content']}>
-            {
-              (this.$slots.title || this.label) && (
-                <div class={this.style['cdr-popover__title']}>
-                  {
-                    this.$slots.title
-                  }
-                  {
-                    !this.$slots.title && this.label && (
-                      <span>
-                        {this.label}
-                      </span>
-                    )
-                  }
-                </div>
-              )
-            }
+      <div class={clsx(this.positionClass, this.cornerClass)}>
+        <div
+          class={this.style['cdr-popover']}
+          role="dialog"
+          ref="popover"
+        >
+          <div class={this.style['cdr-popover__container']}>
+            <div class={this.style['cdr-popover__content']}>
+              {
+                (this.$slots.title || this.label) && (
+                  <div class={this.style['cdr-popover__title']}>
+                    {
+                      this.$slots.title
+                    }
+                    {
+                      !this.$slots.title && this.label && (
+                        <span>
+                          {this.label}
+                        </span>
+                      )
+                    }
+                  </div>
+                )
+              }
 
-            <div class={this.style['cdr-popover__slot']}>
-              {this.$slots.default}
+              <div class={this.style['cdr-popover__slot']}>
+                {this.$slots.default}
+              </div>
             </div>
+            <cdr-button
+              class={this.style['cdr-popover__close-button']}
+              icon-only
+              on-click={this.closePopover}
+              aria-label="Close"
+              size="small"
+            >
+              <icon-x-sm
+                slot="icon"
+                inherit-color
+              />
+            </cdr-button>
           </div>
-          <cdr-button
-            class={this.style['cdr-popover__close-button']}
-            icon-only
-            on-click={this.closePopover}
-            aria-label="Close"
-            size="small"
-          >
-            <icon-x-sm
-              slot="icon"
-              inherit-color
-            />
-          </cdr-button>
         </div>
+        <div class={this.style['cdr-popover__arrow']}/>
       </div>
     ) : undefined;
   },

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -34,6 +34,8 @@ export default {
   data() {
     return {
       style,
+      lastActive: undefined,
+      keyHandler: undefined,
     };
   },
   computed: {
@@ -54,16 +56,43 @@ export default {
         default: break;
       }
     },
+    addHandlers() {
+      this.keyHandler = this.handleKeyDown.bind(this);
+      document.addEventListener('keydown', this.keyHandler);
+    },
+    handleOpened() {
+      const { activeElement } = document;
+
+      this.lastActive = activeElement;
+      this.$nextTick(() => {
+        if (this.$refs.popover) this.$refs.popover.focus(); // wrapped in if so testing error isn't thrown
+        this.addHandlers();
+      });
+    },
+    handleClosed() {
+      document.removeEventListener('keydown', this.keyHandler);
+      if (this.lastActive) this.lastActive.focus();
+    },
   },
-  // TODO: add watcher for opened, focus the popover?
-  // TODO: esc key closes popover (emits closed? i guess?)
+  watch: {
+    open(newValue, oldValue) {
+      if (!!newValue === !!oldValue) return;
+      if (newValue) {
+        this.handleOpened();
+      } else {
+        this.handleClosed();
+      }
+    }
+  },
   render() {
     // TODO: make props/events match whatever modal does?
-    // TODO: what should title tag be????
+    // TODO: what h level should title tag be???? should it have one?
     return this.open ? (
       <div
         class={clsx(this.style['cdr-popover'], this.arrowDirectionClass)}
         role="dialog"
+        ref="popover"
+        tabIndex="0"
       >
         <div class={this.style['cdr-popover__header']}>
           <div class={this.style['cdr-popover__title']}>

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -99,42 +99,41 @@ export default {
       document.addEventListener('click', this.clickHandler);
     },
     calculatePlacement() {
-      this.pos = this.position;
-      this.corner = undefined;
-      this.$nextTick(() => {
-        const rect = this.$refs.popover.getBoundingClientRect();
-        if (this.pos === 'down' && rect.bottom >= window.innerHeight) {
-          this.pos = 'up';
-        } else if (this.pos === 'up' && rect.top <= 0) {
-          this.pos = 'down';
-        } else if (this.pos === 'left' && rect.left <= 0) {
-          this.pos = 'right';
-        } else if (this.pos === 'right' && rect.right >= window.innerWidth) {
-          this.pos = 'left';
-        }
+      const rect = this.$refs.popover.getBoundingClientRect();
+      if (this.pos === 'down' && rect.bottom >= window.innerHeight) {
+        this.pos = 'up';
+      } else if (this.pos === 'up' && rect.top <= 0) {
+        this.pos = 'down';
+      } else if (this.pos === 'left' && rect.left <= 0) {
+        this.pos = 'right';
+      } else if (this.pos === 'right' && rect.right >= window.innerWidth) {
+        this.pos = 'left';
+      }
 
-        const orientation = this.pos === 'down' || this.pos === 'up' ? 'vertical' : 'horizontal';
+      const orientation = this.pos === 'down' || this.pos === 'up' ? 'vertical' : 'horizontal';
 
-        if (orientation === 'vertical' && rect.left <= 0) {
-          this.corner = 'left'
-        } else if (orientation === 'vertical' && rect.right >= window.innerWidth) {
-          this.corner = 'right'
-        } else if (orientation === 'horizontal' && rect.top <= 0) {
-          this.corner = 'top'
-        } else if (orientation === 'horizontal' && rect.bottom >= window.innerHeight) {
-          this.corner = 'bottom'
-        }
-      })
+      if (orientation === 'vertical' && rect.left <= 0) {
+        this.corner = 'left'
+      } else if (orientation === 'vertical' && rect.right >= window.innerWidth) {
+        this.corner = 'right'
+      } else if (orientation === 'horizontal' && rect.top <= 0) {
+        this.corner = 'top'
+      } else if (orientation === 'horizontal' && rect.bottom >= window.innerHeight) {
+        this.corner = 'bottom'
+      }
     },
     handleOpened() {
       const { activeElement } = document;
 
       this.lastActive = activeElement;
-      this.$nextTick(() => {
-        if (this.autoPosition) {
+
+      this.pos = this.position;
+      this.corner = undefined;
+      if (this.autoPosition) {
+        this.$nextTick(() => {
           this.calculatePlacement();
-        }
-      })
+        });
+      }
 
       setTimeout(() => {
         this.addHandlers();

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -5,6 +5,19 @@ import propValidator from '../../utils/propValidator';
 import IconXSm from '../icon/comps/x-sm';
 import CdrButton from '../button/CdrButton';
 
+// for corner cases, im centering the arrow and aligning the popup to the container edge.
+// - Can offset pretty easily if desired
+
+// do we need to handle hovering over an opened tooltip? c1 popover doesn't do that http://patterns.rei.com/modules/tool-tips/
+
+// CSS arrows don't get box-shadow
+// - could theoretically drop in a double arrow SVG instead of the CSS arrows
+
+// need to create a token or value for "tooltip" background,
+// - currently using cta/button-dark for background, text-inverse for color
+
+// binding a tooltip is funky. vue directive?
+
 export default {
   name: 'CdrPopover',
   components: {
@@ -35,7 +48,7 @@ export default {
     // TODO: fix spacing/layout if tooltip
     trigger: {
       type: String,
-      default: 'popover'
+      default: 'popover',
     },
   },
   data() {
@@ -53,11 +66,11 @@ export default {
       return this.style[`cdr-popover__wrapper--${this.pos}`];
     },
     cornerClass() {
-      if (this.corner) return this.style[`cdr-popover__corner--${this.corner}`];
+      return this.corner ? this.style[`cdr-popover__corner--${this.corner}`] : undefined;
     },
     triggerClass() {
-      return this.style[`cdr-popover--${this.trigger}`]
-    }
+      return this.style[`cdr-popover--${this.trigger}`];
+    },
   },
   watch: {
     position() {
@@ -71,6 +84,10 @@ export default {
         this.handleClosed();
       }
     },
+  },
+  destroyed() {
+    document.removeEventListener('keydown', this.keyHandler);
+    document.removeEventListener('click', this.clickHandler);
   },
   methods: {
     closePopover(e) {
@@ -113,13 +130,13 @@ export default {
       const orientation = this.pos === 'down' || this.pos === 'up' ? 'vertical' : 'horizontal';
 
       if (orientation === 'vertical' && rect.left <= 0) {
-        this.corner = 'left'
+        this.corner = 'left';
       } else if (orientation === 'vertical' && rect.right >= window.innerWidth) {
-        this.corner = 'right'
+        this.corner = 'right';
       } else if (orientation === 'horizontal' && rect.top <= 0) {
-        this.corner = 'top'
+        this.corner = 'top';
       } else if (orientation === 'horizontal' && rect.bottom >= window.innerHeight) {
-        this.corner = 'bottom'
+        this.corner = 'bottom';
       }
     },
     handleOpened() {
@@ -142,7 +159,6 @@ export default {
           if (tabbables[0]) tabbables[0].focus();
         }
       }, 1);
-
     },
     handleClosed() {
       document.removeEventListener('keydown', this.keyHandler);
@@ -150,17 +166,14 @@ export default {
       if (this.lastActive && this.trigger === 'popover') this.lastActive.focus();
     },
   },
-  destroyed() {
-    document.removeEventListener('keydown', this.keyHandler);
-    document.removeEventListener('click', this.clickHandler);
-  },
   render() {
     return this.opened ? (
       <div class={clsx(
         this.style['cdr-popover__wrapper'],
         this.positionClass,
         this.cornerClass,
-        this.triggerClass)}
+        this.triggerClass,
+      )}
       >
         <div
           class={this.style['cdr-popover']}

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -8,6 +8,7 @@ import CdrButton from '../button/CdrButton';
 
 export default {
   name: 'CdrPopover',
+  inheritAttrs: false,
   components: {
     IconXSm,
     CdrButton,

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -32,6 +32,11 @@ export default {
       type: String,
       default: '',
     },
+    // TODO: fix spacing/layout if tooltip
+    trigger: {
+      type: String,
+      default: 'popover'
+    },
   },
   data() {
     return {
@@ -78,9 +83,11 @@ export default {
       }
     },
     handleClick({ target }) {
-      if (target !== this.$refs.popover && !this.$refs.popover.contains(target)) {
-        this.closePopover();
-      }
+      this.$nextTick(() => {
+        if (target !== this.$refs.popover && !this.$refs.popover.contains(target)) {
+          this.closePopover();
+        }
+      });
     },
     addHandlers() {
       this.keyHandler = this.handleKeyDown.bind(this);
@@ -128,17 +135,22 @@ export default {
 
       setTimeout(() => {
         this.addHandlers();
-
-        const tabbables = tabbable(this.$refs.popover);
-        if (tabbables[0]) tabbables[0].focus();
+        if (this.trigger === 'popover') {
+          const tabbables = tabbable(this.$refs.popover);
+          if (tabbables[0]) tabbables[0].focus();
+        }
       }, 1);
 
     },
     handleClosed() {
       document.removeEventListener('keydown', this.keyHandler);
       document.removeEventListener('click', this.clickHandler);
-      if (this.lastActive) this.lastActive.focus();
+      if (this.lastActive && this.trigger === 'popover') this.lastActive.focus();
     },
+  },
+  destroyed() {
+    document.removeEventListener('keydown', this.keyHandler);
+    document.removeEventListener('click', this.clickHandler);
   },
   render() {
     return this.opened ? (
@@ -171,18 +183,20 @@ export default {
                 {this.$slots.default}
               </div>
             </div>
-            <cdr-button
-              class={this.style['cdr-popover__close-button']}
-              icon-only
-              on-click={this.closePopover}
-              aria-label="Close"
-              size="small"
-            >
-              <icon-x-sm
-                slot="icon"
-                inherit-color
-              />
-            </cdr-button>
+            {
+              this.trigger === 'popover' && (<cdr-button
+                class={this.style['cdr-popover__close-button']}
+                icon-only
+                on-click={this.closePopover}
+                aria-label="Close"
+                size="small"
+              >
+                <icon-x-sm
+                  slot="icon"
+                  inherit-color
+                />
+              </cdr-button>)
+            }
           </div>
         </div>
         <div class={this.style['cdr-popover__arrow']}/>

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -36,6 +36,7 @@ export default {
       style,
       lastActive: undefined,
       keyHandler: undefined,
+      clickHandler: undefined,
     };
   },
   computed: {
@@ -56,21 +57,28 @@ export default {
         default: break;
       }
     },
+    handleClick({ target }) {
+      if (target !== this.$refs.popover && !this.$refs.popover.contains(target)) {
+        this.closePopover();
+      }
+    },
     addHandlers() {
       this.keyHandler = this.handleKeyDown.bind(this);
       document.addEventListener('keydown', this.keyHandler);
+      this.clickHandler = this.handleClick.bind(this);
+      document.addEventListener('click', this.clickHandler);
     },
     handleOpened() {
       const { activeElement } = document;
 
       this.lastActive = activeElement;
-      this.$nextTick(() => {
-        if (this.$refs.popover) this.$refs.popover.focus(); // wrapped in if so testing error isn't thrown
+      setTimeout(() => {
         this.addHandlers();
-      });
+      }, 1);
     },
     handleClosed() {
       document.removeEventListener('keydown', this.keyHandler);
+      document.removeEventListener('click', this.clickHandler);
       if (this.lastActive) this.lastActive.focus();
     },
   },
@@ -92,7 +100,6 @@ export default {
         class={clsx(this.style['cdr-popover'], this.arrowDirectionClass)}
         role="dialog"
         ref="popover"
-        tabIndex="0"
       >
         <div class={this.style['cdr-popover__header']}>
           <div class={this.style['cdr-popover__title']}>

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -5,14 +5,13 @@ import propValidator from '../../utils/propValidator';
 import IconXSm from '../icon/comps/x-sm';
 import CdrButton from '../button/CdrButton';
 
-
 export default {
   name: 'CdrPopover',
-  inheritAttrs: false,
   components: {
     IconXSm,
     CdrButton,
   },
+  inheritAttrs: false,
   props: {
     opened: {
       type: Boolean,

--- a/src/components/popover/__tests__/CdrPopover.spec.js
+++ b/src/components/popover/__tests__/CdrPopover.spec.js
@@ -15,10 +15,21 @@ describe('CdrPopover', () => {
   it('applies correct arrow class', () => {
     const wrapper = shallowMount(CdrPopover, {
       propsData: {
-        arrowDirection: 'left',
-        open: true
+        position: 'left',
+        opened: true
       },
     });
-    expect(wrapper.classes()).toContain('cdr-popover__arrow--left');
+    expect(wrapper.classes()).toContain('cdr-popover__wrapper--left');
+  });
+
+  it('applies tooltip class if trigger prop is set', () => {
+    const wrapper = shallowMount(CdrPopover, {
+      propsData: {
+        position: 'left',
+        opened: true,
+        trigger: 'tooltip'
+      },
+    });
+    expect(wrapper.classes()).toContain('cdr-popover--tooltip');
   });
 });

--- a/src/components/popover/__tests__/CdrPopover.spec.js
+++ b/src/components/popover/__tests__/CdrPopover.spec.js
@@ -22,7 +22,7 @@ describe('CdrPopover', () => {
     expect(wrapper.classes()).toContain('cdr-popover__wrapper--left');
   });
 
-  it('applies tooltip class if trigger prop is set', () => {
+  it('applies tooltip class and role if trigger prop is set', () => {
     const wrapper = shallowMount(CdrPopover, {
       propsData: {
         position: 'left',
@@ -31,5 +31,18 @@ describe('CdrPopover', () => {
       },
     });
     expect(wrapper.classes()).toContain('cdr-popover--tooltip');
+    expect(wrapper.find('.cdr-popover').attributes('role')).toBe('tooltip')
+  });
+
+
+  it('does not apply tooltip class and role if trigger prop is set', () => {
+    const wrapper = shallowMount(CdrPopover, {
+      propsData: {
+        position: 'left',
+        opened: true,
+      },
+    });
+    expect(wrapper.classes()).not.toContain('cdr-popover--tooltip');
+    expect(wrapper.find('.cdr-popover').attributes('role')).toBe('dialog')
   });
 });

--- a/src/components/popover/__tests__/CdrPopover.spec.js
+++ b/src/components/popover/__tests__/CdrPopover.spec.js
@@ -1,0 +1,24 @@
+import { shallowMount } from '@vue/test-utils';
+import CdrPopover from 'componentdir/popover/CdrPopover';
+
+describe('CdrPopover', () => {
+  it('matches snapshot', () => {
+    const wrapper = shallowMount(CdrPopover);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it('is not visible by default', () => {
+    const wrapper = shallowMount(CdrPopover);
+    expect(wrapper.html()).toBe('');
+  });
+
+  it('applies correct arrow class', () => {
+    const wrapper = shallowMount(CdrPopover, {
+      propsData: {
+        arrowDirection: 'left',
+        open: true
+      },
+    });
+    expect(wrapper.classes()).toContain('cdr-popover__arrow--left');
+  });
+});

--- a/src/components/popover/__tests__/__snapshots__/CdrPopover.spec.js.snap
+++ b/src/components/popover/__tests__/__snapshots__/CdrPopover.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdrPopover matches snapshot 1`] = `<!---->`;

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -24,9 +24,27 @@
       >right</cdr-radio>
     </cdr-form-group>
 
+    <cdr-form-group label="title">
+      <cdr-radio
+        name="title"
+        custom-value="Hello my name is popover"
+        v-model="title"
+      >short title</cdr-radio>
+      <cdr-radio
+        name="title"
+        custom-value=""
+        v-model="title"
+      >no title</cdr-radio>
+      <cdr-radio
+        name="title"
+        custom-value="Hello my name is Popover, Look on my Works, ye Mighty, and despair!"
+        v-model="title"
+      >long title</cdr-radio>
+    </cdr-form-group>
+
 
     <div class="popover-container">
-      <cdr-popover :opened="open" :arrow-direction="direction" @closed="togglePopover" label="im a popover wow how cool is that what happens when this text wraps huh wow">
+      <cdr-popover :opened="open" :arrow-direction="direction" @closed="togglePopover" :label="title">
         <cdr-text>Thanks for stopping by.</cdr-text>
       </cdr-popover>
 
@@ -46,7 +64,8 @@ export default {
   data() {
     return {
       open: false,
-      direction: 'up'
+      direction: 'up',
+      title: 'Hello my name is popover',
     }
   },
   methods: {

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -55,7 +55,6 @@
       >right</cdr-radio>
     </cdr-form-group>
 
-
     <cdr-form-group label="trigger type">
       <cdr-radio
         name="type"

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -87,7 +87,7 @@
       >long title</cdr-radio>
     </cdr-form-group>
 
-    <div style="clear: both"/>
+    <div style="clear: both" />
     <div :class="containerClass">
       <cdr-popover
         @closed="togglePopover"
@@ -97,12 +97,28 @@
         :label="title"
         :trigger="this.type === 'button' ? 'tooltip' : 'popover'"
       >
-        <cdr-text>Thanks for stopping by. What a lovely day it is today. Please come back again soon.</cdr-text>
+        <cdr-text>
+          Thanks for stopping by. What a lovely day it is today. Please come back again soon.
+        </cdr-text>
       </cdr-popover>
 
-      <cdr-button v-if="type === 'icon'" @click="togglePopover" :icon-only="true"><icon-information-fill/></cdr-button>
+      <cdr-button
+        v-if="type === 'icon'"
+        @click="togglePopover"
+        :icon-only="true"
+      >
+        <icon-information-fill />
+      </cdr-button>
       <!-- TODO: export directive to handle hover/focus bindings? -->
-      <cdr-button v-else @mouseover="open = true" @mouseleave="open = false" @focus="open = true" @blur="open = false">lol wow huh</cdr-button>
+      <cdr-button
+        v-else
+        @mouseover="open = true"
+        @mouseleave="open = false"
+        @focus="open = true"
+        @blur="open = false"
+      >
+        lol wow huh
+      </cdr-button>
     </div>
   </div>
 </template>
@@ -122,19 +138,19 @@ export default {
       title: 'Hello my name is popover',
       autoPos: true,
       trigger: 'center',
-      type: 'icon'
-    }
-  },
-  methods: {
-    togglePopover(e) {
-      this.open = !this.open;
-    }
+      type: 'icon',
+    };
   },
   computed: {
     containerClass() {
       return `popover-container popover-container--${this.trigger}`;
-    }
-  }
+    },
+  },
+  methods: {
+    togglePopover() {
+      this.open = !this.open;
+    },
+  },
 };
 </script>
 

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -1,27 +1,40 @@
 <template>
   <div>
     <h2>popover</h2>
-    <cdr-form-group label="arrow direction">
+    <cdr-form-group label="popover position">
       <cdr-radio
-        name="direction"
+        name="position"
         custom-value="up"
-        v-model="direction"
+        v-model="position"
       >up</cdr-radio>
       <cdr-radio
-        name="direction"
+        name="position"
         custom-value="down"
-        v-model="direction"
+        v-model="position"
       >down</cdr-radio>
       <cdr-radio
-        name="direction"
+        name="position"
         custom-value="left"
-        v-model="direction"
+        v-model="position"
       >left</cdr-radio>
       <cdr-radio
-        name="direction"
+        name="position"
         custom-value="right"
-        v-model="direction"
+        v-model="position"
       >right</cdr-radio>
+    </cdr-form-group>
+
+    <cdr-form-group label="auto position">
+      <cdr-radio
+        name="autoPos"
+        :custom-value="true"
+        v-model="autoPos"
+      >true</cdr-radio>
+      <cdr-radio
+        name="autoPos"
+        :custom-value="false"
+        v-model="autoPos"
+      >false</cdr-radio>
     </cdr-form-group>
 
     <cdr-form-group label="title">
@@ -44,7 +57,7 @@
 
 
     <div class="popover-container">
-      <cdr-popover :opened="open" :arrow-direction="direction" @closed="togglePopover" :label="title">
+      <cdr-popover :opened="open" :position="position" :auto-position="autoPos" @closed="togglePopover" :label="title">
         <cdr-text>Thanks for stopping by.</cdr-text>
       </cdr-popover>
 
@@ -64,12 +77,13 @@ export default {
   data() {
     return {
       open: false,
-      direction: 'up',
+      position: 'up',
       title: 'Hello my name is popover',
+      autoPos: true,
     }
   },
   methods: {
-    togglePopover() {
+    togglePopover(e) {
       this.open = !this.open;
     }
   }

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -82,7 +82,7 @@
       >no title</cdr-radio>
       <cdr-radio
         name="title"
-        custom-value="Hello my name is Popover, Look on my Works, ye Mighty, and despair!"
+        custom-value="Hi i am a popover, i can also be a tooltip sometimes, wow"
         v-model="title"
       >long title</cdr-radio>
     </cdr-form-group>
@@ -97,11 +97,11 @@
         :label="title"
         :trigger="this.type === 'button' ? 'tooltip' : 'popover'"
       >
-        <cdr-text>Thanks for stopping by.</cdr-text>
+        <cdr-text>Thanks for stopping by. What a lovely day it is today. Please come back again soon.</cdr-text>
       </cdr-popover>
 
       <cdr-button v-if="type === 'icon'" @click="togglePopover" :icon-only="true"><icon-information-fill/></cdr-button>
-      <!-- TODO: export directive to handle this? -->
+      <!-- TODO: export directive to handle hover/focus bindings? -->
       <cdr-button v-else @mouseover="open = true" @mouseleave="open = false" @focus="open = true" @blur="open = false">lol wow huh</cdr-button>
     </div>
   </div>

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="popover-example">
     <h2>popover</h2>
     <cdr-form-group label="popover position">
       <cdr-radio
@@ -37,6 +37,38 @@
       >false</cdr-radio>
     </cdr-form-group>
 
+    <cdr-form-group label="trigger position">
+      <cdr-radio
+        name="trigger"
+        custom-value="left"
+        v-model="trigger"
+      >left</cdr-radio>
+      <cdr-radio
+        name="trigger"
+        custom-value="center"
+        v-model="trigger"
+      >center</cdr-radio>
+      <cdr-radio
+        name="trigger"
+        custom-value="right"
+        v-model="trigger"
+      >right</cdr-radio>
+    </cdr-form-group>
+
+
+    <cdr-form-group label="trigger type">
+      <cdr-radio
+        name="type"
+        custom-value="button"
+        v-model="type"
+      >button</cdr-radio>
+      <cdr-radio
+        name="type"
+        custom-value="icon"
+        v-model="type"
+      >icon</cdr-radio>
+    </cdr-form-group>
+
     <cdr-form-group label="title">
       <cdr-radio
         name="title"
@@ -56,12 +88,13 @@
     </cdr-form-group>
 
 
-    <div class="popover-container">
+    <div :class="containerClass">
       <cdr-popover :opened="open" :position="position" :auto-position="autoPos" @closed="togglePopover" :label="title">
         <cdr-text>Thanks for stopping by.</cdr-text>
       </cdr-popover>
 
-      <cdr-button @click="togglePopover" :icon-only="true"><icon-information-fill/></cdr-button>
+      <cdr-button v-if="type === 'icon'" @click="togglePopover" :icon-only="true"><icon-information-fill/></cdr-button>
+      <cdr-button v-else @click="togglePopover">lol wow huh</cdr-button>
     </div>
   </div>
 </template>
@@ -80,11 +113,18 @@ export default {
       position: 'up',
       title: 'Hello my name is popover',
       autoPos: true,
+      trigger: 'center',
+      type: 'icon'
     }
   },
   methods: {
     togglePopover(e) {
       this.open = !this.open;
+    }
+  },
+  computed: {
+    containerClass() {
+      return `popover-container popover-container--${this.trigger}`;
     }
   }
 };
@@ -94,6 +134,17 @@ export default {
 .popover-container {
   position: relative;
   width: max-content;
+}
+
+.popover-container--center {
   margin: 0 auto;
+}
+.popover-container--right {
+  margin-left: 95%;
+}
+
+.popover-example {
+  /* lots of bottom space to allow scrolling*/
+  margin-bottom: 1000px;
 }
 </style>

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -106,6 +106,7 @@
         v-if="type === 'icon'"
         @click="togglePopover"
         :icon-only="true"
+        aria-label="information"
       >
         <icon-information-fill />
       </cdr-button>

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -26,12 +26,11 @@
 
 
     <div class="popover-container">
-      <cdr-popover :open="open" :arrow-direction="direction">
-        <h4>Welcome to my amazing popover</h4>
-        <p>Thanks for stopping by.</p>
+      <cdr-popover :open="open" :arrow-direction="direction" @closed="togglePopover" title="im a popover wow how cool is that what happens when this text wraps huh wow">
+        <cdr-text>Thanks for stopping by.</cdr-text>
       </cdr-popover>
 
-      <cdr-button @click="openPopover">open popover</cdr-button>
+      <cdr-button @click="togglePopover" :icon-only="true"><icon-information-fill/></cdr-button>
     </div>
   </div>
 </template>
@@ -51,7 +50,7 @@ export default {
     }
   },
   methods: {
-    openPopover() {
+    togglePopover() {
       this.open = !this.open;
     }
   }

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -26,7 +26,7 @@
 
 
     <div class="popover-container">
-      <cdr-popover :open="open" :arrow-direction="direction" @closed="togglePopover" title="im a popover wow how cool is that what happens when this text wraps huh wow">
+      <cdr-popover :opened="open" :arrow-direction="direction" @closed="togglePopover" label="im a popover wow how cool is that what happens when this text wraps huh wow">
         <cdr-text>Thanks for stopping by.</cdr-text>
       </cdr-popover>
 

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -87,14 +87,22 @@
       >long title</cdr-radio>
     </cdr-form-group>
 
-
+    <div style="clear: both"/>
     <div :class="containerClass">
-      <cdr-popover :opened="open" :position="position" :auto-position="autoPos" @closed="togglePopover" :label="title">
+      <cdr-popover
+        @closed="togglePopover"
+        :opened="open"
+        :position="position"
+        :auto-position="autoPos"
+        :label="title"
+        :trigger="this.type === 'button' ? 'tooltip' : 'popover'"
+      >
         <cdr-text>Thanks for stopping by.</cdr-text>
       </cdr-popover>
 
       <cdr-button v-if="type === 'icon'" @click="togglePopover" :icon-only="true"><icon-information-fill/></cdr-button>
-      <cdr-button v-else @click="togglePopover">lol wow huh</cdr-button>
+      <!-- TODO: export directive to handle this? -->
+      <cdr-button v-else @mouseover="open = true" @mouseleave="open = false" @focus="open = true" @blur="open = false">lol wow huh</cdr-button>
     </div>
   </div>
 </template>
@@ -146,5 +154,10 @@ export default {
 .popover-example {
   /* lots of bottom space to allow scrolling*/
   margin-bottom: 1000px;
+}
+
+fieldset {
+  width: 20%;
+  float: left;
 }
 </style>

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <h2>popover</h2>
+    <cdr-form-group label="arrow direction">
+      <cdr-radio
+        name="direction"
+        custom-value="up"
+        v-model="direction"
+      >up</cdr-radio>
+      <cdr-radio
+        name="direction"
+        custom-value="down"
+        v-model="direction"
+      >down</cdr-radio>
+      <cdr-radio
+        name="direction"
+        custom-value="left"
+        v-model="direction"
+      >left</cdr-radio>
+      <cdr-radio
+        name="direction"
+        custom-value="right"
+        v-model="direction"
+      >right</cdr-radio>
+    </cdr-form-group>
+
+
+    <div class="popover-container">
+      <cdr-popover :open="open" :arrow-direction="direction">
+        <h4>Welcome to my amazing popover</h4>
+        <p>Thanks for stopping by.</p>
+      </cdr-popover>
+
+      <cdr-button @click="openPopover">open popover</cdr-button>
+    </div>
+  </div>
+</template>
+
+<script>
+import * as Components from 'srcdir/index';
+
+export default {
+  name: 'Popover',
+  components: {
+    ...Components,
+  },
+  data() {
+    return {
+      open: false,
+      direction: 'up'
+    }
+  },
+  methods: {
+    openPopover() {
+      this.open = !this.open;
+    }
+  }
+};
+</script>
+
+<style>
+.popover-container {
+  position: relative;
+  width: max-content;
+  margin: 0 auto;
+}
+</style>

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -3,13 +3,12 @@
 @import '../../../css/settings/index.scss';
 
 @mixin arrow($borderSide) {
-  &::before,
-  &::after {
+
+  &::before, &::after {
     border-style: solid;
     border-color: transparent;
     #{$borderSide}: 100%;
   }
-
   &::before {
     border-#{$borderSide}-color: $cdr-color-border-secondary;
     border-width: 10px; // arrow is 10px tall, 1px border
@@ -26,7 +25,7 @@
   padding-left: $cdr-space-one-x;
   background: $cdr-color-background-primary;
   border: 1px solid $cdr-color-border-secondary;
-  box-shadow: $cdr-prominence-elevated;
+  // box-shadow: $cdr-prominence-elevated; // TODO: box-shadow doesn't work on arrow
   min-width: 286px;
   position: absolute;
   z-index: 100;
@@ -49,7 +48,6 @@
     padding: 0;
   }
 
-// Arrow Logic Below
   &::before,
   &::after {
     content: '';
@@ -60,8 +58,8 @@
   }
 
   // Up and down arrows
-  &__arrow--up,
-  &__arrow--down {
+  &__up,
+  &__down {
     &,
     &::before,
     &::after {
@@ -70,20 +68,43 @@
     }
   }
 
-  &__arrow--up {
+  // &__corner--left {
+  //   left: 0;
+  //   transform: unset;
+  //   &::before,
+  //   &::after {
+  //     // magic number?
+  //     left: 2rem;
+  //     transform: unset;
+  //   }
+  // }
+  //
+  // &__corner--right {
+  //   left: unset;
+  //   right: 0;
+  //   transform: unset;
+  //   &::before,
+  //   &::after {
+  //     left: unset;
+  //     right: 0;
+  //     // transform: unset;
+  //   }
+  // }
+
+  &__down {
     @include arrow(bottom);
     top: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
   }
 
-  &__arrow--down {
+  &__up {
     @include arrow(top);
     bottom: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
   }
 
 
   // Left and right arrows
-  &__arrow--left,
-  &__arrow--right {
+  &__left,
+  &__right {
     &,
     &::before,
     &::after {
@@ -92,12 +113,12 @@
     }
   }
 
-  &__arrow--left {
+  &__right {
     @include arrow(right);
     left: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
   }
 
-  &__arrow--right {
+  &__left {
     @include arrow(left);
     right: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
   }

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -2,30 +2,11 @@
 @import url('@rei/cedar/dist/style/cdr-icon.css');
 @import '../../../css/settings/index.scss';
 
-@mixin arrow($borderSide) {
-
-  &::before, &::after {
-    border-style: solid;
-    border-color: transparent;
-    #{$borderSide}: 100%;
-  }
-  &::before {
-    border-#{$borderSide}-color: $cdr-color-border-secondary;
-    border-width: 10px; // arrow is 10px tall, 1px border
-  }
-
-  &::after {
-    border-#{$borderSide}-color: $cdr-color-background-primary;
-    border-width: 9px;
-  }
-}
-
 .cdr-popover{
   padding: $cdr-space-half-x;
   padding-left: $cdr-space-one-x;
   background: $cdr-color-background-primary;
   border: 1px solid $cdr-color-border-secondary;
-  // box-shadow: $cdr-prominence-elevated; // TODO: box-shadow doesn't work on arrow
   min-width: 286px;
   position: absolute;
   z-index: 100;
@@ -48,78 +29,119 @@
     padding: 0;
   }
 
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    margin: auto;
-    width: 0;
-    height: 0;
+
+  @mixin arrow($borderSide, $position, $translate) {
+    &::before, &::after {
+      // TODO: variable, MATCHES padding on cdr-popover, 1rem + space-quarter-x + 0.1rem for overlap
+      #{$borderSide}: -1.5rem;
+      #{$position}: 50%;
+      transform: #{$translate};
+      z-index: 100;
+    }
+    &::before {
+      border-#{$borderSide}-color: $cdr-color-border-secondary;
+    }
+
+    &::after {
+      border-#{$borderSide}-color: $cdr-color-background-primary;
+    }
   }
 
-  // Up and down arrows
   &__up,
   &__down {
-    &,
-    &::before,
-    &::after {
+    .cdr-popover {
       left: 50%;
       transform: translateX(-50%);
     }
   }
 
-  // &__corner--left {
-  //   left: 0;
-  //   transform: unset;
-  //   &::before,
-  //   &::after {
-  //     // magic number?
-  //     left: 2rem;
-  //     transform: unset;
-  //   }
-  // }
-  //
-  // &__corner--right {
-  //   left: unset;
-  //   right: 0;
-  //   transform: unset;
-  //   &::before,
-  //   &::after {
-  //     left: unset;
-  //     right: 0;
-  //     // transform: unset;
-  //   }
-  // }
-
   &__down {
-    @include arrow(bottom);
-    top: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
+    .cdr-popover {
+      top: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
+    }
+
+    .cdr-popover__arrow {
+      @include arrow(bottom, left, translateX(-50%));
+    }
   }
 
   &__up {
-    @include arrow(top);
-    bottom: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
+    .cdr-popover {
+      bottom: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
+    }
+
+    .cdr-popover__arrow {
+      @include arrow(top, left, translateX(-50%));
+    }
   }
 
+  &__corner--left .cdr-popover {
+    left: 0;
+    transform: unset;
+  }
 
-  // Left and right arrows
+  &__corner--right .cdr-popover {
+    left: unset;
+    right: 0;
+    transform: unset;
+  }
+
   &__left,
   &__right {
-    &,
-    &::before,
-    &::after {
+    .cdr-popover {
       top: 50%;
       transform: translateY(-50%);
     }
   }
 
-  &__right {
-    @include arrow(right);
-    left: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
+  &__left {
+    .cdr-popover {
+      right: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
+    }
+
+    .cdr-popover__arrow {
+      @include arrow(left, top, translateY(-50%));
+    }
   }
 
-  &__left {
-    @include arrow(left);
-    right: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
+  &__right {
+    .cdr-popover {
+      left: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
+    }
+
+    .cdr-popover__arrow {
+      @include arrow(right, top, translateY(-50%));
+    }
+  }
+
+  &__corner--top .cdr-popover {
+    top: 0;
+    transform: unset;
+  }
+
+  &__corner--bottom .cdr-popover {
+    top: unset;
+    bottom: 0;
+    transform: unset;
+  }
+
+  &__arrow {
+    &::before, &::after {
+      content: '';
+      position: absolute;
+      margin: auto;
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-color: transparent;
+    }
+
+    &::before {
+      border-width: 10px; // arrow is 10px tall, 1px border (1rem/0.1rem)
+    }
+
+    &::after {
+      border-width: 9px;
+    }
   }
 }

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -1,3 +1,6 @@
+@import url('@rei/cedar/dist/style/cdr-text.css');
+@import url('@rei/cedar/dist/style/cdr-button.css');
+@import url('@rei/cedar/dist/style/cdr-icon.css');
 @import '../../../css/settings/index.scss';
 
 @mixin arrow($borderSide) {
@@ -27,6 +30,21 @@
   min-width: 286px;
   position: absolute;
   z-index: 100;
+
+  &__header {
+    display: flex;
+    padding-bottom: $cdr-space-one-x;
+  }
+
+  &__title {
+    flex: auto;
+  }
+
+  &__close-button {
+    align-self: flex-start;
+    flex: none;
+    padding: 0;
+  }
 
   &::before,
   &::after {

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -55,15 +55,15 @@
     }
   }
 
-  &__up,
-  &__down {
+  &__wrapper--up,
+  &__wrapper--down {
     .cdr-popover {
       left: 50%;
       transform: translateX(-50%);
     }
   }
 
-  &__down {
+  &__wrapper--down {
     .cdr-popover {
       top: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
     }
@@ -73,7 +73,7 @@
     }
   }
 
-  &__bottom.cdr-popover--tooltip .cdr-popover__arrow {
+  &__wrapper--down.cdr-popover--tooltip .cdr-popover__arrow {
     &::before {
       border-bottom-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
     }
@@ -83,7 +83,7 @@
     }
   }
 
-  &__up {
+  &__wrapper--up {
     .cdr-popover {
       bottom: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
     }
@@ -93,7 +93,7 @@
     }
   }
 
-  &__up.cdr-popover--tooltip .cdr-popover__arrow {
+  &__wrapper--up.cdr-popover--tooltip .cdr-popover__arrow {
     &::before {
       border-top-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
     }
@@ -114,15 +114,15 @@
     transform: unset;
   }
 
-  &__left,
-  &__right {
+  &__wrapper--left,
+  &__wrapper--right {
     .cdr-popover {
       top: 50%;
       transform: translateY(-50%);
     }
   }
 
-  &__left {
+  &__wrapper--left {
     .cdr-popover {
       right: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
     }
@@ -132,7 +132,7 @@
     }
   }
 
-  &__left.cdr-popover--tooltip .cdr-popover__arrow {
+  &__wrapper--left.cdr-popover--tooltip .cdr-popover__arrow {
     &::before {
       border-left-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
     }
@@ -142,7 +142,7 @@
     }
   }
 
-  &__right {
+  &__wrapper--right {
     .cdr-popover {
       left: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
     }
@@ -152,7 +152,7 @@
     }
   }
 
-  &__right.cdr-popover--tooltip .cdr-popover__arrow {
+  &__wrapper--right.cdr-popover--tooltip .cdr-popover__arrow {
     &::before {
       border-right-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
     }

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -46,6 +46,7 @@
     padding: 0;
   }
 
+// Arrow Logic Below
   &::before,
   &::after {
     content: '';

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -2,6 +2,14 @@
 @import url('@rei/cedar/dist/style/cdr-icon.css');
 @import '../../../css/settings/index.scss';
 
+.cdr-popover--tooltip {
+  .cdr-popover {
+    background: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
+    color: $cdr-color-text-inverse;
+    border: none;
+  }
+}
+
 .cdr-popover{
   padding: $cdr-space-half-x;
   padding-left: $cdr-space-one-x;
@@ -65,6 +73,16 @@
     }
   }
 
+  &__bottom.cdr-popover--tooltip .cdr-popover__arrow {
+    &::before {
+      border-bottom-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
+    }
+
+    &::after {
+      border-bottom-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
+    }
+  }
+
   &__up {
     .cdr-popover {
       bottom: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
@@ -72,6 +90,16 @@
 
     .cdr-popover__arrow {
       @include arrow(top, left, translateX(-50%));
+    }
+  }
+
+  &__up.cdr-popover--tooltip .cdr-popover__arrow {
+    &::before {
+      border-top-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
+    }
+
+    &::after {
+      border-top-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
     }
   }
 
@@ -104,6 +132,16 @@
     }
   }
 
+  &__left.cdr-popover--tooltip .cdr-popover__arrow {
+    &::before {
+      border-left-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
+    }
+
+    &::after {
+      border-left-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
+    }
+  }
+
   &__right {
     .cdr-popover {
       left: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
@@ -111,6 +149,16 @@
 
     .cdr-popover__arrow {
       @include arrow(right, top, translateY(-50%));
+    }
+  }
+
+  &__right.cdr-popover--tooltip .cdr-popover__arrow {
+    &::before {
+      border-right-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
+    }
+
+    &::after {
+      border-right-color: $cdr-color-background-cta-dark-rest; // TODO: need token/value here
     }
   }
 

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -1,4 +1,3 @@
-@import url('@rei/cedar/dist/style/cdr-text.css');
 @import url('@rei/cedar/dist/style/cdr-button.css');
 @import url('@rei/cedar/dist/style/cdr-icon.css');
 @import '../../../css/settings/index.scss';
@@ -38,6 +37,7 @@
 
   &__title {
     flex: auto;
+    @include cdr-text-heading-serif-400;
   }
 
   &__close-button {

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -13,7 +13,7 @@
 
   &::before {
     border-#{$borderSide}-color: $cdr-color-border-secondary;
-    border-width: 10px;
+    border-width: 10px; // arrow is 10px tall, 1px border
   }
 
   &::after {
@@ -68,12 +68,12 @@
 
   &__arrow--up {
     @include arrow(bottom);
-    top: calc(100% + 2rem);
+    top: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
   }
 
   &__arrow--down {
     @include arrow(top);
-    bottom: calc(100% + 2rem);
+    bottom: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
   }
 
 
@@ -90,11 +90,11 @@
 
   &__arrow--left {
     @include arrow(right);
-    left: calc(100% + 2rem);
+    left: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
   }
 
   &__arrow--right {
     @include arrow(left);
-    right: calc(100% + 2rem);
+    right: calc(100% + 1rem + #{$cdr-space-quarter-x}); // TODO: 1rem arrow size here, variable?
   }
 }

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -22,7 +22,8 @@
 }
 
 .cdr-popover{
-  padding: $cdr-space-inset-one-x-squish;
+  padding: $cdr-space-half-x;
+  padding-left: $cdr-space-one-x;
   background: $cdr-color-background-primary;
   border: 1px solid $cdr-color-border-secondary;
   box-shadow: $cdr-prominence-elevated;
@@ -30,14 +31,16 @@
   position: absolute;
   z-index: 100;
 
-  &__header {
+  &__container {
     display: flex;
-    padding-bottom: $cdr-space-one-x;
   }
-
-  &__title {
+  &__content {
     flex: auto;
+  }
+  &__title {
     @include cdr-text-heading-serif-400;
+    margin-bottom: $cdr-space-one-x;
+    margin-right: $cdr-space-half-x;
   }
 
   &__close-button {

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -1,0 +1,82 @@
+@import '../../../css/settings/index.scss';
+
+@mixin arrow($borderSide) {
+  &::before,
+  &::after {
+    border-style: solid;
+    border-color: transparent;
+    #{$borderSide}: 100%;
+  }
+
+  &::before {
+    border-#{$borderSide}-color: $cdr-color-border-secondary;
+    border-width: 10px;
+  }
+
+  &::after {
+    border-#{$borderSide}-color: $cdr-color-background-primary;
+    border-width: 9px;
+  }
+}
+
+.cdr-popover{
+  padding: $cdr-space-inset-one-x-squish;
+  background: $cdr-color-background-primary;
+  border: 1px solid $cdr-color-border-secondary;
+  box-shadow: $cdr-prominence-elevated;
+  min-width: 286px;
+  position: absolute;
+  z-index: 100;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    margin: auto;
+    width: 0;
+    height: 0;
+  }
+
+  // Up and down arrows
+  &__arrow--up,
+  &__arrow--down {
+    &,
+    &::before,
+    &::after {
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
+
+  &__arrow--up {
+    @include arrow(bottom);
+    top: calc(100% + 2rem);
+  }
+
+  &__arrow--down {
+    @include arrow(top);
+    bottom: calc(100% + 2rem);
+  }
+
+
+  // Left and right arrows
+  &__arrow--left,
+  &__arrow--right {
+    &,
+    &::before,
+    &::after {
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+
+  &__arrow--left {
+    @include arrow(right);
+    left: calc(100% + 2rem);
+  }
+
+  &__arrow--right {
+    @include arrow(left);
+    right: calc(100% + 2rem);
+  }
+}

--- a/src/components/popup/CdrPopup.jsx
+++ b/src/components/popup/CdrPopup.jsx
@@ -31,6 +31,7 @@ export default {
       clickHandler: undefined,
       pos: this.position,
       corner: undefined,
+      exiting: false,
     };
   },
   computed: {
@@ -42,6 +43,9 @@ export default {
     },
     openClass() {
       return this.opened ? this.style['cdr-popup--open'] : undefined;
+    },
+    exitingClass() {
+      return this.exiting ? this.style['cdr-popup--exit'] : undefined;
     },
   },
   watch: {
@@ -128,6 +132,13 @@ export default {
     handleClosed() {
       document.removeEventListener('keydown', this.keyHandler);
       document.removeEventListener('click', this.clickHandler);
+      this.exiting = true;
+      // onTransitionEnd?
+      setTimeout(() => {
+        this.exiting = false;
+      }, 200); // $cdr-duration-2;
+      // add animation exit class
+      // remove it after animation
     },
   },
   render() {
@@ -135,6 +146,7 @@ export default {
       <div class={clsx(
         this.style['cdr-popup'],
         this.openClass,
+        this.exitingClass,
         this.positionClass,
         this.cornerClass,
       )}

--- a/src/components/popup/CdrPopup.jsx
+++ b/src/components/popup/CdrPopup.jsx
@@ -118,7 +118,7 @@ export default {
     handleOpened() {
       this.pos = this.position;
       this.corner = undefined;
-      
+
       if (this.autoPosition) {
         this.$nextTick(() => {
           this.calculatePlacement();

--- a/src/components/popup/CdrPopup.jsx
+++ b/src/components/popup/CdrPopup.jsx
@@ -1,0 +1,153 @@
+import clsx from 'clsx';
+import style from './styles/CdrPopup.scss';
+import propValidator from '../../utils/propValidator';
+
+export default {
+  name: 'CdrPopup',
+  inheritAttrs: false,
+  props: {
+    opened: {
+      type: Boolean,
+      default: false,
+    },
+    position: {
+      type: String,
+      required: false,
+      default: 'up',
+      validator: (value) => propValidator(
+        value,
+        ['up', 'down', 'left', 'right'],
+      ),
+    },
+    autoPosition: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  data() {
+    return {
+      style,
+      keyHandler: undefined,
+      clickHandler: undefined,
+      pos: this.position,
+      corner: undefined,
+    };
+  },
+  computed: {
+    positionClass() {
+      return this.style[`cdr-popup--${this.pos}`];
+    },
+    cornerClass() {
+      return this.corner ? this.style[`cdr-popup--corner-${this.corner}`] : undefined;
+    },
+    openClass() {
+      return this.opened ? this.style['cdr-popup--open'] : undefined;
+    },
+  },
+  watch: {
+    position() {
+      this.pos = this.position;
+    },
+    opened(newValue, oldValue) {
+      if (!!newValue === !!oldValue) return;
+      if (newValue) {
+        this.handleOpened();
+      } else {
+        this.handleClosed();
+      }
+    },
+  },
+  destroyed() {
+    document.removeEventListener('keydown', this.keyHandler);
+    document.removeEventListener('click', this.clickHandler);
+  },
+  methods: {
+    closePopup(e) {
+      this.$emit('closed', e);
+    },
+    handleKeyDown({ key }) {
+      switch (key) {
+        case 'Escape':
+        case 'Esc':
+          this.closePopup();
+          break;
+        default: break;
+      }
+    },
+    handleClick({ target }) {
+      this.$nextTick(() => {
+        if (target !== this.$refs.popup && !this.$refs.popup.contains(target)) {
+          this.closePopup();
+        }
+      });
+    },
+    addHandlers() {
+      this.keyHandler = this.handleKeyDown.bind(this);
+      document.addEventListener('keydown', this.keyHandler);
+      this.clickHandler = this.handleClick.bind(this);
+      document.addEventListener('click', this.clickHandler);
+    },
+    calculatePlacement() {
+      const rect = this.$refs.popup.getBoundingClientRect();
+      if (this.pos === 'down' && rect.bottom >= window.innerHeight) {
+        this.pos = 'up';
+      } else if (this.pos === 'up' && rect.top <= 0) {
+        this.pos = 'down';
+      } else if (this.pos === 'left' && rect.left <= 0) {
+        this.pos = 'right';
+      } else if (this.pos === 'right' && rect.right >= window.innerWidth) {
+        this.pos = 'left';
+      }
+
+      const orientation = this.pos === 'down' || this.pos === 'up' ? 'vertical' : 'horizontal';
+
+      if (orientation === 'vertical' && rect.left <= 0) {
+        this.corner = 'left';
+      } else if (orientation === 'vertical' && rect.right >= window.innerWidth) {
+        this.corner = 'right';
+      } else if (orientation === 'horizontal' && rect.top <= 0) {
+        this.corner = 'top';
+      } else if (orientation === 'horizontal' && rect.bottom >= window.innerHeight) {
+        this.corner = 'bottom';
+      }
+    },
+    handleOpened() {
+      this.pos = this.position;
+      this.corner = undefined;
+      
+      if (this.autoPosition) {
+        this.$nextTick(() => {
+          this.calculatePlacement();
+        });
+      }
+
+      setTimeout(() => {
+        this.addHandlers();
+      }, 1);
+    },
+    handleClosed() {
+      document.removeEventListener('keydown', this.keyHandler);
+      document.removeEventListener('click', this.clickHandler);
+    },
+  },
+  render() {
+    return (
+      <div class={clsx(
+        this.style['cdr-popup'],
+        this.openClass,
+        this.positionClass,
+        this.cornerClass,
+      )}
+      >
+        <div
+          class={this.style['cdr-popup__content']}
+          ref="popup"
+          {... { attrs: this.$attrs } }
+        >
+          { this.$slots.default }
+        </div>
+        <div class={this.style['cdr-popup__arrow']}/>
+      </div>
+    );
+  },
+};

--- a/src/components/popup/__tests__/CdrPopup.spec.js
+++ b/src/components/popup/__tests__/CdrPopup.spec.js
@@ -1,0 +1,9 @@
+import { shallowMount } from '@vue/test-utils';
+import CdrPopup from 'componentdir/popup/CdrPopup';
+
+describe('CdrPopup', () => {
+  it('matches snapshot', () => {
+    const wrapper = shallowMount(CdrPopup);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+});

--- a/src/components/popup/__tests__/__snapshots__/CdrPopup.spec.js.snap
+++ b/src/components/popup/__tests__/__snapshots__/CdrPopup.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdrPopup matches snapshot 1`] = `
+<div
+  class="cdr-popup cdr-popup--up"
+>
+  <div
+    class="cdr-popup__content"
+  />
+  <div
+    class="cdr-popup__arrow"
+  />
+</div>
+`;

--- a/src/components/popup/styles/CdrPopup.scss
+++ b/src/components/popup/styles/CdrPopup.scss
@@ -1,72 +1,110 @@
 @import '../../../css/settings/index.scss';
 
+$animation-transform: 10px;
 
-//
-// @keyframes :global(exit-left) {
-//   from {
-//     transform: translateX(0);
-//     opacity: 1;
-//   }
-//
-//   to {
-//     transform: translateX(-10px);
-//     opacity: 0;
-//   }
-// }
-//
-// @keyframes :global(exit-right) {
-//   from {
-//     transform: translateX(0);
-//     opacity: 1;
-//   }
-//
-//   to {
-//     transform: translateX(10px);
-//     opacity: 0;
-//   }
-// }
-//
-// @keyframes :global(enter-left) {
-//   from {
-//     transform: translateX(-10px);
-//     opacity: 0;
-//   }
-//
-//   to {
-//     transform: translateX(0);
-//     opacity: 1;
-//   }
-// }
-//
-// @keyframes :global(enter-right) {
-//   from {
-//     transform: translateX(10px);
-//     opacity: 0;
-//   }
-//
-//   to {
-//     transform: translateX(0);
-//     opacity: 1;
-//   }
-// }
-//
-// @mixin cdr-popup-animation {
-//   animation-duration: $cdr-duration-2-x;
-//   animation-timing-function: $cdr-timing-function-ease-out;
-// }
+@keyframes :global(popup-exit-down) {
+  from {
+    // transform: translateY(0);
+    opacity: 1;
+  }
+
+  to {
+    // transform: translateY(-#{$animation-transform});
+    opacity: 0;
+  }
+}
+@keyframes :global(popup-enter-down) {
+  from {
+    // transform: translateY(-#{$animation-transform});
+    opacity: 0;
+  }
+
+  to {
+    // transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes :global(popup-exit-up) {
+  from {
+    // transform: translateY(0);
+    opacity: 1;
+  }
+
+  to {
+    // transform: translateY($animation-transform);
+    opacity: 0;
+  }
+}
+@keyframes :global(popup-enter-up) {
+  from {
+    // transform: translateY($animation-transform);
+    opacity: 0;
+  }
+
+  to {
+    // transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes :global(popup-exit-left) {
+  from {
+    // transform: translateX(0);
+    opacity: 1;
+  }
+
+  to {
+    // transform: translateX(-#{$animation-transform});
+    opacity: 0;
+  }
+}
+@keyframes :global(popup-enter-left) {
+  from {
+    // transform: translateX(-#{$animation-transform});
+    opacity: 0;
+  }
+
+  to {
+    // transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes :global(popup-exit-right) {
+  from {
+    // transform: translateX(0);
+    opacity: 1;
+  }
+
+  to {
+    // transform: translateX($animation-transform);
+    opacity: 0;
+  }
+}
+@keyframes :global(popup-enter-right) {
+  from {
+    // transform: translateX($animation-transform);
+    opacity: 0;
+  }
+
+  to {
+    // transform: translateX(0);
+    opacity: 1;
+  }
+}
 
 $arrow-size: 1rem;
 $arrow-spacing: #{$arrow-size + $cdr-space-quarter-x + 0.1rem};
 $content-spacing: calc(100% + #{$arrow-size} + #{$cdr-space-quarter-x});
 
 .cdr-popup {
-
   display: none;
   opacity: 0;
-  transition: opacity 5s;
-  // TODO: keyframes
+  animation-duration: $cdr-duration-2-x;
+  animation-timing-function: $cdr-timing-function-ease-out;
 
-  &--open {
+  &--open, &--exit {
     opacity: 1;
     display: block;
   }
@@ -104,6 +142,18 @@ $content-spacing: calc(100% + #{$arrow-size} + #{$cdr-space-quarter-x});
   }
 
   &--down {
+    &.cdr-popup--open.cdr-popup {
+      :global {
+        animation-name: popup-enter-down;
+      }
+    }
+
+    &.cdr-popup--exit.cdr-popup {
+      :global {
+        animation-name: popup-exit-down;
+      }
+    }
+
     .cdr-popup__content {
       top: $content-spacing;
     }
@@ -114,6 +164,18 @@ $content-spacing: calc(100% + #{$arrow-size} + #{$cdr-space-quarter-x});
   }
 
   &--up {
+    &.cdr-popup--open.cdr-popup {
+      :global {
+        animation-name: popup-enter-up;
+      }
+    }
+
+    &.cdr-popup--exit.cdr-popup {
+      :global {
+        animation-name: popup-exit-up;
+      }
+    }
+
     .cdr-popup__content {
       bottom: $content-spacing;
     }
@@ -143,6 +205,18 @@ $content-spacing: calc(100% + #{$arrow-size} + #{$cdr-space-quarter-x});
   }
 
   &--left {
+    &.cdr-popup--open.cdr-popup {
+      :global {
+        animation-name: popup-enter-left;
+      }
+    }
+
+    &.cdr-popup--exit.cdr-popup {
+      :global {
+        animation-name: popup-exit-left;
+      }
+    }
+
     .cdr-popup__content {
       right: $content-spacing;
     }
@@ -153,6 +227,18 @@ $content-spacing: calc(100% + #{$arrow-size} + #{$cdr-space-quarter-x});
   }
 
   &--right {
+    &.cdr-popup--open.cdr-popup {
+      :global {
+        animation-name: popup-enter-right;
+      }
+    }
+
+    &.cdr-popup--exit.cdr-popup {
+      :global {
+        animation-name: popup-exit-right;
+      }
+    }
+
     .cdr-popup__content {
       left: $content-spacing;
     }

--- a/src/components/popup/styles/CdrPopup.scss
+++ b/src/components/popup/styles/CdrPopup.scss
@@ -1,0 +1,196 @@
+@import '../../../css/settings/index.scss';
+
+
+//
+// @keyframes :global(exit-left) {
+//   from {
+//     transform: translateX(0);
+//     opacity: 1;
+//   }
+//
+//   to {
+//     transform: translateX(-10px);
+//     opacity: 0;
+//   }
+// }
+//
+// @keyframes :global(exit-right) {
+//   from {
+//     transform: translateX(0);
+//     opacity: 1;
+//   }
+//
+//   to {
+//     transform: translateX(10px);
+//     opacity: 0;
+//   }
+// }
+//
+// @keyframes :global(enter-left) {
+//   from {
+//     transform: translateX(-10px);
+//     opacity: 0;
+//   }
+//
+//   to {
+//     transform: translateX(0);
+//     opacity: 1;
+//   }
+// }
+//
+// @keyframes :global(enter-right) {
+//   from {
+//     transform: translateX(10px);
+//     opacity: 0;
+//   }
+//
+//   to {
+//     transform: translateX(0);
+//     opacity: 1;
+//   }
+// }
+//
+// @mixin cdr-popup-animation {
+//   animation-duration: $cdr-duration-2-x;
+//   animation-timing-function: $cdr-timing-function-ease-out;
+// }
+
+$arrow-size: 1rem;
+$arrow-spacing: #{$arrow-size + $cdr-space-quarter-x + 0.1rem};
+$content-spacing: calc(100% + #{$arrow-size} + #{$cdr-space-quarter-x});
+
+.cdr-popup {
+
+  display: none;
+  opacity: 0;
+  transition: opacity 5s;
+  // TODO: keyframes
+
+  &--open {
+    opacity: 1;
+    display: block;
+  }
+
+  &__content {
+    background: $cdr-color-background-primary;
+    border: 1px solid $cdr-color-border-secondary;
+    min-width: 286px; // TODO: max-width???...
+    position: absolute;
+    z-index: 100;
+  }
+
+  @mixin arrow($borderSide, $position, $translate) {
+    &::before, &::after {
+      #{$borderSide}: -#{$arrow-spacing};
+      #{$position}: 50%;
+      transform: #{$translate};
+      z-index: 100;
+    }
+    &::before {
+      border-#{$borderSide}-color: $cdr-color-border-secondary;
+    }
+
+    &::after {
+      border-#{$borderSide}-color: $cdr-color-background-primary;
+    }
+  }
+
+  &--up,
+  &--down {
+    .cdr-popup__content {
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
+
+  &--down {
+    .cdr-popup__content {
+      top: $content-spacing;
+    }
+
+    .cdr-popup__arrow {
+      @include arrow(bottom, left, translateX(-50%));
+    }
+  }
+
+  &--up {
+    .cdr-popup__content {
+      bottom: $content-spacing;
+    }
+
+    .cdr-popup__arrow {
+      @include arrow(top, left, translateX(-50%));
+    }
+  }
+
+  &--corner-left .cdr-popup__content {
+    left: 0;
+    transform: unset;
+  }
+
+  &--corner-right .cdr-popup__content {
+    left: unset;
+    right: 0;
+    transform: unset;
+  }
+
+  &--left,
+  &--right {
+    .cdr-popup__content {
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+
+  &--left {
+    .cdr-popup__content {
+      right: $content-spacing;
+    }
+
+    .cdr-popup__arrow {
+      @include arrow(left, top, translateY(-50%));
+    }
+  }
+
+  &--right {
+    .cdr-popup__content {
+      left: $content-spacing;
+    }
+
+    .cdr-popup__arrow {
+      @include arrow(right, top, translateY(-50%));
+    }
+  }
+
+
+  &--corner-top .cdr-popup__content {
+    top: 0;
+    transform: unset;
+  }
+
+  &--corner-bottom .cdr-popup__content {
+    top: unset;
+    bottom: 0;
+    transform: unset;
+  }
+
+  &__arrow {
+    &::before, &::after {
+      content: '';
+      position: absolute;
+      margin: auto;
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-color: transparent;
+    }
+
+    &::before {
+      border-width: $arrow-size;
+    }
+
+    &::after {
+      border-width: #{$arrow-size - 0.1rem};
+    }
+  }
+}

--- a/src/components/tooltip/CdrTooltip.backstop.js
+++ b/src/components/tooltip/CdrTooltip.backstop.js
@@ -1,0 +1,5 @@
+module.exports = [{
+  url: 'http://localhost:3000/#/tooltip',
+  label: 'Tooltip',
+  responsive: true,
+}];

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -1,0 +1,91 @@
+import style from './styles/CdrTooltip.scss';
+import CdrPopup from '../popup/CdrPopup';
+import propValidator from '../../utils/propValidator';
+
+export default {
+  name: 'CdrTooltip',
+  components: {
+    CdrPopup,
+  },
+  props: {
+    // TODO: popup mixin?
+    position: {
+      type: String,
+      required: false,
+      default: 'up',
+      validator: (value) => propValidator(
+        value,
+        ['up', 'down', 'left', 'right'],
+      ),
+    },
+    autoPosition: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  data() {
+    return {
+      style,
+      open: false,
+      openHandler: undefined,
+      closeHandler: undefined,
+    };
+  },
+  methods: {
+    openTooltip() {
+      this.open = true
+    },
+    closeTooltip() {
+      this.open = false
+    },
+    addHandlers() {
+      this.openHandler = this.openTooltip.bind(this);
+      this.closeHandler = this.closeTooltip.bind(this);
+
+      const triggerElement = this.$refs.trigger.children[0];
+      if (triggerElement) {
+        triggerElement.addEventListener('mouseover', this.openHandler);
+        triggerElement.addEventListener('focus', this.openHandler);
+
+        triggerElement.addEventListener('mouseleave', this.closeHandler);
+        triggerElement.addEventListener('blur', this.closeHandler);
+      }
+    },
+  },
+  mounted() {
+    this.addHandlers();
+  },
+  destroyed() {
+    // TODO: no need to do this since the element listened to gets destroyted with this too?
+    // const triggerElement = this.$refs.trigger.children[0];
+    // if (triggerElement) {
+    //   triggerElement.removeEventListener('mouseover', this.openHandler);
+    //   triggerElement.removeEventListener('focus', this.openHandler);
+    //
+    //
+    //   triggerElement.removeEventListener('mouseleave', this.closeHandler);
+    //   triggerElement.removeEventListener('blur', this.closeHandler);
+    // }
+  },
+  render() {
+    // TODO: aria-opened/expanded logic for tooltip?
+    return (
+      <div
+        class={this.style['cdr-tooltip--wrapper']}
+      >
+        <div ref="trigger">
+          { this.$slots.trigger }
+        </div>
+        <cdr-popup
+          class={this.style['cdr-tooltip']}
+          role="tooltip"
+          position={ this.position }
+          autoPosition={ this.autoPosition }
+          opened={ this.open }
+        >
+          { this.$slots.default }
+        </cdr-popup>
+      </div>
+    );
+  },
+};

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -8,7 +8,6 @@ export default {
     CdrPopup,
   },
   props: {
-    // TODO: popup mixin?
     position: {
       type: String,
       required: false,

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -28,28 +28,8 @@ export default {
       open: false,
       openHandler: undefined,
       closeHandler: undefined,
+      timeout: undefined,
     };
-  },
-  methods: {
-    openTooltip() {
-      this.open = true
-    },
-    closeTooltip() {
-      this.open = false
-    },
-    addHandlers() {
-      this.openHandler = this.openTooltip.bind(this);
-      this.closeHandler = this.closeTooltip.bind(this);
-
-      const triggerElement = this.$refs.trigger.children[0];
-      if (triggerElement) {
-        triggerElement.addEventListener('mouseover', this.openHandler);
-        triggerElement.addEventListener('focus', this.openHandler);
-
-        triggerElement.addEventListener('mouseleave', this.closeHandler);
-        triggerElement.addEventListener('blur', this.closeHandler);
-      }
-    },
   },
   mounted() {
     this.addHandlers();
@@ -66,8 +46,37 @@ export default {
     //   triggerElement.removeEventListener('blur', this.closeHandler);
     // }
   },
+  methods: {
+    openTooltip() {
+      if (this.timeout) clearTimeout(this.timeout);
+      this.open = true;
+    },
+    closeTooltip() {
+      this.timeout = setTimeout(() => {
+        this.open = false;
+      }, 250);
+    },
+    addHandlers() {
+      this.openHandler = this.openTooltip.bind(this);
+      this.closeHandler = this.closeTooltip.bind(this);
+
+      const triggerElement = this.$refs.trigger.children[0];
+      const popupElement = this.$refs.popup.$el;
+      if (triggerElement) {
+        triggerElement.addEventListener('mouseover', this.openHandler);
+        triggerElement.addEventListener('focus', this.openHandler);
+
+        triggerElement.addEventListener('mouseleave', this.closeHandler);
+        triggerElement.addEventListener('blur', this.closeHandler);
+
+        popupElement.addEventListener('mouseover', this.openHandler);
+        popupElement.addEventListener('mouseleave', this.closeHandler);
+      }
+    },
+  },
   render() {
-    // TODO: aria-opened/expanded logic for tooltip?
+    // TODO: aria-hidden/opened/expanded logic for tooltip?
+    // aria-live when content gets displayed?
     return (
       <div
         class={this.style['cdr-tooltip--wrapper']}
@@ -78,6 +87,7 @@ export default {
         <cdr-popup
           class={this.style['cdr-tooltip']}
           role="tooltip"
+          ref="popup"
           position={ this.position }
           autoPosition={ this.autoPosition }
           opened={ this.open }

--- a/src/components/tooltip/__tests__/CdrTooltip.spec.js
+++ b/src/components/tooltip/__tests__/CdrTooltip.spec.js
@@ -1,0 +1,9 @@
+import { shallowMount } from '@vue/test-utils';
+import CdrTooltip from 'componentdir/tooltip/CdrTooltip';
+
+describe('CdrTooltip', () => {
+  it('matches snapshot', () => {
+    const wrapper = shallowMount(CdrTooltip);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+});

--- a/src/components/tooltip/__tests__/__snapshots__/CdrTooltip.spec.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/CdrTooltip.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdrTooltip matches snapshot 1`] = `
+<div
+  class="cdr-tooltip--wrapper"
+>
+  <div />
+  <cdr-popup-stub
+    autoposition="true"
+    position="up"
+    role="tooltip"
+  />
+</div>
+`;

--- a/src/components/tooltip/examples/Tooltip.vue
+++ b/src/components/tooltip/examples/Tooltip.vue
@@ -57,8 +57,14 @@
 
     <div style="clear: both" />
 
-    <cdr-tooltip :position="position" :autoPosition="autoPos" :class="containerClass">
-      <cdr-button slot="trigger">tooltip</cdr-button>
+    <cdr-tooltip
+      :position="position"
+      :auto-position="autoPos"
+      :class="containerClass"
+    >
+      <cdr-button slot="trigger">
+        tooltip
+      </cdr-button>
       <div>
         oh hey
       </div>

--- a/src/components/tooltip/examples/Tooltip.vue
+++ b/src/components/tooltip/examples/Tooltip.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="tooltip-example">
+    <h2>tooltip</h2>
+    <cdr-form-group label="tooltip position">
+      <cdr-radio
+        name="position"
+        custom-value="up"
+        v-model="position"
+      >up</cdr-radio>
+      <cdr-radio
+        name="position"
+        custom-value="down"
+        v-model="position"
+      >down</cdr-radio>
+      <cdr-radio
+        name="position"
+        custom-value="left"
+        v-model="position"
+      >left</cdr-radio>
+      <cdr-radio
+        name="position"
+        custom-value="right"
+        v-model="position"
+      >right</cdr-radio>
+    </cdr-form-group>
+
+    <cdr-form-group label="auto position">
+      <cdr-radio
+        name="autoPos"
+        :custom-value="true"
+        v-model="autoPos"
+      >true</cdr-radio>
+      <cdr-radio
+        name="autoPos"
+        :custom-value="false"
+        v-model="autoPos"
+      >false</cdr-radio>
+    </cdr-form-group>
+
+    <cdr-form-group label="trigger position">
+      <cdr-radio
+        name="trigger"
+        custom-value="left"
+        v-model="trigger"
+      >left</cdr-radio>
+      <cdr-radio
+        name="trigger"
+        custom-value="center"
+        v-model="trigger"
+      >center</cdr-radio>
+      <cdr-radio
+        name="trigger"
+        custom-value="right"
+        v-model="trigger"
+      >right</cdr-radio>
+    </cdr-form-group>
+
+    <div style="clear: both" />
+
+    <cdr-tooltip :position="position" :autoPosition="autoPos" :class="containerClass">
+      <cdr-button slot="trigger">tooltip</cdr-button>
+      <div>
+        oh hey
+      </div>
+    </cdr-tooltip>
+  </div>
+</template>
+
+<script>
+import * as Components from 'srcdir/index';
+
+export default {
+  name: 'Tooltip',
+  components: {
+    ...Components,
+  },
+  data() {
+    return {
+      position: 'up',
+      autoPos: true,
+      trigger: 'center',
+    };
+  },
+  computed: {
+    containerClass() {
+      return `tooltip-container--${this.trigger}`;
+    },
+  },
+};
+</script>
+
+<style>
+
+.tooltip-container--center {
+  margin: 0 auto;
+}
+.tooltip-container--right {
+  margin-left: 95%;
+}
+
+.tooltip-example {
+  /* lots of bottom space to allow scrolling*/
+  margin-bottom: 1000px;
+}
+
+fieldset {
+  width: 20%;
+  float: left;
+}
+</style>

--- a/src/components/tooltip/styles/CdrTooltip.scss
+++ b/src/components/tooltip/styles/CdrTooltip.scss
@@ -1,0 +1,67 @@
+@import '../../../css/settings/index.scss';
+@import url('@rei/cedar/dist/style/cdr-popup.css');
+
+// TODO: delete these once tokens is updated
+$cdr-color-border-tooltip-default: #f9f8f6;
+$cdr-color-background-tooltip-default: #373734;
+$cdr-color-text-tooltip-default: #f9f8f6;
+
+// TODO: enable hover logic
+// add hover handlers to popup content?
+// special logic in close to wait before actually closing?
+
+.cdr-tooltip--wrapper {
+  position: relative;
+  width: max-content;
+  height: max-content;
+
+  .cdr-popup__content {
+    background: $cdr-color-background-tooltip-default;
+    color: $cdr-color-text-tooltip-default;
+    border: 1px solid $cdr-color-border-tooltip-default;
+    border-radius: $cdr-radius-softer;
+    @include cdr-text-utility-strong-100;
+    padding: $cdr-space-inset-three-quarter-x-squish;
+  }
+
+  // set arrow color on popup
+  .cdr-popup--down .cdr-popup__arrow {
+    &::before {
+      border-bottom-color: $cdr-color-border-tooltip-default;
+    }
+
+    &::after {
+      border-bottom-color: $cdr-color-background-tooltip-default;
+    }
+  }
+
+  .cdr-popup--up .cdr-popup__arrow {
+    &::before {
+      border-top-color: $cdr-color-border-tooltip-default;
+    }
+
+    &::after {
+      border-top-color: $cdr-color-background-tooltip-default;
+    }
+  }
+
+  .cdr-popup--right .cdr-popup__arrow {
+    &::before {
+      border-right-color: $cdr-color-border-tooltip-default;
+    }
+
+    &::after {
+      border-right-color: $cdr-color-background-tooltip-default;
+    }
+  }
+
+  .cdr-popup--left .cdr-popup__arrow {
+    &::before {
+      border-left-color: $cdr-color-border-tooltip-default;
+    }
+
+    &::after {
+      border-left-color: $cdr-color-background-tooltip-default;
+    }
+  }
+}

--- a/src/dev/router.js
+++ b/src/dev/router.js
@@ -39,6 +39,7 @@ const routes = [
   { path: '/lists', name: 'Lists', component: Examples.list },
   { path: '/modals', name: 'Modals', component: Examples.modal },
   { path: '/pagination', name: 'Pagination', component: Examples.pagination },
+  { path: '/popover', name: 'Popover', component: Examples.popover },
   { path: '/quotes', name: 'Quotes', component: Examples.quote },
   { path: '/radios', name: 'Radios', component: Examples.radio },
   { path: '/ratings', name: 'Ratings', component: Examples.rating },

--- a/src/dev/router.js
+++ b/src/dev/router.js
@@ -40,6 +40,7 @@ const routes = [
   { path: '/modals', name: 'Modals', component: Examples.modal },
   { path: '/pagination', name: 'Pagination', component: Examples.pagination },
   { path: '/popover', name: 'Popover', component: Examples.popover },
+  { path: '/tooltip', name: 'Tooltip', component: Examples.tooltip },
   { path: '/quotes', name: 'Quotes', component: Examples.quote },
   { path: '/radios', name: 'Radios', component: Examples.radio },
   { path: '/ratings', name: 'Ratings', component: Examples.rating },

--- a/src/index.js
+++ b/src/index.js
@@ -30,3 +30,4 @@ export { default as CdrTable } from './components/table/CdrTable';
 export { default as CdrTabPanel } from './components/tabs/CdrTabPanel';
 export { default as CdrTabs } from './components/tabs/CdrTabs';
 export { default as CdrText } from './components/text/CdrText';
+export { default as CdrTooltip } from './components/tooltip/CdrTooltip';

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export { default as CdrLink } from './components/link/CdrLink';
 export { default as CdrList } from './components/list/CdrList';
 export { default as CdrModal } from './components/modal/CdrModal';
 export { default as CdrPagination } from './components/pagination/CdrPagination';
+export { default as CdrPopover } from './components/popover/CdrPopover';
 export { default as CdrQuote } from './components/quote/CdrQuote';
 export { default as CdrRadio } from './components/radio/CdrRadio';
 export { default as CdrRating } from './components/rating/CdrRating';


### PR DESCRIPTION
This should be in a good state to merge this initial work in. Can always comment out the `export` if this isn't ready for summer release.

I think to implement the open/close animations, as well as fully support all the a11y reqs (ability to hover over an open tooltip, and setting aria-labelledby on the trigger pointing to an ID on the popover) will need to refactor this component a bit to make it so it's always rendered on the page but is simply hidden when it is not shown. 

