### PR TITLE
Make build class handle empty space

### DIFF
--- a/src/mixins/buildClass.js
+++ b/src/mixins/buildClass.js
@@ -13,7 +13,7 @@ export default {
         checkBase = this.baseClass;
       }
       const base = checkBase;
-      let propArgsArr = this[prop] ? this[prop].split(' ') : [];
+      let propArgsArr = this[prop] ? this[prop].split(' ').filter(x => x) : [];
       let builtClasses = [];
 
       if (propNamePrefix) {

--- a/src/mixins/buildClass.js
+++ b/src/mixins/buildClass.js
@@ -13,7 +13,7 @@ export default {
         checkBase = this.baseClass;
       }
       const base = checkBase;
-      let propArgsArr = this[prop] ? this[prop].split(' ').filter(x => x) : [];
+      let propArgsArr = this[prop] ? this[prop].split(' ').filter((x) => x) : [];
       let builtClasses = [];
 
       if (propNamePrefix) {
@@ -23,13 +23,8 @@ export default {
         propArgsArr = propArgsArr.map((mod) => `${prop}${mod}`);
       }
 
-      if (!this.style) {
-        builtClasses = builtClasses
-          .concat(propArgsArr.map((mod) => this.modifyClassName(base, mod)));
-      } else {
-        builtClasses = builtClasses
-          .concat(propArgsArr.map((mod) => this.modifyClassName(base, mod)));
-      }
+      builtClasses = builtClasses
+        .concat(propArgsArr.map((mod) => this.modifyClassName(base, mod)));
 
       return builtClasses.join(' ');
     },


### PR DESCRIPTION
Noticed this bug while helping out landing-site team with an issue.

If you format a modifier with line breaks/spacing to avoid having a super long line:

```
<cdr-text modifier="
    heading-serif-500@xs
    heading-serif-600">
```

You end up with a bunch of empty class names like this:

<img width="429" alt="Screen Shot 2020-09-17 at 10 33 04 AM" src="https://user-images.githubusercontent.com/48567940/93506506-350b2e80-f8d1-11ea-8ba0-96f54f3399c9.png">

This just filters out the empty results of `split(' ')`. Also removes an if/else branch that has the exact same result either way (it looks like `modifyClassName` at some point was updated to contain the if/else logic)
