### PR TITLE
fix/improve placement logic for popup, add a11y hooks to popover and tooltip

### DIFF
--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -31,6 +31,10 @@ export default {
       type: String,
       required: false,
     },
+    id: {
+      type: String,
+      required: true,
+    },
   },
   data() {
     return {
@@ -42,6 +46,12 @@ export default {
   },
   mounted() {
     this.addHandlers();
+
+    const trigger = this.$refs.trigger.children[0];
+    if (trigger) {
+      this.$refs.trigger.children[0].setAttribute('aria-controls', this.id);
+      this.$refs.trigger.children[0].setAttribute('aria-haspopup', 'dialog');
+    }
   },
   methods: {
     openPopover() {
@@ -80,6 +90,8 @@ export default {
           autoPosition={ this.autoPosition }
           opened={ this.open }
           onClosed={ this.closePopover }
+          aria-expanded={ `${this.open}` }
+          id= { this.id }
         >
           <div class={this.style['cdr-popover__container']}>
             <div class={this.style['cdr-popover__content']}>

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -49,8 +49,8 @@ export default {
 
     const trigger = this.$refs.trigger.children[0];
     if (trigger) {
-      this.$refs.trigger.children[0].setAttribute('aria-controls', this.id);
-      this.$refs.trigger.children[0].setAttribute('aria-haspopup', 'dialog');
+      trigger.setAttribute('aria-controls', this.id);
+      trigger.setAttribute('aria-haspopup', 'dialog');
     }
   },
   methods: {

--- a/src/components/popover/__tests__/CdrPopover.spec.js
+++ b/src/components/popover/__tests__/CdrPopover.spec.js
@@ -1,9 +1,46 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import CdrPopover from 'componentdir/popover/CdrPopover';
 
 describe('CdrPopover', () => {
   it('matches snapshot', () => {
-    const wrapper = shallowMount(CdrPopover);
+    const wrapper = mount(CdrPopover, {
+      propsData: {
+        id: 'popover-test',
+      },
+      slots: {
+        trigger: '<button id="popover-trigger"></button>',
+        default: 'popover content',
+      }
+    });
     expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it('sets aria properties on trigger', () => {
+    const wrapper = mount(CdrPopover, {
+      propsData: {
+        id: 'popover-test',
+      },
+      slots: {
+        trigger: '<button id="popover-trigger"></button>'
+      }
+    });
+    expect(wrapper.find('#popover-trigger').attributes('aria-controls')).toBe('popover-test');
+  });
+
+  it('sets aria expanded on popup', async (done) => {
+    const wrapper = mount(CdrPopover, {
+      propsData: {
+        id: 'popover-test',
+      },
+      slots: {
+        trigger: '<button id="popover-trigger"></button>'
+      }
+    });
+    expect(wrapper.find('#popover-test').attributes('aria-expanded')).toBe('false');
+    wrapper.find('#popover-trigger').trigger('click');
+    wrapper.vm.$nextTick(() => {
+      expect(wrapper.find('#popover-test').attributes('aria-expanded')).toBe('true');
+      done();
+    });
   });
 });

--- a/src/components/popover/__tests__/__snapshots__/CdrPopover.spec.js.snap
+++ b/src/components/popover/__tests__/__snapshots__/CdrPopover.spec.js.snap
@@ -4,34 +4,52 @@ exports[`CdrPopover matches snapshot 1`] = `
 <div
   class="cdr-popover--wrapper"
 >
-  <div />
-  <cdr-popup-stub
-    autoposition="true"
-    position="up"
-    role="dialog"
+  <div>
+    <button
+      aria-controls="popover-test"
+      aria-haspopup="dialog"
+      id="popover-trigger"
+    />
+  </div>
+  <div
+    class="cdr-popup cdr-popup--closed"
   >
     <div
-      class="cdr-popover__container"
+      aria-expanded="false"
+      class="cdr-popup__content"
+      id="popover-test"
+      role="dialog"
     >
       <div
-        class="cdr-popover__content"
-      />
-      <cdr-button-stub
-        aria-label="Close"
-        class="cdr-popover__close-button"
-        icononly="true"
-        size="small"
-        space=""
-        tag="button"
-        type="button"
+        class="cdr-popover__container"
       >
-        <icon-x-sm-stub
-          inheritcolor="true"
-          size="medium"
-          space=""
-        />
-      </cdr-button-stub>
+        <div
+          class="cdr-popover__content"
+        >
+          popover content
+        </div>
+        <button
+          aria-label="Close"
+          class="cdr-button cdr-button--primary cdr-button--icon-only cdr-popover__close-button"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="cdr-icon cdr-icon--inherit-color"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13.406 12.006l3.297-3.296a1 1 0 10-1.414-1.414l-3.297 3.295-3.285-3.295A1 1 0 107.293 8.71l3.285 3.295-3.285 3.288a1 1 0 001.414 1.415l3.285-3.289 3.297 3.289a1 1 0 001.414-1.415l-3.297-3.287z"
+              role="presentation"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
-  </cdr-popup-stub>
+    <div
+      class="cdr-popup__arrow"
+    />
+  </div>
 </div>
 `;

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -79,6 +79,7 @@
       :auto-position="autoPos"
       :label="title"
       :class="containerClass"
+      id="popover-test"
     >
       <cdr-button
         :icon-only="true"

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -9,6 +9,11 @@
     position: relative;
     width: max-content;
     height: max-content;
+
+    // Override CdrPopup closed state for a11y
+    .cdr-popup--closed {
+      display: none;
+    }
   }
   &__title {
     @include cdr-text-heading-serif-400;

--- a/src/components/popup/CdrPopup.jsx
+++ b/src/components/popup/CdrPopup.jsx
@@ -102,7 +102,7 @@ export default {
     handleResize() {
       debounce(() => {
         this.measurePopup();
-      }, 300)
+      }, 300);
     },
     addHandlers() {
       this.keyHandler = this.handleKeyDown.bind(this);
@@ -115,7 +115,7 @@ export default {
       this.$nextTick(() => {
         this.popupRect = this.$refs.popup.getBoundingClientRect();
         this.closed = true;
-      })
+      });
     },
     calculatePlacement(triggerRect, popupRect, screenWidth, screenHeight) {
       const offset = 15; // 10px for arrow 5px for spacing
@@ -127,46 +127,57 @@ export default {
         down: screenHeight - triggerRect.bottom - popupRect.height - offset,
         left: triggerRect.left - popupRect.width - offset,
         right: screenWidth - triggerRect.right - popupRect.width - offset,
-      }
+      };
 
       const corners = {
         left: triggerCenterX - (popupRect.width / 2) < 0,
         right: triggerCenterX + (popupRect.width / 2) > screenWidth,
         top: triggerCenterY - (popupRect.height / 2) < 0,
         bottom: triggerCenterY + (popupRect.height / 2) > screenHeight,
-      }
+      };
 
       const invert = {
         up: 'down',
         down: 'up',
         left: 'right',
         right: 'left',
-      }
+      };
 
       const inverse = invert[this.position];
-      const validDirs = Object.keys(dirs).filter(dir => dirs[dir] > 0);
+      const validDirs = Object.keys(dirs).filter((dir) => dirs[dir] > 0);
       const sortedDirs = Object.keys(dirs).sort((a, b) => {
-        return dirs[a] > dirs[b] ? -1 : dirs[a] < dirs[b] ? 1 : 0;
+        if (dirs[a] > dirs[b]) {
+          return -1;
+        } if (dirs[a] < dirs[b]) {
+          return 1;
+        }
+        return 0;
       });
 
       if (dirs[this.position] > 0) {
         // selected position is valid, or no positions are valid
         this.pos = this.position;
-      } else if (dirs[inverse] > 0){
+      } else if (dirs[inverse] > 0) {
         // inverted position is valid
         this.pos = inverse;
-      } else if (validDirs.length){
+      } else if (validDirs.length) {
         // try the angles
-        this.pos = validDirs[0];
+        [this.pos] = validDirs;
       } else {
         // use whichever direction has the most space
-        this.pos = sortedDirs[0];
+        [this.pos] = sortedDirs;
       }
 
-      if (this.pos === 'down' || this.pos === 'up' ) {
-        this.corner = corners['left'] ? 'left' : corners['right'] ? 'right' : undefined;
-      } else {
-        this.corner = corners['top'] ? 'top' : corners['bottom'] ? 'bottom' : undefined;
+      if (this.pos === 'down' || this.pos === 'up') {
+        if (corners.left) {
+          this.corner = 'left';
+        } else if (corners.right) {
+          this.corner = 'right';
+        }
+      } else if (corners.top) {
+        this.corner = 'top';
+      } else if (corners.bottom) {
+        this.corner = 'bottom';
       }
     },
     handleOpened() {

--- a/src/components/popup/CdrPopup.jsx
+++ b/src/components/popup/CdrPopup.jsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import debounce from 'lodash-es/debounce';
 import style from './styles/CdrPopup.scss';
 import propValidator from '../../utils/propValidator';
 
@@ -29,20 +30,26 @@ export default {
       style,
       keyHandler: undefined,
       clickHandler: undefined,
+      resizeHandler: undefined,
       pos: this.position,
       corner: undefined,
       exiting: false,
+      popupRect: undefined,
+      closed: !this.opened,
     };
   },
   computed: {
     positionClass() {
-      return this.style[`cdr-popup--${this.pos}`];
+      return this.opened || this.exiting ? this.style[`cdr-popup--${this.pos}`] : undefined;
     },
     cornerClass() {
       return this.corner ? this.style[`cdr-popup--corner-${this.corner}`] : undefined;
     },
     openClass() {
       return this.opened ? this.style['cdr-popup--open'] : undefined;
+    },
+    closedClass() {
+      return this.closed ? this.style['cdr-popup--closed'] : undefined;
     },
     exitingClass() {
       return this.exiting ? this.style['cdr-popup--exit'] : undefined;
@@ -61,9 +68,16 @@ export default {
       }
     },
   },
+  mounted() {
+    this.measurePopup();
+
+    this.resizeHandler = this.handleResize.bind(this);
+    window.addEventListener('resize', this.resizeHandler);
+  },
   destroyed() {
     document.removeEventListener('keydown', this.keyHandler);
     document.removeEventListener('click', this.clickHandler);
+    window.removeEventListener('resize', this.resizeHandler);
   },
   methods: {
     closePopup(e) {
@@ -85,43 +99,87 @@ export default {
         }
       });
     },
+    handleResize() {
+      debounce(() => {
+        this.measurePopup();
+      }, 300)
+    },
     addHandlers() {
       this.keyHandler = this.handleKeyDown.bind(this);
       document.addEventListener('keydown', this.keyHandler);
       this.clickHandler = this.handleClick.bind(this);
       document.addEventListener('click', this.clickHandler);
     },
-    calculatePlacement() {
-      const rect = this.$refs.popup.getBoundingClientRect();
-      if (this.pos === 'down' && rect.bottom >= window.innerHeight) {
-        this.pos = 'up';
-      } else if (this.pos === 'up' && rect.top <= 0) {
-        this.pos = 'down';
-      } else if (this.pos === 'left' && rect.left <= 0) {
-        this.pos = 'right';
-      } else if (this.pos === 'right' && rect.right >= window.innerWidth) {
-        this.pos = 'left';
+    measurePopup() {
+      this.closed = false;
+      this.$nextTick(() => {
+        this.popupRect = this.$refs.popup.getBoundingClientRect();
+        this.closed = true;
+      })
+    },
+    calculatePlacement(triggerRect, popupRect, screenWidth, screenHeight) {
+      const offset = 15; // 10px for arrow 5px for spacing
+      const triggerCenterY = triggerRect.top + (triggerRect.height / 2);
+      const triggerCenterX = triggerRect.left + (triggerRect.width / 2);
+
+      const dirs = {
+        up: triggerRect.top - popupRect.height - offset,
+        down: screenHeight - triggerRect.bottom - popupRect.height - offset,
+        left: triggerRect.left - popupRect.width - offset,
+        right: screenWidth - triggerRect.right - popupRect.width - offset,
       }
 
-      const orientation = this.pos === 'down' || this.pos === 'up' ? 'vertical' : 'horizontal';
+      const corners = {
+        left: triggerCenterX - (popupRect.width / 2) < 0,
+        right: triggerCenterX + (popupRect.width / 2) > screenWidth,
+        top: triggerCenterY - (popupRect.height / 2) < 0,
+        bottom: triggerCenterY + (popupRect.height / 2) > screenHeight,
+      }
 
-      if (orientation === 'vertical' && rect.left <= 0) {
-        this.corner = 'left';
-      } else if (orientation === 'vertical' && rect.right >= window.innerWidth) {
-        this.corner = 'right';
-      } else if (orientation === 'horizontal' && rect.top <= 0) {
-        this.corner = 'top';
-      } else if (orientation === 'horizontal' && rect.bottom >= window.innerHeight) {
-        this.corner = 'bottom';
+      const invert = {
+        up: 'down',
+        down: 'up',
+        left: 'right',
+        right: 'left',
+      }
+
+      const inverse = invert[this.position];
+      const validDirs = Object.keys(dirs).filter(dir => dirs[dir] > 0);
+      const sortedDirs = Object.keys(dirs).sort((a, b) => {
+        return dirs[a] > dirs[b] ? -1 : dirs[a] < dirs[b] ? 1 : 0;
+      });
+
+      if (dirs[this.position] > 0) {
+        // selected position is valid, or no positions are valid
+        this.pos = this.position;
+      } else if (dirs[inverse] > 0){
+        // inverted position is valid
+        this.pos = inverse;
+      } else if (validDirs.length){
+        // try the angles
+        this.pos = validDirs[0];
+      } else {
+        // use whichever direction has the most space
+        this.pos = sortedDirs[0];
+      }
+
+      if (this.pos === 'down' || this.pos === 'up' ) {
+        this.corner = corners['left'] ? 'left' : corners['right'] ? 'right' : undefined;
+      } else {
+        this.corner = corners['top'] ? 'top' : corners['bottom'] ? 'bottom' : undefined;
       }
     },
     handleOpened() {
+      this.closed = false;
       this.pos = this.position;
       this.corner = undefined;
 
       if (this.autoPosition) {
         this.$nextTick(() => {
-          this.calculatePlacement();
+          const triggerRect = this.$el.parentElement.getBoundingClientRect();
+          const { popupRect } = this;
+          const { innerHeight, innerWidth } = window;
+          this.calculatePlacement(triggerRect, popupRect, innerWidth, innerHeight);
         });
       }
 
@@ -130,15 +188,13 @@ export default {
       }, 1);
     },
     handleClosed() {
+      this.closed = true;
       document.removeEventListener('keydown', this.keyHandler);
       document.removeEventListener('click', this.clickHandler);
       this.exiting = true;
-      // onTransitionEnd?
       setTimeout(() => {
         this.exiting = false;
       }, 200); // $cdr-duration-2;
-      // add animation exit class
-      // remove it after animation
     },
   },
   render() {
@@ -149,6 +205,7 @@ export default {
         this.exitingClass,
         this.positionClass,
         this.cornerClass,
+        this.closedClass,
       )}
       >
         <div

--- a/src/components/popup/__tests__/CdrPopup.spec.js
+++ b/src/components/popup/__tests__/CdrPopup.spec.js
@@ -6,4 +6,75 @@ describe('CdrPopup', () => {
     const wrapper = shallowMount(CdrPopup);
     expect(wrapper.element).toMatchSnapshot();
   });
+
+  describe('autoPosition', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = shallowMount(CdrPopup, {
+        propsData: {
+          position: 'up',
+          autoPosition: true,
+        }
+      });
+    });
+    it('Uses selected position if it is valid', () => {
+      wrapper.vm.calculatePlacement({
+        top: 90,
+        bottom: 95,
+        left: 45,
+        right: 55,
+        height: 5,
+        width: 10,
+      }, {
+        width: 100,
+        height: 50,
+      }, 100, 100);
+      expect(wrapper.vm.pos).toBe('up');
+    });
+
+    it('Uses inverted position if selected is invalid', () => {
+      wrapper.vm.calculatePlacement({
+        top: 5,
+        bottom: 10,
+        left: 45,
+        right: 55,
+        height: 5,
+        width: 10,
+      }, {
+        width: 200,
+        height: 50,
+      }, 100, 100);
+      expect(wrapper.vm.pos).toBe('down');
+    });
+
+    it('Uses angled position if selected and inverted is invalid', () => {
+      wrapper.vm.calculatePlacement({
+        top: 40,
+        bottom: 50,
+        left: 80,
+        right: 90,
+        height: 10,
+        width: 10,
+      }, {
+        width: 55,
+        height: 55,
+      }, 100, 100);
+      expect(wrapper.vm.pos).toBe('left');
+    });
+
+    it('Uses position with most space if all are invalid', () => {
+      wrapper.vm.calculatePlacement({
+        top: 45,
+        bottom: 55,
+        left: 30,
+        right: 40,
+        height: 10,
+        width: 10,
+      }, {
+        width: 45,
+        height: 50,
+      }, 100, 100);
+      expect(wrapper.vm.pos).toBe('right');
+    });
+  });
 });

--- a/src/components/popup/__tests__/__snapshots__/CdrPopup.spec.js.snap
+++ b/src/components/popup/__tests__/__snapshots__/CdrPopup.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrPopup matches snapshot 1`] = `
 <div
-  class="cdr-popup cdr-popup--up"
+  class="cdr-popup cdr-popup--closed"
 >
   <div
     class="cdr-popup__content"

--- a/src/components/popup/styles/CdrPopup.scss
+++ b/src/components/popup/styles/CdrPopup.scss
@@ -1,7 +1,7 @@
 @import '../../../css/settings/index.scss';
 
 $animation-transform: 10px;
-
+// TODO: if animating opacity only, replace keyframes with regular transition
 @keyframes :global(popup-exit-down) {
   from {
     // transform: translateY(0);
@@ -99,14 +99,16 @@ $arrow-spacing: #{$arrow-size + $cdr-space-quarter-x + 0.1rem};
 $content-spacing: calc(100% + #{$arrow-size} + #{$cdr-space-quarter-x});
 
 .cdr-popup {
-  display: none;
   opacity: 0;
   animation-duration: $cdr-duration-2-x;
   animation-timing-function: $cdr-timing-function-ease-out;
 
   &--open, &--exit {
     opacity: 1;
-    display: block;
+  }
+  
+  &--closed {
+    opacity: 0;
   }
 
   &__content {

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -21,6 +21,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    id: {
+      type: String,
+      required: true,
+    },
   },
   data() {
     return {
@@ -33,6 +37,8 @@ export default {
   },
   mounted() {
     this.addHandlers();
+    const trigger = this.$refs.trigger.children[0];
+    if (trigger) this.$refs.trigger.children[0].setAttribute('aria-describedby', this.id);
   },
   methods: {
     openTooltip() {
@@ -77,6 +83,7 @@ export default {
           position={ this.position }
           autoPosition={ this.autoPosition }
           opened={ this.open }
+          id={this.id}
         >
           { this.$slots.default }
         </cdr-popup>

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -38,7 +38,7 @@ export default {
   mounted() {
     this.addHandlers();
     const trigger = this.$refs.trigger.children[0];
-    if (trigger) this.$refs.trigger.children[0].setAttribute('aria-describedby', this.id);
+    if (trigger) trigger.setAttribute('aria-describedby', this.id);
   },
   methods: {
     openTooltip() {

--- a/src/components/tooltip/__tests__/CdrTooltip.spec.js
+++ b/src/components/tooltip/__tests__/CdrTooltip.spec.js
@@ -1,9 +1,29 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import CdrTooltip from 'componentdir/tooltip/CdrTooltip';
 
 describe('CdrTooltip', () => {
   it('matches snapshot', () => {
-    const wrapper = shallowMount(CdrTooltip);
+    const wrapper = mount(CdrTooltip, {
+      propsData: {
+        id: 'tooltip-test',
+      },
+      slots: {
+        trigger: '<button id="tooltip-trigger"></button>',
+        default: 'tooltip content',
+      }
+    });
     expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it('sets aria properties on trigger', () => {
+    const wrapper = mount(CdrTooltip, {
+      propsData: {
+        id: 'tooltip-test',
+      },
+      slots: {
+        trigger: '<button id="tooltip-trigger"></button>'
+      }
+    });
+    expect(wrapper.find('#tooltip-trigger').attributes('aria-describedby')).toBe('tooltip-test');
   });
 });

--- a/src/components/tooltip/__tests__/__snapshots__/CdrTooltip.spec.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/CdrTooltip.spec.js.snap
@@ -4,11 +4,25 @@ exports[`CdrTooltip matches snapshot 1`] = `
 <div
   class="cdr-tooltip--wrapper"
 >
-  <div />
-  <cdr-popup-stub
-    autoposition="true"
-    position="up"
-    role="tooltip"
-  />
+  <div>
+    <button
+      aria-describedby="tooltip-test"
+      id="tooltip-trigger"
+    />
+  </div>
+  <div
+    class="cdr-popup cdr-popup--closed"
+  >
+    <div
+      class="cdr-popup__content"
+      id="tooltip-test"
+      role="tooltip"
+    >
+      tooltip content
+    </div>
+    <div
+      class="cdr-popup__arrow"
+    />
+  </div>
 </div>
 `;

--- a/src/components/tooltip/examples/Tooltip.vue
+++ b/src/components/tooltip/examples/Tooltip.vue
@@ -61,6 +61,7 @@
       :position="position"
       :auto-position="autoPos"
       :class="containerClass"
+      id="tooltip-test"
     >
       <cdr-button slot="trigger">
         tooltip

--- a/src/components/tooltip/styles/CdrTooltip.scss
+++ b/src/components/tooltip/styles/CdrTooltip.scss
@@ -11,6 +11,10 @@ $cdr-color-text-tooltip-default: #f9f8f6;
   width: max-content;
   height: max-content;
 
+  .cdr-popup--closed {
+    @include cdr-display-sr-only;
+  }
+
   .cdr-popup__content {
     background: $cdr-color-background-tooltip-default;
     color: $cdr-color-text-tooltip-default;


### PR DESCRIPTION
- refactors placement logic: 
-- separates `calculatePlacement` function from `window` stuff so it can be tested 🎉 
-- on load the popup closed state is briefly removed to measure the popup
-- on opened the triggering element is measured
-- does a bunch of math with the popup and trigger rects to see where the popup can render without overflowing.
-- if no positions are possible without overflowing (weird edge case) will render in whichever direction has the most space

- tooltip/popover each individually override the `closed` state for the popup component (tooltip is sr-only, popover is display: none)
- tooltip accepts an `id` which is used to link up the `aria-describedby` on the trigger
- popover accepts an `id` to link up the `aria-controls` on the trigger element. toggles `aria-expanded` on the popup. adds `aria-haspopup` to the trigger element.

