### PR TITLE
move type inheritance logic out of reset and onto italic/strong

### DIFF
--- a/src/css/reset.scss
+++ b/src/css/reset.scss
@@ -102,13 +102,4 @@ h5.cdr-text,
 h6.cdr-text {
   @include cdr-text-default;
   margin: 0;
-
-  .cdr-text {
-    font-weight: inherit;
-    font-size: inherit;
-    line-height: inherit;
-    letter-spacing: inherit;
-    color: inherit;
-    font-family: inherit;
-  }
 }

--- a/src/css/utility/_text.scss
+++ b/src/css/utility/_text.scss
@@ -20,10 +20,21 @@ h6.cdr-text.cdr-text,
   &--italic {
     font-variation-settings: 'ital' 1;
     font-style: italic;
+    font-weight: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    font-family: inherit;
   }
 
   &--strong {
     font-weight: 700;
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    font-family: inherit;
   }
 
   &--body {


### PR DESCRIPTION
Since we only really need the font inheritance logic for italic/strong, just moves that logic into those classes. Backstop tests pass 100% when making this change.

This seems to cover our main use case for the cdr-text nesting/inheritance logic, which is someone highlighting a few words within a larger cdr-text element

Only 2 projects are using these modifiers so should have minimal impact if any.
https://git.rei.com/plugins/servlet/search?q=%22modifier%20strong%22
https://git.rei.com/plugins/servlet/search?q=%22modifier%20italic%22