### PR TITLE
tab focus/underline alignment

### DIFF
--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -245,6 +245,7 @@ export default {
           vOn:click_prevent={(e) => this.handleClick(tab, e)}
           href={`#${tab.id}`}
           class={this.style['cdr-tabs__header-item-label']}
+          js-name={ tab.name }
         >
           { tab.name }
         </a>

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -78,7 +78,7 @@ export default {
       this.calculateOverflow();
       setTimeout(() => {
         this.updateUnderline();
-      }, 300);
+      }, 500);
     });
     // Check for header overflow on window resize for gradient behavior.
     window.addEventListener('resize', debounce(() => {

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -78,7 +78,7 @@ export default {
       this.calculateOverflow();
       setTimeout(() => {
         this.updateUnderline();
-      }, 250);
+      }, 300);
     });
     // Check for header overflow on window resize for gradient behavior.
     window.addEventListener('resize', debounce(() => {

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -152,7 +152,7 @@ export default {
       }
       this.activeTabIndex = newIndex;
       this.updateUnderline();
-      this.$refs.cdrTabsHeader.children[this.activeTabIndex].children[0].focus();
+      this.$refs.cdrTabsHeader.children[this.activeTabIndex].focus();
     },
     rightArrowNav: debounce(function handleRightArrow() {
       const nextTab = this.getNextTab(this.activeTabIndex + 1);
@@ -188,7 +188,7 @@ export default {
         const activeTab = elements[this.activeTabIndex];
         this.underlineOffsetX = activeTab.offsetLeft
           - this.$refs.cdrTabsHeader.parentElement.scrollLeft;
-        this.underlineWidth = activeTab.firstChild.offsetWidth;
+        this.underlineWidth = activeTab.offsetWidth;
 
         // mobile fix, hide the underline if it scrolls outside the container
         if (this.underlineOffsetX > this.$refs.cdrTabsContainer.offsetWidth) {
@@ -203,7 +203,7 @@ export default {
       }
     },
     setFocusToActiveTabHeader() {
-      this.$refs.cdrTabsHeader.children[this.activeTabIndex].children[0].focus();
+      this.$refs.cdrTabsHeader.children[this.activeTabIndex].focus();
     },
     getHeaderWidth() {
       let headerElements = [];
@@ -229,26 +229,32 @@ export default {
     },
     getTabEl(tab) {
       return tab.disabled ? (
-        <span
+        <button
           class={clsx(
-            this.style['cdr-tabs__header-item-label'],
-            this.style['cdr-tabs__header-item-label--disabled'],
+            this.style['cdr-tabs__header-item'],
+            this.style['cdr-tabs__header-item--disabled'],
           )}
-          aria-disabled="true"
-          aria-selected="false"
+          disabled
         >
           {tab.name}
-        </span>
+        </button>
       ) : (
-        <a
+        <button
+          role="tab"
+          aria-selected={tab.active}
+          aria-controls={tab.id}
+          id={tab.ariaLabelledby}
+          key={tab.id}
+          class={clsx(
+            tab.active ? this.style['cdr-tabs__header-item-active'] : '',
+            this.style['cdr-tabs__header-item'],
+          )}
           tabIndex={tab.active ? 0 : -1}
           vOn:click_prevent={(e) => this.handleClick(tab, e)}
-          href={`#${tab.id}`}
-          class={this.style['cdr-tabs__header-item-label']}
           js-name={ tab.name }
         >
           { tab.name }
-        </a>
+        </button>
       );
     },
   },
@@ -275,28 +281,13 @@ export default {
           <nav
             class={this.style['cdr-tabs__header-container']}
           >
-            <ol
+            <div
               class={this.style['cdr-tabs__header']}
               role="tablist"
               ref="cdrTabsHeader"
             >
-              {this.tabs.map((tab) => (
-                  <li
-                    role="tab"
-                    aria-selected={tab.active}
-                    aria-disabled="false"
-                    aria-controls={tab.id}
-                    id={tab.ariaLabelledby}
-                    key={tab.id}
-                    class={clsx(
-                      tab.active ? this.style['cdr-tabs__header-item-active'] : '',
-                      this.style['cdr-tabs__header-item'],
-                    )}
-                  >
-                    {this.getTabEl(tab)}
-                  </li>
-              ))}
-            </ol>
+              {this.tabs.map((tab) => this.getTabEl(tab))}
+            </div>
           </nav>
           <div class={clsx(
             this.style['cdr-tabs__gradient'],

--- a/src/components/tabs/CdrTabs.jsx
+++ b/src/components/tabs/CdrTabs.jsx
@@ -186,13 +186,20 @@ export default {
       const elements = Array.from(this.$refs.cdrTabsHeader.children);
       if (elements.length > 0) {
         const activeTab = elements[this.activeTabIndex];
-        this.underlineOffsetX = activeTab.offsetLeft
-          - this.$refs.cdrTabsHeader.parentElement.scrollLeft;
-        this.underlineWidth = activeTab.offsetWidth;
+        const activeRect = activeTab.getBoundingClientRect();
+        const parentRect = this.$refs.cdrTabsHeader.getBoundingClientRect();
+        const offset = activeRect.x - parentRect.x;
 
-        // mobile fix, hide the underline if it scrolls outside the container
-        if (this.underlineOffsetX > this.$refs.cdrTabsContainer.offsetWidth) {
-          this.underlineOffsetX = this.$refs.cdrTabsContainer.offsetWidth;
+        this.underlineOffsetX = offset
+          - this.$refs.cdrTabsHeader.parentElement.scrollLeft;
+        this.underlineWidth = activeRect.width;
+
+        // hide the underline if it scrolls outside the container
+        if (this.underlineOffsetX > parentRect.width) {
+          this.underlineOffsetX = parentRect.width;
+          this.underlineWidth = 0;
+        } else if (this.underlineOffsetX < 0) {
+          this.underlineOffsetX = 0;
           this.underlineWidth = 0;
         }
       }

--- a/src/components/tabs/__tests__/CdrTabs.spec.js
+++ b/src/components/tabs/__tests__/CdrTabs.spec.js
@@ -300,7 +300,6 @@ describe('CdrTabs', () => {
 
     expect(tab1.attributes()['aria-selected']).toBe('true');
     expect(tab1.attributes()['role']).toBe('tab');
-    expect(tab1.attributes()['aria-disabled']).toBe('false');
 
     // tablist role
     expect(wrapper.findComponent({ref: 'cdrTabsHeader'}).attributes()['role']).toBe('tablist');

--- a/src/components/tabs/__tests__/CdrTabs.spec.js
+++ b/src/components/tabs/__tests__/CdrTabs.spec.js
@@ -38,7 +38,7 @@ describe('CdrTabs', () => {
       expect(wrapper.element).toMatchSnapshot();
 
       expect(wrapper.vm.tabs.length).toBe(2);
-      expect(wrapper.findAll('li').length).toBe(2);
+      expect(wrapper.findAll('button').length).toBe(2);
       expect(wrapper.vm.activeTabIndex).toBe(1);
       setTimeout(() => { // for debounce
         expect(spyGetHeaderWidth).toHaveBeenCalled();
@@ -156,7 +156,7 @@ describe('CdrTabs', () => {
       });
 
       await wrapper.vm.$nextTick();
-      wrapper.findAll('a').at(1).trigger('click');
+      wrapper.findAll('button').at(1).trigger('click');
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.activeTabIndex).toBe(1);
     });
@@ -352,7 +352,7 @@ describe('CdrTabs', () => {
     await wrapper.vm.$nextTick();
     wrapper.vm.setFocusToActiveTabHeader();
     await wrapper.vm.$nextTick();
-    expect(wrapper.vm.$refs.cdrTabsHeader.children[wrapper.vm.activeTabIndex].children[0]).toBe(document.activeElement);
+    expect(wrapper.vm.$refs.cdrTabsHeader.children[wrapper.vm.activeTabIndex]).toBe(document.activeElement);
     wrapper.destroy();
   });
 

--- a/src/components/tabs/__tests__/__snapshots__/CdrTabs.spec.js.snap
+++ b/src/components/tabs/__tests__/__snapshots__/CdrTabs.spec.js.snap
@@ -53,7 +53,6 @@ exports[`CdrTabs mounted mounts with cdr-tab-panel children 1`] = `
       >
         <button
           aria-controls="tab-panel-1"
-          aria-disabled="false"
           class="cdr-tabs__header-item"
           id="tab-1"
           js-name="tab1"
@@ -64,7 +63,6 @@ exports[`CdrTabs mounted mounts with cdr-tab-panel children 1`] = `
         </button>
         <button
           aria-controls="tab-panel-2"
-          aria-disabled="false"
           aria-selected="true"
           class="cdr-tabs__header-item-active cdr-tabs__header-item"
           id="tab-2"

--- a/src/components/tabs/__tests__/__snapshots__/CdrTabs.spec.js.snap
+++ b/src/components/tabs/__tests__/__snapshots__/CdrTabs.spec.js.snap
@@ -14,7 +14,7 @@ exports[`CdrTabs mounted mounts tabs 1`] = `
     <nav
       class="cdr-tabs__header-container"
     >
-      <ol
+      <div
         class="cdr-tabs__header"
         role="tablist"
       />
@@ -47,42 +47,34 @@ exports[`CdrTabs mounted mounts with cdr-tab-panel children 1`] = `
     <nav
       class="cdr-tabs__header-container"
     >
-      <ol
+      <div
         class="cdr-tabs__header"
         role="tablist"
       >
-        <li
+        <button
           aria-controls="tab-panel-1"
           aria-disabled="false"
           class="cdr-tabs__header-item"
           id="tab-1"
+          js-name="tab1"
           role="tab"
+          tabindex="-1"
         >
-          <a
-            class="cdr-tabs__header-item-label"
-            href="#tab-panel-1"
-            tabindex="-1"
-          >
-            tab1
-          </a>
-        </li>
-        <li
+          tab1
+        </button>
+        <button
           aria-controls="tab-panel-2"
           aria-disabled="false"
           aria-selected="true"
           class="cdr-tabs__header-item-active cdr-tabs__header-item"
           id="tab-2"
+          js-name="tab2"
           role="tab"
+          tabindex="0"
         >
-          <a
-            class="cdr-tabs__header-item-label"
-            href="#tab-panel-2"
-            tabindex="0"
-          >
-            tab2
-          </a>
-        </li>
-      </ol>
+          tab2
+        </button>
+      </div>
     </nav>
     <div
       class="cdr-tabs__gradient cdr-tabs__gradient--right"

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -110,6 +110,16 @@
     color: inherit;
     font-weight: inherit;
 
+    // Prevent content from shifting when font-weight changes
+    &::before {
+      display: block;
+      content: attr(js-name);
+      font-weight: 500;
+      height: 0;
+      overflow: hidden;
+      visibility: hidden;
+    }
+
     &:active,
     &:hover,
     &:focus {

--- a/src/components/tabs/styles/CdrTabs.scss
+++ b/src/components/tabs/styles/CdrTabs.scss
@@ -81,34 +81,25 @@
     padding: 0;
     position: relative;
   }
-
   &__header-item {
-    display: block;
-    padding: 0;
-    color: $cdr-color-text-tab-rest;
-    font-weight: 300;
-
     & + & {
       margin-left: $cdr-space-one-x;
     }
-
-  }
-
-  &__header-item-active {
-    color: $cdr-color-text-tab-active;
-    font-weight: 500;
-  }
-
-  &__header-item-label {
     @include cdr-tabs-base-header-item-label;
-
+    border: none;
+    background-color: transparent;
     display: block;
+    color: $cdr-color-text-tab-rest;
+    font-weight: 300;
     text-decoration: none;
     padding: $cdr-space-inset-half-x-stretch;
     white-space: nowrap;
     outline-offset: -3px;
-    color: inherit;
-    font-weight: inherit;
+
+    &-active {
+      color: $cdr-color-text-tab-active;
+      font-weight: 500;
+    }
 
     // Prevent content from shifting when font-weight changes
     &::before {
@@ -128,6 +119,8 @@
     }
 
     &--disabled {
+      border: none;
+      background-color: transparent;
       color: $cdr-color-text-tab-disabled;
 
       &:active,
@@ -149,7 +142,6 @@
     box-sizing: border-box;
     border: none;
 
-    /* border: none; */
     background-color: $cdr-color-border-tab-keyline-active;
     transition: $cdr-duration-4-x $cdr-timing-function-ease-out;
   }


### PR DESCRIPTION
- adds an invisible ::before element to the tab headers containing a bolded copy of the header text to prevent content from shifting when bolded
- switches li/a structure to buttons
- uses getBoundingClientRect for underline measurement, offsetLeft/offsetWidth are integers and can cause the underline to be off by a pixel or two
- increases the underline timeout in mounted to ensure it renders properly
