### PR TITLE
Input round 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3888,9 +3888,9 @@
       }
     },
     "@rei/cdr-tokens": {
-      "version": "7.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-7.0.0-alpha.0.tgz",
-      "integrity": "sha512-8t8afY3U+NJiJZW4kDF0y91KFKJRfqAfhXoJshzvMLko2zOVtFeIHfv1H437T5WsDDbDm7uSlcDJj+bqwI4APA==",
+      "version": "7.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-7.0.0-alpha.1.tgz",
+      "integrity": "sha512-YdfAwWWRpUVqm8cTnE9T3OkvlDbWBK0qKt09T5aAwXxDcGCBqsnSyiadPTTKXNBJzj+s+qk8xv3sSA4jsQYWAQ==",
       "dev": true
     },
     "@rei/cedar-icons": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@betit/rollup-plugin-rename-extensions": "^0.1.0",
     "@commitlint/cli": "^9.1.2",
     "@commitlint/config-conventional": "^9.1.1",
-    "@rei/cdr-tokens": "^7.0.0-alpha.0",
+    "@rei/cdr-tokens": "^7.0.0-alpha.1",
     "@rei/cedar-icons": "^2.1.0",
     "@rollup/plugin-alias": "^3.1.1",
     "@vue/babel-preset-jsx": "^1.1.2",

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -196,7 +196,8 @@ export default {
     return (
       <div class={this.containerClass}>
         <div class={this.style['cdr-input-label-wrap']}>
-          {this.labelEl}<br/>
+          {this.labelEl}
+          {this.labelEl && this.$slots['helper-text-top'] && (<br/>)}
           { this.$slots['helper-text-top'] && (
             <span
               class={

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -86,6 +86,7 @@ export default {
   data() {
     return {
       style,
+      isFocused: false,
     };
   },
   computed: {
@@ -95,6 +96,12 @@ export default {
     },
     baseClass() {
       return 'cdr-input';
+    },
+    containerClass() {
+      return {
+        [this.style['cdr-input-container']]: true,
+        [this.style['cdr-input--focused']]: this.isFocused,
+      }
     },
     labelClass() {
       return {
@@ -119,6 +126,14 @@ export default {
         ...this.$listeners,
         input(event) {
           vm.$emit('input', event.target.value);
+        },
+        focus(event) {
+          vm.isFocused = true;
+          vm.$emit('focus', event);
+        },
+        blur(event) {
+          vm.isFocused = false;
+          vm.$emit('blur', event);
         },
       };
     },
@@ -191,8 +206,8 @@ export default {
   },
   render() {
     return (
-      <div class={this.style['cdr-input-container']}>
-        <div class={this.style['cdr-input-wrap']}>
+      <div class={this.containerClass}>
+        <div class={this.style['cdr-input-label-wrap']}>
           {this.labelEl}<br/>
           { this.$slots['helper-text'] && this.helperPosition === 'top' && (
             <span
@@ -212,14 +227,16 @@ export default {
           )}
         </div>
         <div class={this.style['cdr-input-wrap']}>
-          {this.inputEl}
-          {this.$slots['pre-icon'] && (
-            <span
-              class={this.style['cdr-input__pre-icon']}
-            >
-              {this.$slots['pre-icon']}
-            </span>
-          )}
+          <div class={this.style['cdr-input-inner-wrap']}>
+            {this.inputEl}
+            {this.$slots['pre-icon'] && (
+              <span
+                class={this.style['cdr-input__pre-icon']}
+              >
+                {this.$slots['pre-icon']}
+              </span>
+            )}
+          </div>
           {this.$slots['post-icon'] && (
             <span
               class={this.style['cdr-input__post-icon']}

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -89,7 +89,7 @@ export default {
     containerClass() {
       return {
         [this.style['cdr-input--focused']]: this.isFocused,
-      }
+      };
     },
     labelClass() {
       return {

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -102,6 +102,11 @@ export default {
         [this.style['cdr-input']]: true,
         [this.style['cdr-input--multiline']]: this.rows > 1,
         [this.style['cdr-input--preicon']]: this.$slots['pre-icon'],
+      };
+    },
+    wrapperClass() {
+      return {
+        [this.style['cdr-input-wrap']]: true,
         [this.style[`cdr-input--${this.background}`]]: true,
         [this.style['cdr-input--error']]: this.error,
       };
@@ -215,7 +220,7 @@ export default {
             </span>
           )}
         </div>
-        <div class={this.style['cdr-input-wrap']}>
+        <div class={this.wrapperClass}>
           <div class={this.style['cdr-input-inner-wrap']}>
             {this.inputEl}
             {this.$slots['pre-icon'] && (

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -51,17 +51,6 @@ export default {
      * Number of rows for input.  Converts component to text-area if rows greater than 1.
     */
     rows: Number,
-    /**
-     * Set whether helper text renders above or below the input element
-    */
-    helperPosition: {
-      type: [String],
-      default: 'bottom',
-      validator: (value) => propValidator(
-        value,
-        ['top', 'bottom'],
-      ),
-    },
     // Set which background type the input renders on
     background: {
       type: [String],
@@ -99,7 +88,6 @@ export default {
     },
     containerClass() {
       return {
-        [this.style['cdr-input-container']]: true,
         [this.style['cdr-input--focused']]: this.isFocused,
       }
     },
@@ -209,13 +197,13 @@ export default {
       <div class={this.containerClass}>
         <div class={this.style['cdr-input-label-wrap']}>
           {this.labelEl}<br/>
-          { this.$slots['helper-text'] && this.helperPosition === 'top' && (
+          { this.$slots['helper-text-top'] && (
             <span
               class={
                 clsx(this.style['cdr-input__helper-text'],
                   this.style['cdr-input__helper-text-top'])}
             >
-              {this.$slots['helper-text']}
+              {this.$slots['helper-text-top']}
             </span>
           )}
           {this.$slots.info && (
@@ -245,14 +233,15 @@ export default {
             </span>
           )}
         </div>
-        {this.$slots['helper-text'] && this.helperPosition === 'bottom' && !this.error && (
-          <span
-            class={
-              clsx(this.style['cdr-input__helper-text'],
-                this.style['cdr-input__helper-text-bottom'])}
-          >
-            {this.$slots['helper-text']}
-          </span>
+        {(this.$slots['helper-text'] || this.$slots['helper-text-bottom'])
+          && !this.error && !this.$slots.error && (
+            <span
+              class={
+                clsx(this.style['cdr-input__helper-text'],
+                  this.style['cdr-input__helper-text-bottom'])}
+            >
+              {this.$slots['helper-text'] || this.$slots['helper-text-bottom']}
+            </span>
         )}
         {this.$slots.error && this.error && (
           <span

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -294,7 +294,7 @@ describe('CdrInput', () => {
     expect(spy.called).toBeTruthy();
   });
 
-  it('renders helper-text slot', () => {
+  it('renders deprecated helper-text slot', () => {
     const wrapper = shallowMount(CdrInput, {
       propsData: {
         label: 'test',
@@ -306,14 +306,25 @@ describe('CdrInput', () => {
     expect(wrapper.find('.cdr-input__helper-text-bottom').text()).toBe('very helpful');
   });
 
-  it('renders helper-text slot in top position', () => {
+  it('renders helper-text-bottom slot', () => {
     const wrapper = shallowMount(CdrInput, {
       propsData: {
         label: 'test',
-        helperPosition: 'top'
       },
       slots: {
-        'helper-text': 'very helpful',
+        'helper-text-bottom': 'very helpful',
+      },
+    });
+    expect(wrapper.find('.cdr-input__helper-text-bottom').text()).toBe('very helpful');
+  });
+
+  it('renders helper-text-top slot', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      slots: {
+        'helper-text-top': 'very helpful',
       },
     });
     expect(wrapper.find('.cdr-input__helper-text-top').text()).toBe('very helpful');

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -330,6 +330,31 @@ describe('CdrInput', () => {
     expect(wrapper.find('.cdr-input__helper-text-top').text()).toBe('very helpful');
   });
 
+  it('renders break between label and helper-text-top if both are present', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      slots: {
+        'helper-text-top': 'very helpful',
+      },
+    });
+    expect(wrapper.find('br').exists()).toBe(true);
+  });
+
+  it('does not render break between label and helper-text-top if label is hidden', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+        hideLabel: true
+      },
+      slots: {
+        'helper-text-top': 'very helpful',
+      },
+    });
+    expect(wrapper.find('br').exists()).toBe(false);
+  });
+
   it('renders info slot', () => {
     const wrapper = shallowMount(CdrInput, {
       propsData: {

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -243,6 +243,25 @@ describe('CdrInput', () => {
     expect(spy.calledOnce).toBeTruthy();
   });
 
+  it('adds focused class to wrapper on input focus', async () => {
+    const spy = sinon.spy();
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      listeners: {
+        'focus': spy
+      }
+    });
+    const input = wrapper.findComponent({ ref: 'input' });
+    input.trigger('focus')
+    await wrapper.vm.$nextTick();
+    expect(wrapper.classes('cdr-input--focused')).toBeTruthy();
+    input.trigger('blur')
+    await wrapper.vm.$nextTick();
+    expect(wrapper.classes('cdr-input--focused')).toBeFalsy();
+  });
+
   it('emits a paste event', () => {
     const spy = sinon.spy();
     const wrapper = shallowMount(CdrInput, {

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CdrInput renders a label element 1`] = `
-<div>
+<div
+  class=""
+>
   <div
-    class="cdr-input-wrap"
+    class="cdr-input-label-wrap"
   >
     <label
       class="cdr-input__label"
@@ -16,19 +18,25 @@ exports[`CdrInput renders a label element 1`] = `
   <div
     class="cdr-input-wrap"
   >
-    <input
-      class="cdr-input cdr-input--primary"
-      id="1"
-      type="text"
-    />
+    <div
+      class="cdr-input-inner-wrap"
+    >
+      <input
+        class="cdr-input cdr-input--primary"
+        id="1"
+        type="text"
+      />
+    </div>
   </div>
 </div>
 `;
 
 exports[`CdrInput renders required label correctly 1`] = `
-<div>
+<div
+  class=""
+>
   <div
-    class="cdr-input-wrap"
+    class="cdr-input-label-wrap"
   >
     <label
       class="cdr-input__label"
@@ -47,12 +55,16 @@ exports[`CdrInput renders required label correctly 1`] = `
   <div
     class="cdr-input-wrap"
   >
-    <input
-      class="cdr-input cdr-input--primary"
-      id="3"
-      required="required"
-      type="text"
-    />
+    <div
+      class="cdr-input-inner-wrap"
+    >
+      <input
+        class="cdr-input cdr-input--primary"
+        id="3"
+        required="required"
+        type="text"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -15,13 +15,13 @@ exports[`CdrInput renders a label element 1`] = `
     </label>
   </div>
   <div
-    class="cdr-input-wrap"
+    class="cdr-input-wrap cdr-input--primary"
   >
     <div
       class="cdr-input-inner-wrap"
     >
       <input
-        class="cdr-input cdr-input--primary"
+        class="cdr-input"
         id="1"
         type="text"
       />
@@ -51,13 +51,13 @@ exports[`CdrInput renders required label correctly 1`] = `
     </label>
   </div>
   <div
-    class="cdr-input-wrap"
+    class="cdr-input-wrap cdr-input--primary"
   >
     <div
       class="cdr-input-inner-wrap"
     >
       <input
-        class="cdr-input cdr-input--primary"
+        class="cdr-input"
         id="3"
         required="required"
         type="text"

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -13,7 +13,6 @@ exports[`CdrInput renders a label element 1`] = `
     >
       Label Test
     </label>
-    <br />
   </div>
   <div
     class="cdr-input-wrap"
@@ -50,7 +49,6 @@ exports[`CdrInput renders required label correctly 1`] = `
         *
       </span>
     </label>
-    <br />
   </div>
   <div
     class="cdr-input-wrap"

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -116,15 +116,10 @@
         />
       </template>
       <template slot="post-icon">
-        <cdr-button
-          :icon-only="true"
-          class="cdr-input__button"
-        >
-          <cdr-icon
-            use="#check-lg"
-            inherit-color
-          />
-        </cdr-button>
+        <cdr-icon
+          use="#check-lg"
+          inherit-color
+        />
       </template>
       <template slot="helper-text">
         This is helper text. Input length: {{ requiredWithIcons.length }}
@@ -154,6 +149,7 @@
             <cdr-button
               :icon-only="true"
               slot="trigger"
+              aria-label="navigate"
             >
               <cdr-icon
                 use="#map"
@@ -166,6 +162,7 @@
           <cdr-button
             :icon-only="true"
             class="cdr-input__button"
+            aria-label="close"
           >
             <cdr-icon
               use="#x-lg"

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -150,7 +150,7 @@
           />
         </template>
         <template slot="post-icon">
-          <cdr-tooltip class="cdr-input__button">
+          <cdr-tooltip class="cdr-input__button" id="input-tooltip">
             <cdr-button
               :icon-only="true"
               slot="trigger"

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -96,7 +96,7 @@
       v-model="requiredWithIcons"
       id="required-with-icon"
       placeholder="Required with Icon"
-      label="Input Label"
+      label="Required with Icon"
       required
       type="email"
       :background="backgroundColor"
@@ -116,27 +116,76 @@
         />
       </template>
       <template slot="post-icon">
-        <cdr-icon
-          use="#check-lg"
-          inherit-color
-        />
+        <cdr-button
+          :icon-only="true"
+          class="cdr-input__button"
+        >
+          <cdr-icon
+            use="#check-lg"
+            inherit-color
+          />
+        </cdr-button>
       </template>
       <template slot="helper-text">
         This is helper text. Input length: {{ requiredWithIcons.length }}
       </template>
     </cdr-input>
 
+    <form>
+      <cdr-input
+        class="demo-input"
+        v-model="formWithButtons"
+        id="form-example"
+        placeholder="For testing icon/button placement with autofill"
+        label="Form with Two Buttons"
+        required
+        type="email"
+        autocomplete="username"
+        :background="backgroundColor"
+      >
+        <template slot="pre-icon">
+          <cdr-icon
+            use="#twitter"
+            inherit-color
+          />
+        </template>
+        <template slot="post-icon">
+          <cdr-tooltip class="cdr-input__button">
+            <cdr-button
+              :icon-only="true"
+              slot="trigger"
+            >
+              <cdr-icon
+                use="#map"
+                inherit-color
+              />
+            </cdr-button>
+
+            hey where am i?
+          </cdr-tooltip>
+          <cdr-button
+            :icon-only="true"
+            class="cdr-input__button"
+          >
+            <cdr-icon
+              use="#x-lg"
+              inherit-color
+            />
+          </cdr-button>
+        </template>
+      </cdr-input>
+    </form>
+
     <cdr-input
       class="demo-input"
       v-model="helperValidationModel"
-      helper-position="top"
       placeholder=""
       :error="helperValidationError"
       @blur="validate"
       label="Top helper with validation"
       :background="backgroundColor"
     >
-      <template slot="helper-text">
+      <template slot="helper-text-top">
         Must be 4 or less characters
       </template>
 
@@ -193,6 +242,9 @@
       With Icons Input Value = {{ requiredWithIcons }}
     </div>
     <div class="demo-input">
+      Form With Buttons Value = {{ formWithButtons }}
+    </div>
+    <div class="demo-input">
       Helper/Validation Input Value = {{ helperValidationModel }}
     </div>
     <div class="demo-input">
@@ -227,9 +279,18 @@ export default {
       requiredWithIcons: '',
       multiRowModel: '',
       sizeModel: '',
+      formWithButtons: '',
       masterModel: '',
       backgroundColor: 'primary',
     };
+  },
+  watch: {
+    $route(to) {
+      this.setBackground(to.query.background);
+    },
+  },
+  mounted() {
+    this.setBackground(this.$router.currentRoute.query.background);
   },
   methods: {
     validate() {
@@ -242,6 +303,7 @@ export default {
       this.optionalModel = value;
       this.hiddenModel = value;
       this.disabledModel = value;
+      this.formWithButtons = value;
       this.requiredWithIcons = value;
       this.helperValidationModel = value;
       this.multiRowModel = value;
@@ -259,14 +321,6 @@ export default {
           this.backgroundColor = 'primary';
       }
     },
-  },
-  watch: {
-    $route(to) {
-      this.setBackground(to.query.background);
-    },
-  },
-  mounted() {
-    this.setBackground(this.$router.currentRoute.query.background);
   },
 };
 </script>

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -134,7 +134,7 @@
   }
 
   &__optional-label {
-    @include cdr-input-required-label-mixin;
+    @include cdr-input-optional-label-mixin;
   }
 
   &__info-container {

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -49,6 +49,7 @@
   }
 
   &:last-child {
+    margin-right: -$cdr-space-half-x;
     border-top-right-radius: $cdr-radius-softer;
     border-bottom-right-radius: $cdr-radius-softer;
   }
@@ -143,6 +144,10 @@
 
   &__post-icon {
     display: block;
+    position: absolute;
+    top: 50%;
+    right: $cdr-space-half-x;
+    transform: translateY(-50%);
   }
 
   &__required-label {

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -13,6 +13,47 @@
   }
 }
 
+:global(.cdr-input__button) {
+  fill: inherit;
+  & ~ & {
+    position: relative;
+    margin-left: -4px; // TODO: why is ther ea space there?
+    &::before {
+      content: '';
+      background-color: $cdr-color-border-input-default;
+      position: absolute;
+      left: -1px;
+      width: 1px;
+      height: 55%;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+
+  &:hover,
+  &:active,
+  &:focus,
+  &:focus-within {
+    background-color: $cdr-color-background-input-default-selected;
+    box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
+    outline: none;
+    fill: $cdr-color-text-primary;
+    svg {
+      box-shadow: none;
+      fill: $cdr-color-text-primary !important;
+    }
+
+    &::before {
+      width: 0px;
+    }
+  }
+
+  &:last-child {
+    border-top-right-radius: $cdr-radius-softer;
+    border-bottom-right-radius: $cdr-radius-softer;
+  }
+}
+
 /* ==========================================================================
   # INPUT
   ========================================================================== */
@@ -50,16 +91,13 @@
     }
   }
 
-  &--has-buttons {
-    box-shadow: none;
-  }
-
   &--error {
     background-color: $cdr-color-background-input-error;
     box-shadow: inset 0 0 0 1px $cdr-color-border-input-error;
   }
 
   &__error-message {
+    margin-top: $cdr-space-quarter-x;
     // TODO: use token once fixed
     color: #B33322;//$cdr-color-text-input-error;
     fill: #B33322;//$cdr-color-text-input-error;
@@ -118,15 +156,15 @@
     top: 50%;
     left: $cdr-space-half-x;
     transform: translateY(-50%);
-    fill: $cdr-color-icon-default;
   }
 
   &__post-icon {
-    fill: $cdr-color-icon-default;
-    position: absolute;
-    top: 50%;
-    right: $cdr-space-half-x;
-    transform: translateY(-50%);
+  //   // CENTER ALIGN ME
+  //   // position: absolute;
+  //   // top: 50%;
+  //   // right: 0;//$cdr-space-half-x;
+  //   // transform: translateY(-50%);
+  // nothing?
   }
 
   &__required-label {
@@ -158,7 +196,31 @@
    # INPUT WRAPPER
    ========================================================================== */
 
-/* related to positioning/layout? */
+.cdr-input-label-wrap {
+  position: relative;
+}
+
+// real cedar input wrapper
+.cdr-input-inner-wrap {
+  position: relative;
+  flex-grow: 1
+}
+
 .cdr-input-wrap {
   position: relative;
+  border: 1px solid $cdr-color-border-input-default;
+  border-radius: $cdr-radius-softer;
+  fill: $cdr-color-icon-default;
+  display: flex;
+}
+
+.cdr-input--focused .cdr-input-wrap {
+  border: 1px solid $cdr-color-border-input-default-active;
+  // TODO: rename hover to active?
+  background-color: $cdr-color-background-input-default-hover;
+  box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
+  svg {
+    // TODO: token?
+    fill: $cdr-color-text-primary;
+  }
 }

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -185,7 +185,7 @@
   }
 
   &__helper-text-top {
-    margin-bottom: $cdr-space-quarter-x;
+    margin-top: $cdr-space-eighth-x;
   }
 
   &__helper-text-bottom {
@@ -209,14 +209,14 @@
 
 .cdr-input-wrap {
   position: relative;
-  border: 1px solid $cdr-color-border-input-default;
+  box-shadow: inset 0 0 0 1px $cdr-color-border-input-default;
   border-radius: $cdr-radius-softer;
   fill: $cdr-color-icon-default;
   display: flex;
+  margin-top: $cdr-space-half-x;
 }
 
 .cdr-input--focused .cdr-input-wrap {
-  border: 1px solid $cdr-color-border-input-default-active;
   // TODO: rename hover to active?
   background-color: $cdr-color-background-input-default-hover;
   box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -164,7 +164,8 @@
   //   // top: 50%;
   //   // right: 0;//$cdr-space-half-x;
   //   // transform: translateY(-50%);
-  // nothing?
+  // necessary????
+    display: block;
   }
 
   &__required-label {

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -17,7 +17,7 @@
   fill: inherit;
   & ~ & {
     position: relative;
-    margin-left: -4px; // TODO: why is ther ea space there?
+    margin-left: -4px;
     &::before {
       content: '';
       background-color: $cdr-color-border-input-default;
@@ -59,7 +59,7 @@
   ========================================================================== */
 
 .cdr-input {
-  @include cdr-input-base-mixin;
+  @include cdr-input-core-mixin;
 
   /* Style variants
     ========================================================================== */
@@ -75,34 +75,17 @@
     padding-left: calc(#{$cdr-space-half-x} + #{$cdr-space-quarter-x} + 25px);
   }
 
-// TODO: merge with variables (clean up variables?)  //
   &--primary {
-    background-color: $cdr-color-background-input-default;
-    &:active,
-    &:focus {
-      background-color: $cdr-color-background-input-default;
-    }
+    @include cdr-input-primary-mixin;
   }
+
   &--secondary {
-    background-color: $cdr-color-background-input-secondary;
-    &:active,
-    &:focus {
-      background-color: $cdr-color-background-input-secondary-selected;
-    }
+    @include cdr-input-secondary-mixin;
   }
 
   &--error {
-    background-color: $cdr-color-background-input-error;
-    box-shadow: inset 0 0 0 1px $cdr-color-border-input-error;
+    @include cdr-input-error-mixin;
   }
-
-  &__error-message {
-    margin-top: $cdr-space-quarter-x;
-    // TODO: use token once fixed
-    color: #B33322;//$cdr-color-text-input-error;
-    fill: #B33322;//$cdr-color-text-input-error;
-  }
-
 
   /* Size variants
     ========================================================================== */
@@ -159,29 +142,28 @@
   }
 
   &__post-icon {
-  //   // CENTER ALIGN ME
-  //   // position: absolute;
-  //   // top: 50%;
-  //   // right: 0;//$cdr-space-half-x;
-  //   // transform: translateY(-50%);
-  // necessary????
     display: block;
   }
 
   &__required-label {
-    @include cdr-input-required-label-mixin;
+    margin-left: $cdr-space-inset-quarter-x;
   }
 
   &__optional-label {
     @include cdr-input-optional-label-mixin;
+    margin-left: $cdr-space-inset-quarter-x;
   }
 
   &__info-container {
     @include cdr-input-info-container-mixin;
+    position: absolute;
+    right: 0;
+    bottom: 0;
   }
 
   &__helper-text {
     @include cdr-input-helper-text-mixin;
+    display: inline-block;
   }
 
   &__helper-text-top {
@@ -190,6 +172,11 @@
 
   &__helper-text-bottom {
     margin-top: $cdr-space-quarter-x;
+  }
+
+  &__error-message {
+    margin-top: $cdr-space-quarter-x;
+    @include cdr-input-error-message-mixin;
   }
 }
 
@@ -209,19 +196,10 @@
 
 .cdr-input-wrap {
   position: relative;
-  box-shadow: inset 0 0 0 1px $cdr-color-border-input-default;
-  border-radius: $cdr-radius-softer;
-  fill: $cdr-color-icon-default;
   display: flex;
-  margin-top: $cdr-space-half-x;
+  @include cdr-input-outline-mixin;
 }
 
 .cdr-input--focused .cdr-input-wrap {
-  // TODO: rename hover to active?
-  background-color: $cdr-color-background-input-default-hover;
-  box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
-  svg {
-    // TODO: token?
-    fill: $cdr-color-text-primary;
-  }
+  @include cdr-input-focus-mixin;
 }

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -34,7 +34,7 @@
   &:active,
   &:focus,
   &:focus-within {
-    background-color: $cdr-color-background-input-default-selected;
+    background-color: $cdr-color-background-input-default-active;
     box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
     outline: none;
     fill: $cdr-color-text-primary;

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -64,20 +64,11 @@
   margin-top: $cdr-space-half-x;
 }
 
-@mixin cdr-input-focus-mixin() {
-  background-color: $cdr-color-background-input-default-hover; // $cdr-color-background-input-default-active TODO:
-  box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
-  svg {
-    // TODO: token?
-    fill: $cdr-color-text-primary;
-  }
-}
-
 @mixin cdr-input-primary-mixin() {
   background-color: $cdr-color-background-input-default;
   &:active,
   &:focus {
-    background-color: $cdr-color-background-input-default;
+    background-color: $cdr-color-background-input-default-active;
   }
 }
 
@@ -85,7 +76,15 @@
   background-color: $cdr-color-background-input-secondary;
   &:active,
   &:focus {
-    background-color: $cdr-color-background-input-secondary-selected;
+    background-color: $cdr-color-background-input-secondary-active;
+  }
+}
+
+@mixin cdr-input-focus-mixin() {
+  box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
+  svg {
+    // TODO: token?
+    fill: $cdr-color-text-primary;
   }
 }
 

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -1,4 +1,13 @@
+// base mixin used for component variables only
 @mixin cdr-input-base-mixin() {
+  @include cdr-input-core-mixin;
+  @include cdr-input-outline-mixin;
+  &:focus {
+    @include cdr-input-focus-mixin;
+  }
+}
+
+@mixin cdr-input-core-mixin() {
   @include cdr-text-utility-sans-300;
   background-color: $cdr-color-background-input-default;
   color: $cdr-color-text-input-default;
@@ -48,6 +57,49 @@
   }
 }
 
+@mixin cdr-input-outline-mixin() {
+  box-shadow: inset 0 0 0 1px $cdr-color-border-input-default;
+  border-radius: $cdr-radius-softer;
+  fill: $cdr-color-icon-default;
+  margin-top: $cdr-space-half-x;
+}
+
+@mixin cdr-input-focus-mixin() {
+  background-color: $cdr-color-background-input-default-hover; // $cdr-color-background-input-default-active TODO:
+  box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
+  svg {
+    // TODO: token?
+    fill: $cdr-color-text-primary;
+  }
+}
+
+@mixin cdr-input-primary-mixin() {
+  background-color: $cdr-color-background-input-default;
+  &:active,
+  &:focus {
+    background-color: $cdr-color-background-input-default;
+  }
+}
+
+@mixin cdr-input-secondary-mixin() {
+  background-color: $cdr-color-background-input-secondary;
+  &:active,
+  &:focus {
+    background-color: $cdr-color-background-input-secondary-selected;
+  }
+}
+
+@mixin cdr-input-error-mixin() {
+  background-color: $cdr-color-background-input-error;
+  box-shadow: inset 0 0 0 1px $cdr-color-border-input-error;
+}
+
+@mixin cdr-input-error-message-mixin() {
+  // TODO: use token once fixed
+  color: #B33322;//$cdr-color-text-input-error;
+  fill: #B33322;//$cdr-color-text-input-error;
+}
+
 @mixin cdr-input-base-label-mixin() {
   @include cdr-text-utility-sans-200;
   font-weight: 600;
@@ -67,26 +119,21 @@
 }
 
 @mixin cdr-input-helper-text-mixin() {
-  // TODO: possible custom font token
   font-family: $cdr-font-family-sans;
   font-size: 1.4rem;
   line-height: 1.8rem;
   letter-spacing: -0.016rem;
   color: $cdr-color-text-input-help;
-  display: inline-block;
 }
 
 @mixin cdr-input-info-container-mixin() {
   @include cdr-text-utility-sans-200;
-  position: absolute;
-  right: 0;
 }
 
 @mixin cdr-input-required-label-mixin() {
-  margin-left: $cdr-space-inset-quarter-x;
+  color: $cdr-color-text-input-label;
 }
 
 @mixin cdr-input-optional-label-mixin() {
   color: $cdr-color-text-input-optional;
-  margin-left: $cdr-space-inset-quarter-x;
 }

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -95,7 +95,6 @@
 }
 
 @mixin cdr-input-optional-label-mixin() {
-  // TODO: add -optional token? update $cdr-color-text-input-required
-  color: $cdr-color-text-input-secondary;
+  color: $cdr-color-text-input-optional;
   margin-left: $cdr-space-inset-quarter-x;
 }

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -54,8 +54,6 @@
   color: $cdr-color-text-input-label;
   display: inline-block;
   margin: 0;
-  margin-bottom: $cdr-space-quarter-x;
-  margin-right: $cdr-space-inset-quarter-x;
 }
 
 @mixin cdr-input-large-mixin() {
@@ -80,10 +78,8 @@
 
 @mixin cdr-input-info-container-mixin() {
   @include cdr-text-utility-sans-200;
-
   position: absolute;
   right: 0;
-  bottom: $cdr-space-quarter-x;
 }
 
 @mixin cdr-input-required-label-mixin() {

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -2,9 +2,7 @@
   @include cdr-text-utility-sans-300;
   background-color: $cdr-color-background-input-default;
   color: $cdr-color-text-input-default;
-  box-shadow: inset 0 0 0 1px $cdr-color-border-input-default;
   border: 0;
-  border-radius: $cdr-radius-softer;
   padding: $cdr-space-inset-half-x;
   height: 40px;
   display: block;
@@ -25,8 +23,6 @@
 
   &:active,
   &:focus {
-    background-color: $cdr-color-background-input-default-selected;
-    box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
     outline: none;
   }
 

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -9,6 +9,7 @@
     position: relative;
     width: max-content;
     height: max-content;
+    display: inline-block;
 
     // Override CdrPopup closed state for a11y
     .cdr-popup--closed {

--- a/src/components/tooltip/styles/CdrTooltip.scss
+++ b/src/components/tooltip/styles/CdrTooltip.scss
@@ -10,6 +10,7 @@ $cdr-color-text-tooltip-default: #f9f8f6;
   position: relative;
   width: max-content;
   height: max-content;
+  display: inline-block;
 
   .cdr-popup--closed {
     @include cdr-display-sr-only;


### PR DESCRIPTION
- creates `cdr-input__icon` helper class for styling buttons passed into the icon slots
- adds a helper-text-top slot instead of doing the `helperPosition` prop. makes more sense as a slot and inevitably someday someone will want to render content in both spots so 🤷 
- moves `post-icon` slot outside of the "real" input, creates fake input wrapper around both (to solve safari/lastpass/etc. inserting an autofill icon where the post-icon slot usually renders) 
- refactors some of the input component variables. splits input-base into input- core/outline/focus. In our SCSS we apply outline/focus to the fake input wrapper and core to the real input, wheres in the base mixin for component variables they're all combined into one thing that could be applied to a plain <input>


<img width="506" alt="Screen Shot 2020-10-21 at 2 45 10 PM" src="https://user-images.githubusercontent.com/48567940/96790710-173b5880-13ac-11eb-84fd-8b90aa297674.png">
<img width="545" alt="Screen Shot 2020-10-21 at 2 44 09 PM" src="https://user-images.githubusercontent.com/48567940/96790718-199db280-13ac-11eb-83f3-8b7db7a4b441.png">

