### PR TITLE
feat(grid): add responsive options for xs breakpoint

### DIFF
--- a/src/components/grid/styles/CdrCol.scss
+++ b/src/components/grid/styles/CdrCol.scss
@@ -270,10 +270,206 @@ $colPct12: calc(12 / #{$rowColumns} * 100%);
   }
   */
 
+
+  /* COL EXTRA SMALL
+  ========================================================================== */
+
+  @include cdr-xs-mq-up {
+    &_span1\@xs {
+      flex-basis: $colPct1;
+      width: $colPct1;
+      max-width: $colPct1;
+    }
+
+    &_span2\@xs {
+      flex-basis: $colPct2;
+      width: $colPct2;
+      max-width: $colPct2;
+    }
+
+    &_span3\@xs {
+      flex-basis: $colPct3;
+      width: $colPct3;
+      max-width: $colPct3;
+    }
+
+    &_span4\@xs {
+      flex-basis: $colPct4;
+      width: $colPct4;
+      max-width: $colPct4;
+    }
+
+    &_span5\@xs {
+      flex-basis: $colPct5;
+      width: $colPct5;
+      max-width: $colPct5;
+    }
+
+    &_span6\@xs {
+      flex-basis: $colPct6;
+      width: $colPct6;
+      max-width: $colPct6;
+    }
+
+    &_span7\@xs {
+      flex-basis: $colPct7;
+      width: $colPct7;
+      max-width: $colPct7;
+    }
+
+    &_span8\@xs {
+      flex-basis: $colPct8;
+      width: $colPct8;
+      max-width: $colPct8;
+    }
+
+    &_span9\@xs {
+      flex-basis: $colPct9;
+      width: $colPct9;
+      max-width: $colPct9;
+    }
+
+    &_span10\@xs {
+      flex-basis: $colPct10;
+      width: $colPct10;
+      max-width: $colPct10;
+    }
+
+    &_span11\@xs {
+      flex-basis: $colPct11;
+      width: $colPct11;
+      max-width: $colPct11;
+    }
+
+    &_span12\@xs {
+      flex-basis: $colPct12;
+      width: $colPct12;
+      max-width: $colPct12;
+    }
+
+    /* Col small offsets
+    ========================================================================== */
+
+    &--offsetLeft0\@xs {
+      margin-left: 0;
+    }
+
+    &--offsetLeft1\@xs {
+      margin-left: $colPct1;
+    }
+
+    &--offsetLeft2\@xs {
+      margin-left: $colPct2;
+    }
+
+    &--offsetLeft3\@xs {
+      margin-left: $colPct3;
+    }
+
+    &--offsetLeft4\@xs {
+      margin-left: $colPct4;
+    }
+
+    &--offsetLeft5\@xs {
+      margin-left: $colPct5;
+    }
+
+    &--offsetLeft6\@xs {
+      margin-left: $colPct6;
+    }
+
+    &--offsetLeft7\@xs {
+      margin-left: $colPct7;
+    }
+
+    &--offsetLeft8\@xs {
+      margin-left: $colPct8;
+    }
+
+    &--offsetLeft9\@xs {
+      margin-left: $colPct9;
+    }
+
+    &--offsetLeft10\@xs {
+      margin-left: $colPct10;
+    }
+
+    &--offsetLeft11\@xs {
+      margin-left: $colPct11;
+    }
+
+    &--offsetRight0\@xs {
+      margin-right: 0;
+    }
+
+    &--offsetRight1\@xs {
+      margin-right: $colPct1;
+    }
+
+    &--offsetRight2\@xs {
+      margin-right: $colPct2;
+    }
+
+    &--offsetRight3\@xs {
+      margin-right: $colPct3;
+    }
+
+    &--offsetRight4\@xs {
+      margin-right: $colPct4;
+    }
+
+    &--offsetRight5\@xs {
+      margin-right: $colPct5;
+    }
+
+    &--offsetRight6\@xs {
+      margin-right: $colPct6;
+    }
+
+    &--offsetRight7\@xs {
+      margin-right: $colPct7;
+    }
+
+    &--offsetRight8\@xs {
+      margin-right: $colPct8;
+    }
+
+    &--offsetRight9\@xs {
+      margin-right: $colPct9;
+    }
+
+    &--offsetRight10\@xs {
+      margin-right: $colPct10;
+    }
+
+    &--offsetRight11\@xs {
+      margin-right: $colPct11;
+    }
+
+    /* Col small modifiers
+    ========================================================================== */
+
+    &--top\@xs {
+      align-self: flex-start;
+    }
+
+    &--middle\@xs {
+      align-self: center;
+    }
+
+    &--bottom\@xs {
+      align-self: flex-end;
+    }
+
+    &--stretch\@xs {
+      align-self: stretch;
+    }
+  }
+
   /* COL SMALL
   ========================================================================== */
 
-  @include cdr-sm-mq {
+  @include cdr-sm-mq-up {
     /* increase specificity to prevent cedar 1 from overriding */
     &.cdr-col {
       padding-top: $rowGutter-sm;
@@ -484,7 +680,7 @@ $colPct12: calc(12 / #{$rowColumns} * 100%);
   /* COL MEDIUM
   ========================================================================== */
 
-  @include cdr-md-mq {
+  @include cdr-md-mq-up {
     /* increase specificity to prevent cedar 1 from overriding */
     &.cdr-col {
       padding-top: $rowGutter-md;
@@ -695,7 +891,7 @@ $colPct12: calc(12 / #{$rowColumns} * 100%);
   /* COL LARGE
   ========================================================================== */
 
-  @include cdr-lg-mq {
+  @include cdr-lg-mq-up {
     /* increase specificity to prevent cedar 1 from overriding */
     &.cdr-col {
       padding-top: $rowGutter-lg;

--- a/src/components/grid/styles/CdrRow.scss
+++ b/src/components/grid/styles/CdrRow.scss
@@ -247,10 +247,208 @@ $rowPct12: calc(#{$rowColumns} / 12 / #{$rowColumns} * 100%);
     }
   }
 
+
+  /* ROW EXTRA SMALL
+  ========================================================================== */
+
+  @include cdr-xs-mq-up {
+    /* Row small elements
+    ========================================================================== */
+    &_row1\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct1;
+        width: $rowPct1;
+        max-width: $rowPct1;
+      }
+    }
+
+    &_row2\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct2;
+        width: $rowPct2;
+        max-width: $rowPct2;
+      }
+    }
+
+    &_row3\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct3;
+        width: $rowPct3;
+        max-width: $rowPct3;
+      }
+    }
+
+    &_row4\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct4;
+        width: $rowPct4;
+        max-width: $rowPct4;
+      }
+    }
+
+    &_row5\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct5;
+        width: $rowPct5;
+        max-width: $rowPct5;
+      }
+    }
+
+    &_row6\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct6;
+        width: $rowPct6;
+        max-width: $rowPct6;
+      }
+    }
+
+    &_row7\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct7;
+        width: $rowPct7;
+        max-width: $rowPct7;
+      }
+    }
+
+    &_row8\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct8;
+        width: $rowPct8;
+        max-width: $rowPct8;
+      }
+    }
+
+    &_row9\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct9;
+        width: $rowPct9;
+        max-width: $rowPct9;
+      }
+    }
+
+    &_row10\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct10;
+        width: $rowPct10;
+        max-width: $rowPct10;
+      }
+    }
+
+    &_row11\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct11;
+        width: $rowPct11;
+        max-width: $rowPct11;
+      }
+    }
+
+    &_row12\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex-basis: $rowPct12;
+        width: $rowPct12;
+        max-width: $rowPct12;
+      }
+    }
+
+    &_rowauto\@xs {
+      & > [class^="cdr-col"]:not([class*="cdr-col_span"]) {
+        flex: 0 0 auto;
+        width: auto;
+        max-width: none;
+      }
+    }
+
+    /* Row small modifiers
+    ========================================================================== */
+    &--gutter-none\@xs {
+      margin: 0 !important;
+
+      & > .cdr-col {
+        padding: 0 !important;
+      }
+    }
+
+    &--gutter-xxs\@xs {
+      margin-top: calc(#{$cdr-space-eighth-x} * -1) !important;
+      margin-left: calc(#{$cdr-space-eighth-x} * -1) !important;
+
+      & > .cdr-col {
+        padding-top: $cdr-space-eighth-x !important;
+        padding-left: $cdr-space-eighth-x !important;
+      }
+    }
+
+    &--nowrap\@xs {
+      flex-wrap: nowrap;
+      overflow: auto;
+
+      & > .cdr-col {
+        flex-shrink: 0;
+        flex-grow: 0;
+      }
+    }
+
+    &--wrap\@xs {
+      flex-wrap: wrap;
+
+      & > .cdr-col {
+        flex-shrink: 1;
+        flex-grow: 1;
+      }
+    }
+
+    &--left\@xs {
+      justify-content: flex-start;
+      align-self: flex-start;
+    }
+
+    &--center\@xs {
+      justify-content: center;
+    }
+
+    &--right\@xs {
+      justify-content: flex-end;
+      align-self: flex-end;
+    }
+
+    &--stretch\@xs {
+      align-items: stretch;
+    }
+
+    &--top\@xs {
+      align-items: flex-start;
+    }
+
+    &--middle\@xs {
+      align-items: center;
+    }
+
+    &--bottom\@xs {
+      align-items: flex-end;
+    }
+
+    &--vertical\@xs {
+      flex-direction: column;
+
+      & > .cdr-col,
+      & > .cdr-col[class*="cdr-col_span"] {
+        flex-basis: auto !important;
+      }
+    }
+
+    &--between\@xs {
+      justify-content: space-between;
+    }
+
+    &--around\@xs {
+      justify-content: space-around;
+    }
+  }
+
   /* ROW SMALL
   ========================================================================== */
 
-  @include cdr-sm-mq {
+  @include cdr-sm-mq-up {
     margin-top: calc(#{$rowGutter-sm} * -1);
     margin-left: calc(#{$rowGutter-sm} * -1);
 
@@ -450,7 +648,7 @@ $rowPct12: calc(#{$rowColumns} / 12 / #{$rowColumns} * 100%);
   /* ROW MEDIUM
   ========================================================================== */
 
-  @include cdr-md-mq {
+  @include cdr-md-mq-up {
     margin-top: calc(#{$rowGutter-md} * -1);
     margin-left: calc(#{$rowGutter-md} * -1);
 
@@ -652,7 +850,7 @@ $rowPct12: calc(#{$rowColumns} / 12 / #{$rowColumns} * 100%);
   /* ROW LARGE
   ========================================================================== */
 
-  @include cdr-lg-mq {
+  @include cdr-lg-mq-up {
     margin-top: calc(#{$rowGutter-lg} * -1);
     margin-left: calc(#{$rowGutter-lg} * -1);
 


### PR DESCRIPTION
- adds xs responsive options
- updates to new mq syntax

Could publish this as a minor version bump since it only adds functionality.

i think these media queries should technically be mq-only not mq-up, but that would be a big breaking change
`<cdr-row cols="6 12@sm">` currently turns into 6@xs, 12@sm/md/lg, whereas all of our other responsive options apply only at the specified breakpoints which would turn that into 6@xs/md/lg 12@sm. Might be worth assessing how many people are using the responsive aspects of grid and possibly making this consistent in a future release.

Like Grid, Image is also missing responsive props for XS and is using mq-up media queries, but it's a lil weird in that it applies the breakpoint classes via custom props and specifically calls out that it applies to mq-up: https://github.com/rei/rei-cedar/blob/next/src/components/image/CdrImg.jsx#L53-L79 
