### PR TITLE
fix modal scrolling in ios14

### DIFF
--- a/src/components/modal/styles/CdrModal.scss
+++ b/src/components/modal/styles/CdrModal.scss
@@ -23,17 +23,14 @@ $modal-animation-duration: 150ms;
     right: 0;
     top: 0;
     transition: opacity $modal-animation-duration;
-    z-index: -1;
+    z-index: 0;
   }
 
   &__outerWrap {
     display: flex;
     box-sizing: border-box;
-    left: 0;
     min-height: 100%;
-    position: absolute;
-    right: 0;
-    top: 0;
+    position: static;
     z-index: -1;
   }
 


### PR DESCRIPTION
- seems like ios14 treats position fixed/absolute weirdly? (or possibly because we have like, layers of position fixed/absolute going on in modal) Not 100% clear what the bug is or why position static on the wrapper element fixes it, but the position: absolute stuff on that wrapper doesn't seem to matter either so 🤷‍♀️ 
- needs z-index: 0 on the overlay to preserve the "click outside logic"
