### PR TITLE
feat(popup): emit opened/closed events when popup components change state

### DIFF
--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -54,18 +54,20 @@ export default {
     }
   },
   methods: {
-    openPopover() {
+    openPopover(e) {
       const { activeElement } = document;
 
       this.lastActive = activeElement;
       this.open = true;
+      this.$emit('opened', e);
       this.$nextTick(() => {
         const tabbables = tabbable(this.$refs.popup.$el);
         if (tabbables[0]) tabbables[0].focus();
       });
     },
-    closePopover() {
+    closePopover(e) {
       this.open = false;
+      this.$emit('closed', e);
       if (this.lastActive) this.lastActive.focus();
     },
     addHandlers() {

--- a/src/components/popover/__tests__/CdrPopover.spec.js
+++ b/src/components/popover/__tests__/CdrPopover.spec.js
@@ -15,6 +15,32 @@ describe('CdrPopover', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
+  it('emits event when opened', () => {
+    const wrapper = mount(CdrPopover, {
+      propsData: {
+        id: 'popover-test',
+      },
+      slots: {
+        trigger: '<button id="popover-trigger"></button>'
+      }
+    });
+    wrapper.vm.openPopover(true);
+    expect(wrapper.emitted('opened')).toBeTruthy();
+  });
+
+  it('emits event when closed', () => {
+    const wrapper = mount(CdrPopover, {
+      propsData: {
+        id: 'popover-test',
+      },
+      slots: {
+        trigger: '<button id="popover-trigger"></button>'
+      }
+    });
+    wrapper.vm.closePopover(true);
+    expect(wrapper.emitted('closed')).toBeTruthy();
+  });
+
   it('sets aria properties on trigger', () => {
     const wrapper = mount(CdrPopover, {
       propsData: {

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -80,6 +80,8 @@
       :label="title"
       :class="containerClass"
       id="popover-test"
+      @opened="popupHandler"
+      @closed="popupHandler"
     >
       <cdr-button
         :icon-only="true"
@@ -116,6 +118,11 @@ export default {
   computed: {
     containerClass() {
       return `popover-container--${this.trigger}`;
+    },
+  },
+  methods: {
+    popupHandler(e) {
+      console.log(e);
     },
   },
 };

--- a/src/components/popup/CdrPopup.jsx
+++ b/src/components/popup/CdrPopup.jsx
@@ -83,19 +83,19 @@ export default {
     closePopup(e) {
       this.$emit('closed', e);
     },
-    handleKeyDown({ key }) {
-      switch (key) {
+    handleKeyDown(e) {
+      switch (e.key) {
         case 'Escape':
         case 'Esc':
-          this.closePopup();
+          this.closePopup(e);
           break;
         default: break;
       }
     },
-    handleClick({ target }) {
+    handleClick(e) {
       this.$nextTick(() => {
-        if (target !== this.$refs.popup && !this.$refs.popup.contains(target)) {
-          this.closePopup();
+        if (e.target !== this.$refs.popup && !this.$refs.popup.contains(e.target)) {
+          this.closePopup(e);
         }
       });
     },

--- a/src/components/popup/__tests__/CdrPopup.spec.js
+++ b/src/components/popup/__tests__/CdrPopup.spec.js
@@ -76,5 +76,20 @@ describe('CdrPopup', () => {
       }, 100, 100);
       expect(wrapper.vm.pos).toBe('right');
     });
+
+    it('emits closed event on esc key press', () => {
+      wrapper.vm.handleKeyDown({ key: 'Esc' });
+      expect(wrapper.emitted('closed')).toBeTruthy();
+    });
+
+    it('emits closed event on click outside', async (done) => {
+      const randomElement = document.createElement('div');
+      document.body.appendChild(randomElement);
+      wrapper.vm.handleClick({ target: randomElement });
+      wrapper.vm.$nextTick(() => {
+        expect(wrapper.emitted('closed')).toBeTruthy();
+        done();
+      })
+    });
   });
 });

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -41,13 +41,15 @@ export default {
     if (trigger) trigger.setAttribute('aria-describedby', this.id);
   },
   methods: {
-    openTooltip() {
+    openTooltip(e) {
       if (this.timeout) clearTimeout(this.timeout);
       this.open = true;
+      this.$emit('opened', e);
     },
-    closeTooltip() {
+    closeTooltip(e) {
       this.timeout = setTimeout(() => {
         this.open = false;
+        this.$emit('closed', e);
       }, 250);
     },
     addHandlers() {
@@ -84,6 +86,7 @@ export default {
           autoPosition={ this.autoPosition }
           opened={ this.open }
           id={this.id}
+          onClosed={ this.closeTooltip }
         >
           { this.$slots.default }
         </cdr-popup>

--- a/src/components/tooltip/__tests__/CdrTooltip.spec.js
+++ b/src/components/tooltip/__tests__/CdrTooltip.spec.js
@@ -15,6 +15,36 @@ describe('CdrTooltip', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
+
+  it('emits event when opened', () => {
+    const wrapper = mount(CdrTooltip, {
+      propsData: {
+        id: 'tooltip-test',
+      },
+      slots: {
+        trigger: '<button id="tooltip-trigger"></button>'
+      }
+    });
+    wrapper.vm.openTooltip(true);
+    expect(wrapper.emitted('opened')).toBeTruthy();
+  });
+
+  it('emits event when closed', async (done) => {
+    const wrapper = mount(CdrTooltip, {
+      propsData: {
+        id: 'tooltip-test',
+      },
+      slots: {
+        trigger: '<button id="tooltip-trigger"></button>'
+      }
+    });
+    wrapper.vm.closeTooltip(true);
+    setTimeout(() => {
+      expect(wrapper.emitted('closed')).toBeTruthy();
+      done();
+    }, 251)
+  });
+
   it('sets aria properties on trigger', () => {
     const wrapper = mount(CdrTooltip, {
       propsData: {

--- a/src/components/tooltip/examples/Tooltip.vue
+++ b/src/components/tooltip/examples/Tooltip.vue
@@ -62,6 +62,8 @@
       :auto-position="autoPos"
       :class="containerClass"
       id="tooltip-test"
+      @opened="tooltipHandler"
+      @closed="tooltipHandler"
     >
       <cdr-button slot="trigger">
         tooltip
@@ -92,6 +94,11 @@ export default {
   computed: {
     containerClass() {
       return `tooltip-container--${this.trigger}`;
+    },
+  },
+  methods: {
+    tooltipHandler(e) {
+      console.log(e);
     },
   },
 };


### PR DESCRIPTION
makes popover/tooltip emit `opened`/`closed` events. Inevitably someone is going to want to fire a metric or etc. etc.