### PR TITLE
replace fade on modal with scrollbar

### DIFF
--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -60,8 +60,6 @@ export default {
       offset: null,
       headerHeight: 0,
       totalHeight: 0,
-      scrollHeight: 0,
-      offsetHeight: 0,
       fullscreen: false,
     };
   },
@@ -89,9 +87,6 @@ export default {
       return this.totalHeight
         - this.headerHeight
         - this.verticalSpace;
-    },
-    scrolling() {
-      return this.scrollHeight > this.offsetHeight;
     },
   },
   watch: {
@@ -125,8 +120,6 @@ export default {
         this.totalHeight = window.innerHeight;
         this.fullscreen = window.innerWidth < CdrBreakpointSm;
         this.headerHeight = this.$refs.header.offsetHeight;
-        this.scrollHeight = this.$refs.content.scrollHeight;
-        this.offsetHeight = this.$refs.content.offsetHeight;
       });
     },
     handleKeyDown({ key }) {
@@ -344,13 +337,6 @@ export default {
                     >
                       {this.$slots.default}
                     </div>
-                    {
-                      this.scrolling && (
-                        <div
-                        class={this.style['cdr-modal__text-fade']}
-                      />
-                      )
-                    }
                   </div>
                 </div>
               </section>

--- a/src/components/modal/__tests__/CdrModal.spec.js
+++ b/src/components/modal/__tests__/CdrModal.spec.js
@@ -5,7 +5,7 @@ import Vue from 'vue';
 import CdrButton from 'componentdir/button/CdrButton';
 
 describe('CdrModal.vue', () => {
-  it('default open, scrolling', async () => {
+  it('default open', async () => {
     const elem = document.createElement('div')
     if (document.body) {
       document.body.appendChild(elem)
@@ -18,14 +18,10 @@ describe('CdrModal.vue', () => {
       slots: {
         default: 'Sticky content',
       },
-      computed: {
-        scrolling: () => true,
-      },
       attachTo: elem,
     });
 
     expect(wrapper.element).toMatchSnapshot();
-    expect(wrapper.find('.cdr-modal__text-fade').exists()).toBe(true);
 
     wrapper.setProps({ opened: false });
     await wrapper.vm.$nextTick();
@@ -105,7 +101,7 @@ describe('CdrModal.vue', () => {
     wrapper.destroy();
   });
 
-  it('scrolling and fullscreen snapshot', () => {
+  it('fullscreen snapshot', () => {
     const elem = document.createElement('div')
     if (document.body) {
       document.body.appendChild(elem)
@@ -118,8 +114,6 @@ describe('CdrModal.vue', () => {
       },
       data() {
         return {
-          offsetHeight: 400,
-          scrollHeight: 500,
           fullscreen: true,
         };
       },
@@ -132,7 +126,6 @@ describe('CdrModal.vue', () => {
       attachTo: elem,
     });
 
-    expect(wrapper.vm.scrolling).toBe(true);
     expect(wrapper.element).toMatchSnapshot();
     wrapper.destroy();
   });

--- a/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
+++ b/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CdrModal.vue default open, scrolling 1`] = `
+exports[`CdrModal.vue default open 1`] = `
 <div
   class="cdr-modal"
 >
@@ -70,8 +70,85 @@ exports[`CdrModal.vue default open, scrolling 1`] = `
               >
                 Sticky content
               </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    <div
+      tabindex="0"
+    />
+  </div>
+</div>
+`;
+
+exports[`CdrModal.vue fullscreen snapshot 1`] = `
+<div
+  class="cdr-modal"
+>
+  <div
+    class="cdr-modal__outerWrap"
+  >
+    <div
+      aria-hidden="true"
+      class="cdr-modal__overlay"
+    />
+    <div
+      tabindex="0"
+    />
+    <div
+      aria-label="Label is the modal title"
+      aria-modal="true"
+      class="cdr-modal__contentWrap cdr-modal__dialog"
+      role="dialog"
+      tabindex="-1"
+    >
+      <div
+        class="cdr-modal__innerWrap"
+      >
+        <section>
+          <div
+            class="cdr-modal__content"
+          >
+            <div
+              class="cdr-modal__header"
+            >
               <div
-                class="cdr-modal__text-fade"
+                class="cdr-modal__title"
+              >
+                <cdr-text-stub
+                  modifier="heading-serif-600"
+                  space=""
+                  tag="h1"
+                >
+                  Label is the modal title
+                </cdr-text-stub>
+              </div>
+              <cdr-button-stub
+                aria-label="Close"
+                class="cdr-modal__close-button"
+                icononly="true"
+                size="medium"
+                space=""
+                tag="button"
+                type="button"
+                withbackground="true"
+              >
+                <iconxlg-stub
+                  inheritcolor="true"
+                  size="medium"
+                  space=""
+                />
+              </cdr-button-stub>
+            </div>
+            <div
+              class="cdr-modal__text"
+              role="document"
+            >
+              <div
+                class="cdr-modal__text-content"
+                style="max-height: -32px;"
+                tabindex="0"
               />
             </div>
           </div>
@@ -156,89 +233,6 @@ exports[`CdrModal.vue leaves optional slots empty, handleOpened 1`] = `
               >
                 Main content
               </div>
-            </div>
-          </div>
-        </section>
-      </div>
-    </div>
-    <div
-      tabindex="0"
-    />
-  </div>
-</div>
-`;
-
-exports[`CdrModal.vue scrolling and fullscreen snapshot 1`] = `
-<div
-  class="cdr-modal"
->
-  <div
-    class="cdr-modal__outerWrap"
-  >
-    <div
-      aria-hidden="true"
-      class="cdr-modal__overlay"
-    />
-    <div
-      tabindex="0"
-    />
-    <div
-      aria-label="Label is the modal title"
-      aria-modal="true"
-      class="cdr-modal__contentWrap cdr-modal__dialog"
-      role="dialog"
-      tabindex="-1"
-    >
-      <div
-        class="cdr-modal__innerWrap"
-      >
-        <section>
-          <div
-            class="cdr-modal__content"
-          >
-            <div
-              class="cdr-modal__header"
-            >
-              <div
-                class="cdr-modal__title"
-              >
-                <cdr-text-stub
-                  modifier="heading-serif-600"
-                  space=""
-                  tag="h1"
-                >
-                  Label is the modal title
-                </cdr-text-stub>
-              </div>
-              <cdr-button-stub
-                aria-label="Close"
-                class="cdr-modal__close-button"
-                icononly="true"
-                size="medium"
-                space=""
-                tag="button"
-                type="button"
-                withbackground="true"
-              >
-                <iconxlg-stub
-                  inheritcolor="true"
-                  size="medium"
-                  space=""
-                />
-              </cdr-button-stub>
-            </div>
-            <div
-              class="cdr-modal__text"
-              role="document"
-            >
-              <div
-                class="cdr-modal__text-content"
-                style="max-height: -32px;"
-                tabindex="0"
-              />
-              <div
-                class="cdr-modal__text-fade"
-              />
             </div>
           </div>
         </section>

--- a/src/components/modal/styles/CdrModal.scss
+++ b/src/components/modal/styles/CdrModal.scss
@@ -94,23 +94,23 @@ $modal-animation-duration: 150ms;
   &__text {
     padding: 0;
     position: relative;
+
+    // https://davidwalsh.name/osx-overflow
+    ::-webkit-scrollbar {
+      -webkit-appearance: none;
+      width: 7px;
+    }
+    ::-webkit-scrollbar-thumb {
+      border-radius: 4px;
+      background-color: rgba(0, 0, 0, .5);
+      -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+    }
   }
 
   &__text-content {
     overflow: auto;
     padding-right: $cdr-space-one-and-a-half-x;
     position: relative;
-  }
-
-  &__text-fade {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    height: $cdr-space-two-x;
-    /* full transparency doesn't fly on safari */
-    background: linear-gradient(rgba(255,255,255,0.001), rgba(255,255,255,1));
-    background-attachment: scroll;
-    width: 100%;
   }
 
   @media (min-width: $cdr-breakpoint-sm) {

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -1,4 +1,5 @@
 import tabbable from 'tabbable';
+import clsx from 'clsx';
 import style from './styles/CdrPopover.scss';
 import propValidator from '../../utils/propValidator';
 import IconXSm from '../icon/comps/x-sm';
@@ -39,14 +40,28 @@ export default {
       type: String,
       required: false,
     },
+    open: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
   },
   data() {
     return {
       style,
-      open: false,
+      isOpen: false,
       openHandler: undefined,
       lastActive: undefined,
     };
+  },
+  watch: {
+    open() {
+      if (this.open) {
+        this.openPopover();
+      } else {
+        this.closePopover();
+      }
+    },
   },
   mounted() {
     this.addHandlers();
@@ -62,7 +77,7 @@ export default {
       const { activeElement } = document;
 
       this.lastActive = activeElement;
-      this.open = true;
+      this.isOpen = true;
       this.$emit('opened', e);
       this.$nextTick(() => {
         const tabbables = tabbable(this.$refs.popup.$el);
@@ -70,7 +85,7 @@ export default {
       });
     },
     closePopover(e) {
-      this.open = false;
+      this.isOpen = false;
       this.$emit('closed', e);
       if (this.lastActive) this.lastActive.focus();
     },
@@ -84,7 +99,10 @@ export default {
   },
   render() {
     return (
-      <div class={this.style['cdr-popover--wrapper']}>
+      <div class={clsx(
+        this.style['cdr-popover--wrapper'],
+        this.$slots.trigger ? this.style['cdr-popover--position'] : '',
+      )}>
         <div ref="trigger">
           { this.$slots.trigger }
         </div>
@@ -94,9 +112,9 @@ export default {
           ref="popup"
           position={ this.position }
           autoPosition={ this.autoPosition }
-          opened={ this.open }
+          opened={ this.isOpen }
           onClosed={ this.closePopover }
-          aria-expanded={ `${this.open}` }
+          aria-expanded={ `${this.isOpen}` }
           id={ this.id }
           contentClass={ this.contentClass }
         >

--- a/src/components/popover/__tests__/__snapshots__/CdrPopover.spec.js.snap
+++ b/src/components/popover/__tests__/__snapshots__/CdrPopover.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrPopover matches snapshot 1`] = `
 <div
-  class="cdr-popover--wrapper"
+  class="cdr-popover--wrapper cdr-popover--position"
 >
   <div>
     <button

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -95,6 +95,38 @@
         Thanks for stopping by. What a lovely day it is today. Please come back again soon.
       </cdr-text>
     </cdr-popover>
+
+    <hr>
+
+    <div style="clear: both" />
+    <div
+      style="position: relative; width: max-content;"
+      :class="containerClass"
+    >
+      <cdr-button
+        :icon-only="true"
+        aria-label="information"
+        @click="open = !open"
+        aria-controls="popover-custom-test"
+        aria-haspopup="dialog"
+      >
+        <icon-brand-rei-ice-axes />
+      </cdr-button>
+      <cdr-popover
+        :position="position"
+        :auto-position="autoPos"
+        :label="title"
+        :open="open"
+        content-class="popover-override"
+        id="popover-custom-test"
+        @opened="popupHandler"
+        @closed="popupHandler"
+      >
+        <cdr-text>
+          This is an example of a popover where the trigger is not passed into the component
+        </cdr-text>
+      </cdr-popover>
+    </div>
   </div>
 </template>
 

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -4,9 +4,10 @@
 @import '../../../css/settings/index.scss';
 
 .cdr-popover{
-
-  &--wrapper {
+  &--position {
     position: relative;
+  }
+  &--wrapper {
     width: max-content;
     height: max-content;
 

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -175,38 +175,38 @@
         </cdr-tab-panel>
 
         <cdr-tab-panel
-          name="six"
-          id="centered-six"
+          name="nine"
+          id="centered-nine"
         >
           <cdr-text
             tag="strong"
             modifier="subheading"
           >
-            Tab six Content
+            Tab nine Content
           </cdr-text>
         </cdr-tab-panel>
 
         <cdr-tab-panel
-          name="seven"
-          id="centered-seven"
+          name="ten"
+          id="centered-ten"
         >
           <cdr-text
             tag="strong"
             modifier="subheading"
           >
-            Tab seven Content
+            Tab ten Content
           </cdr-text>
         </cdr-tab-panel>
 
         <cdr-tab-panel
-          name="eight"
-          id="centered-eight"
+          name="eleven"
+          id="centered-eleven"
         >
           <cdr-text
             tag="strong"
             modifier="subheading"
           >
-            Tab eight Content
+            Tab eleven Content
           </cdr-text>
         </cdr-tab-panel>
       </cdr-tabs>

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import style from './styles/CdrTooltip.scss';
 import CdrPopup from '../popup/CdrPopup';
 import propValidator from '../../utils/propValidator';
@@ -29,15 +30,29 @@ export default {
       type: String,
       required: false,
     },
+    open: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
   },
   data() {
     return {
       style,
-      open: false,
+      isOpen: false,
       openHandler: undefined,
       closeHandler: undefined,
       timeout: undefined,
     };
+  },
+  watch: {
+    open() {
+      if (this.open) {
+        this.openTooltip();
+      } else {
+        this.closeTooltip();
+      }
+    },
   },
   mounted() {
     this.addHandlers();
@@ -47,12 +62,12 @@ export default {
   methods: {
     openTooltip(e) {
       if (this.timeout) clearTimeout(this.timeout);
-      this.open = true;
+      this.isOpen = true;
       this.$emit('opened', e);
     },
     closeTooltip(e) {
       this.timeout = setTimeout(() => {
-        this.open = false;
+        this.isOpen = false;
         this.$emit('closed', e);
       }, 250);
     },
@@ -76,9 +91,10 @@ export default {
   },
   render() {
     return (
-      <div
-        class={this.style['cdr-tooltip--wrapper']}
-      >
+      <div class={clsx(
+        this.style['cdr-tooltip--wrapper'],
+        this.$slots.trigger ? this.style['cdr-tooltip--position'] : '',
+      )}>
         <div ref="trigger">
           { this.$slots.trigger }
         </div>
@@ -89,7 +105,7 @@ export default {
           ref="popup"
           position={ this.position }
           autoPosition={ this.autoPosition }
-          opened={ this.open }
+          opened={ this.isOpen }
           id={this.id}
           onClosed={ this.closeTooltip }
         >

--- a/src/components/tooltip/__tests__/__snapshots__/CdrTooltip.spec.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/CdrTooltip.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrTooltip matches snapshot 1`] = `
 <div
-  class="cdr-tooltip--wrapper"
+  class="cdr-tooltip--wrapper cdr-tooltip--position"
 >
   <div>
     <button

--- a/src/components/tooltip/examples/Tooltip.vue
+++ b/src/components/tooltip/examples/Tooltip.vue
@@ -74,6 +74,38 @@
         We're using the internet right now!
       </div>
     </cdr-tooltip>
+
+    <hr>
+
+    <div
+      style="position: relative; width: max-content"
+      :class="containerClass"
+    >
+      <cdr-button
+        @mouseover="open = true"
+        @mouseleave="open = false"
+        @focus="open = true"
+        @blur="open = false"
+        aria-describedby="tooltip-custom-test"
+      >
+        tooltip with custom trigger
+      </cdr-button>
+      <cdr-tooltip
+        :position="position"
+        :auto-position="autoPos"
+        content-class="tooltip-override"
+        :open="open"
+        id="tooltip-custom-test"
+        @opened="tooltipHandler"
+        @closed="tooltipHandler"
+      >
+        <div>
+          Hello! This tooltip contains important information about the web site you are visiting!
+          We're using the internet right now!
+        </div>
+      </cdr-tooltip>
+
+    </div>
   </div>
 </template>
 
@@ -90,6 +122,7 @@ export default {
       position: 'top',
       autoPos: true,
       trigger: 'center',
+      open: false,
     };
   },
   computed: {

--- a/src/components/tooltip/styles/CdrTooltip.scss
+++ b/src/components/tooltip/styles/CdrTooltip.scss
@@ -1,9 +1,11 @@
 @import '../../../css/settings/index.scss';
 @import url('@rei/cedar/dist/style/cdr-popup.css');
 
+.cdr-tooltip--position {
+  position: relative;
+}
 
 .cdr-tooltip--wrapper {
-  position: relative;
   width: max-content;
   height: max-content;
 


### PR DESCRIPTION
https://trello.com/c/Sr2eZH4M/846-overlaying-a-filter-on-text-in-modal-and-tab-causes-text-to-fail-contrast-requirements

- replaces scrolling text fade logic on modal
- forces scrollbar to show on macos (using same CSS hack that CdrTabs is using for vertical scrolling)

The CdrTabs header horizontal scrolling will be more complicated to fix, but this seemed like an easy update
