### PR TITLE
fix(modal): make modal handle scroll-behavior: smooth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4453,21 +4453,13 @@
       "dev": true
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "dev": true
-        }
       }
     },
     "ajv": {
@@ -5756,27 +5748,27 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "83.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-83.0.1.tgz",
-      "integrity": "sha512-51/YsLIMRF+L0ooMlM4aZjyoOpDs0gDXGlT6+/CwWEnvK53PUyef9FkotKbzknCaUeL/qUw3ic3IMmsNc+SUxg==",
+      "version": "84.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-84.0.1.tgz",
+      "integrity": "sha512-iJ6Y680yp58+KlAPS5YgYe3oePVFf8jY5k4YoczhXkT0p/mQZKfGNkGG/Xc0LjGWDQRTgZwXg66hOXoApIQecg==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
         "axios": "^0.19.2",
         "del": "^5.1.0",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^2.2.4",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
         "mkdirp": "^1.0.4",
         "tcp-port-used": "^1.0.1"
       },
       "dependencies": {
         "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
           "dev": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "debug": "4"
           }
         },
         "extract-zip": {
@@ -5801,24 +5793,13 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
           "dev": true,
           "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "dev": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "mkdirp": {
@@ -12225,6 +12206,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
       "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "indexes-of": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "babel-plugin-istanbul": "^6.0.0",
     "backstopjs": "^5.0.4",
     "chalk": "^4.1.0",
-    "chromedriver": "^83.0.1",
+    "chromedriver": "^84.0.1",
     "codecov": "^3.7.2",
     "concat": "^1.0.3",
     "cross-env": "^7.0.2",

--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -176,6 +176,7 @@ export default {
       });
     },
     handleClosed() {
+      const { documentElement } = document;
       document.removeEventListener('keydown', this.keyHandler);
 
       this.unsubscribe = onTransitionEnd(
@@ -186,8 +187,11 @@ export default {
           this.unsubscribe = null;
           this.reallyClosed = true;
 
+          // handle scroll-behavior: smooth
+          if (documentElement) documentElement.style.scrollBehavior = 'auto';
           // restore previous scroll position
           window.scrollTo(this.offset.x, this.offset.y);
+          if (documentElement) documentElement.style.scrollBehavior = '';
 
           document.removeEventListener('focusin', this.focusHandler, true);
 


### PR DESCRIPTION
Reported in user-support: https://rei.slack.com/archives/CA58YCGN4/p1598378042017300

Smooth scroll basically makes it so `window.scrollTo` is animated rather than immediate. When the CdrModal is closed, it scrolls the user back to the position they were at before they opened the modal. When smooth scrolling is active the user is able to see the scrolling animation, whereas when it is off they cannot.

We use scroll-behavior: smooth on the doc-site, so you can actually repro it there currently: https://rei.github.io/rei-cedar-docs/components/modal/ (scroll down the page a bit, open the modal, then close it. you should see that page smoothly scroll back into place)
 

