### PR TITLE
switch min-width to max-width, allow overrides

### DIFF
--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -35,6 +35,10 @@ export default {
       type: String,
       required: true,
     },
+    contentClass: {
+      type: String,
+      required: false,
+    },
   },
   data() {
     return {
@@ -93,7 +97,8 @@ export default {
           opened={ this.open }
           onClosed={ this.closePopover }
           aria-expanded={ `${this.open}` }
-          id= { this.id }
+          id={ this.id }
+          contentClass={ this.contentClass }
         >
           <div class={this.style['cdr-popover__container']}>
             <div class={this.style['cdr-popover__content']}>

--- a/src/components/popover/__tests__/CdrPopover.spec.js
+++ b/src/components/popover/__tests__/CdrPopover.spec.js
@@ -69,4 +69,17 @@ describe('CdrPopover', () => {
       done();
     });
   });
+
+  it('binds contentClass to content', () => {
+    const wrapper = mount(CdrPopover, {
+      propsData: {
+        id: 'popover-test',
+        contentClass: 'popover-override',
+      },
+      slots: {
+        trigger: '<button id="popover-trigger"></button>'
+      }
+    });
+    expect(wrapper.find('.popover-override').exists()).toBe(true);
+  });
 });

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -79,6 +79,7 @@
       :auto-position="autoPos"
       :label="title"
       :class="containerClass"
+      contentClass="popover-override"
       id="popover-test"
       @opened="popupHandler"
       @closed="popupHandler"
@@ -129,6 +130,10 @@ export default {
 </script>
 
 <style>
+.popover-override {
+
+}
+
 .popover-container--center {
   margin: 0 auto;
 }

--- a/src/components/popup/CdrPopup.jsx
+++ b/src/components/popup/CdrPopup.jsx
@@ -24,6 +24,9 @@ export default {
       type: Boolean,
       default: true,
     },
+    contentClass: {
+      type: String,
+    },
   },
   data() {
     return {
@@ -221,7 +224,7 @@ export default {
       )}
       >
         <div
-          class={this.style['cdr-popup__content']}
+          class={clsx(this.style['cdr-popup__content'], this.contentClass)}
           ref="popup"
           {... { attrs: this.$attrs } }
         >

--- a/src/components/popup/styles/CdrPopup.scss
+++ b/src/components/popup/styles/CdrPopup.scss
@@ -19,7 +19,8 @@
     animation-fill-mode: forwards;
     background: $cdr-color-background-primary;
     border: 1px solid $cdr-color-border-secondary;
-    min-width: 286px;
+    max-width: 286px;
+    width: max-content;
     position: absolute;
     z-index: 100;
   }

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -25,6 +25,10 @@ export default {
       type: String,
       required: true,
     },
+    contentClass: {
+      type: String,
+      required: false,
+    },
   },
   data() {
     return {
@@ -80,6 +84,7 @@ export default {
         </div>
         <cdr-popup
           class={this.style['cdr-tooltip']}
+          contentClass={ this.contentClass }
           role="tooltip"
           ref="popup"
           position={ this.position }

--- a/src/components/tooltip/__tests__/CdrTooltip.spec.js
+++ b/src/components/tooltip/__tests__/CdrTooltip.spec.js
@@ -56,4 +56,17 @@ describe('CdrTooltip', () => {
     });
     expect(wrapper.find('#tooltip-trigger').attributes('aria-describedby')).toBe('tooltip-test');
   });
+
+  it('binds contentClass to content', () => {
+    const wrapper = mount(CdrTooltip, {
+      propsData: {
+        id: 'tooltip-test',
+        contentClass: 'tooltip-override',
+      },
+      slots: {
+        trigger: '<button id="tooltip-trigger"></button>'
+      }
+    });
+    expect(wrapper.find('.tooltip-override').exists()).toBe(true);
+  });
 });

--- a/src/components/tooltip/examples/Tooltip.vue
+++ b/src/components/tooltip/examples/Tooltip.vue
@@ -61,6 +61,7 @@
       :position="position"
       :auto-position="autoPos"
       :class="containerClass"
+      contentClass="tooltip-override"
       id="tooltip-test"
       @opened="tooltipHandler"
       @closed="tooltipHandler"
@@ -105,6 +106,9 @@ export default {
 </script>
 
 <style>
+
+.tooltip-override {
+}
 
 .tooltip-container--center {
   margin: 0 auto;


### PR DESCRIPTION
Im pretty sure the `min-width: 286px` bit was an artifact from the original adventures popover implementation. Was wiring up the tooltip to a forms POC and noticed it does this when the popup message is short

<img width="323" alt="Screen Shot 2020-09-23 at 3 13 38 PM" src="https://user-images.githubusercontent.com/48567940/94075099-62fbe180-fdaf-11ea-8d2f-80b6d18efe84.png">

Seems to make more sense for the popup to be as wide as it's content with a max-width.

max-width should also probably be changed to something in our space scale (256px would be `cdr-space-four-x` * 4)

Also updated popover/tooltip to accept a `contentClass` like modal does so they can override whatever default we set if needed.