### PR TITLE
feat(tabs): enable auto height for tabs

### DIFF
--- a/src/components/tabs/styles/CdrTabPanel.scss
+++ b/src/components/tabs/styles/CdrTabPanel.scss
@@ -1,7 +1,6 @@
 @import '../../../css/settings/index.scss';
 
 .cdr-tab-panel {
-  position: absolute;
   width: 100%;
   height: 100%;
   padding-top: $cdr-space-eighth-x;
@@ -12,7 +11,7 @@
     transform: translateX(0);
     opacity: 1;
   }
-  
+
   to {
     transform: translateX(-10px);
     opacity: 0;
@@ -87,4 +86,3 @@
   }
   @include cdr-tab-panel-animation;
 }
-


### PR DESCRIPTION
https://rei.slack.com/archives/CA58YCGN4/p1597868182318400

`position: absolute` doesn't actually do anything here since the element is width/height 100% anyways. removing it allows consumers to pass `height="auto"` to get CdrTabs with auto height rather than specifying a static height value.