### PR TITLE
fix(card): fix image/border-radius clipping in card

### DIFF
--- a/src/components/card/styles/vars/CdrCard.vars.scss
+++ b/src/components/card/styles/vars/CdrCard.vars.scss
@@ -7,6 +7,7 @@
   width: 100%;
   transition: box-shadow $cdr-duration-2-x $cdr-timing-function-ease;
   cursor: pointer;
+  overflow: hidden;
 
   &:active, &:hover {
     box-shadow: $cdr-prominence-floating;


### PR DESCRIPTION
fixes the bug where the top left/right corners of a full width image inside a card would clip outside of the rounded border-radius.

overflow: hidden seems to make the most sense here, as a scrolling card would be very weird. But consumers can also override that attr if they really need that