### PR TITLE
fix(form): fix input/select appearance on ios13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -13,10 +13,7 @@
   margin: 0;
 
   /* Prevent iOS from altering border and box-shadow */
-  @supports (-webkit-overflow-scrolling: touch) {
-    /* CSS specific to iOS devices */
-    -webkit-appearance: none;
-  }
+  -webkit-appearance: none;
 
   &[type=number]::-webkit-inner-spin-button,
   &[type=number]::-webkit-outer-spin-button {

--- a/src/components/select/styles/vars/CdrSelect.vars.scss
+++ b/src/components/select/styles/vars/CdrSelect.vars.scss
@@ -40,12 +40,6 @@
     display: none;
   }
 
-  /* Prevent iOS from altering border and box-shadow */
-  @supports (-webkit-overflow-scrolling: touch) {
-    /* CSS specific to iOS devices */
-    -webkit-appearance: none;
-  }
-
   &[disabled] {
     background-color: $cdr-color-background-input-default-disabled;
     color: $cdr-color-text-input-disabled;


### PR DESCRIPTION
- removes feature query from input so`webkit-appearance: none` is always set.
- select already sets `webkit-appearance: none` on page 35, so the feature query is not needed

bug seems to only occur in ios13. looks like they made `webkit-overflow-scrolling: touch` the default which might be why ipad is broken? https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes#Layout-and-Rendering

webkit-appearance just states whether or not to use native styling for elements, so seems like we'd always want that to be none 🤔  doesn't seem to have any impact cross browser