### PR TITLE
Form examples 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3888,9 +3888,9 @@
       }
     },
     "@rei/cdr-tokens": {
-      "version": "7.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-7.0.0-alpha.3.tgz",
-      "integrity": "sha512-rEW8I1rGos5Yj13/v/UWppzI8vdeI24jUarVjvmgB8DQ9JkMw+GrPUU6Vh7U2AZthMRDaHgaLXG18J5IQe7dBg==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-aPF4cz6hi32PwyJZbw+C39gX5aihCpUPQZhz4PfIJK+3OXcmRLkrNOfx0vgwq+pE85Gr4zwnFqlbzmDAMF5eTw==",
       "dev": true
     },
     "@rei/cedar-icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "7.0.0-alpha.2",
+  "version": "7.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "7.0.0-alpha.2",
+  "version": "7.0.0-alpha.3",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@betit/rollup-plugin-rename-extensions": "^0.1.0",
     "@commitlint/cli": "^9.1.2",
     "@commitlint/config-conventional": "^9.1.1",
-    "@rei/cdr-tokens": "^7.0.0-alpha.3",
+    "@rei/cdr-tokens": "^7.0.0-alpha.4",
     "@rei/cedar-icons": "^2.1.0",
     "@rollup/plugin-alias": "^3.1.1",
     "@vue/babel-preset-jsx": "^1.1.2",

--- a/src/components/Form/AddressForm.vue
+++ b/src/components/Form/AddressForm.vue
@@ -1,0 +1,131 @@
+<template>
+  <div>
+    <cdr-text
+      tag="h2"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
+    >
+      Address Form Example
+    </cdr-text>
+
+    <form class="form-example" novalidate>
+
+      <cdr-select
+        :required="true"
+        v-model="country"
+        :options="countryOpts"
+        label="Country"
+      />
+      <cdr-input
+        :required="true"
+        v-model="fullName"
+        label="Full name"
+      />
+      <cdr-input
+        :required="true"
+        v-model="address"
+        label="Street address"
+      />
+      <cdr-input
+        :optional="true"
+        v-model="address2"
+        label="Address line 2"
+      />
+      <cdr-input
+        :required="true"
+        v-model="postal"
+        label="ZIP code"
+        type="number"
+        maxlength="5"
+      />
+      <cdr-input
+        :required="true"
+        v-model="city"
+        label="City"
+      />
+      <cdr-select
+        :required="true"
+        v-model="state"
+        :options="stateOpts"
+        label="State"
+      />
+      <cdr-input
+        :required="true"
+        v-model="phone"
+        label="Phone number"
+        type="tel"
+        maxlength="10"
+        placeholder="(555)555-5555"
+      >
+        <template slot="helper-text-top">In case there's an issue with an order.</template>
+      </cdr-input>
+
+      <cdr-button @click="validate">
+        Save
+      </cdr-button>
+    </form>
+  </div>
+</template>
+
+<script>
+import * as Components from 'srcdir/index';
+
+export default {
+  name: 'Form',
+  components: {
+    ...Components,
+  },
+  data() {
+    return {
+      countryOpts: ['Canada', 'Mexico', 'United States'],
+      stateOpts: ['California', 'Florida', 'New York', 'Oregon', 'Texas', 'Washington', ],
+      country: '',
+      countryErr: false,
+      fullName: '',
+      fullNameErr: false,
+      address: '',
+      addressErr: false,
+      address2: '',
+      city: '',
+      cityErr: false,
+      state: '',
+      stateErr: false,
+      postal: '',
+      postalErr: false,
+      phone: '',
+      phoneErr: false,
+      backgroundColor: 'primary',
+    };
+  },
+  watch: {
+    $route(to) {
+      this.setBackground(to.query.background);
+    },
+  },
+  mounted() {
+    this.setBackground(this.$router.currentRoute.query.background);
+  },
+  methods: {
+    validate() {
+      // check if all the models have good content
+      // vue forms patterns?
+    },
+    setBackground(background) {
+      switch (background) {
+        case 'primary':
+          this.backgroundColor = 'primary';
+          break;
+        case 'secondary':
+          this.backgroundColor = 'secondary';
+          break;
+        default:
+          this.backgroundColor = 'primary';
+      }
+    },
+  },
+};
+</script>
+<style>
+.form-example {
+  width: 640px;
+}
+</style>

--- a/src/components/Form/AddressForm.vue
+++ b/src/components/Form/AddressForm.vue
@@ -7,7 +7,10 @@
       Address Form Example
     </cdr-text>
 
-    <form class="form-example" novalidate>
+    <form
+      class="form-example"
+      novalidate
+    >
 
       <cdr-select
         :required="true"
@@ -56,7 +59,9 @@
         maxlength="10"
         placeholder="(555)555-5555"
       >
-        <template slot="helper-text-top">In case there's an issue with an order.</template>
+        <template slot="helper-text-top">
+          In case there's an issue with an order.
+        </template>
       </cdr-input>
 
       <cdr-button @click="validate">
@@ -77,7 +82,7 @@ export default {
   data() {
     return {
       countryOpts: ['Canada', 'Mexico', 'United States'],
-      stateOpts: ['California', 'Florida', 'New York', 'Oregon', 'Texas', 'Washington', ],
+      stateOpts: ['California', 'Florida', 'New York', 'Oregon', 'Texas', 'Washington'],
       country: '',
       countryErr: false,
       fullName: '',
@@ -106,8 +111,6 @@ export default {
   },
   methods: {
     validate() {
-      // check if all the models have good content
-      // vue forms patterns?
     },
     setBackground(background) {
       switch (background) {

--- a/src/components/Form/LoginForm.vue
+++ b/src/components/Form/LoginForm.vue
@@ -7,7 +7,10 @@
       Login Form Example
     </cdr-text>
 
-    <form class="form-example" novalidate>
+    <form
+      class="form-example"
+      novalidate
+    >
 
       <cdr-input
         :required="true"
@@ -23,18 +26,24 @@
         label="Password"
         :type="passwordVisible ? 'text' : 'password'"
       >
-        <cdr-tooltip slot="post-icon" class="cdr-input__button">
+        <cdr-tooltip
+          slot="post-icon"
+          class="cdr-input__button"
+        >
           <cdr-button
             slot="trigger"
             :icon-only="true"
             @click="passwordVisible = !passwordVisible"
           >
-            <icon-x-stroke/>
+            <icon-x-stroke />
           </cdr-button>
           {{ passwordVisible ? 'Hide' : 'Show' }} Password
         </cdr-tooltip>
       </cdr-input>
-      <cdr-button @click="validate" type="submit">
+      <cdr-button
+        @click="validate"
+        type="submit"
+      >
         Save
       </cdr-button>
 
@@ -100,13 +109,6 @@ export default {
 };
 </script>
 <style>
-/*
-TODO:
-- how to deal with width/layout...grid?
-
-
-
-*/
 .form-example {
   width: 640px;
 }

--- a/src/components/Form/LoginForm.vue
+++ b/src/components/Form/LoginForm.vue
@@ -1,0 +1,113 @@
+<template>
+  <div>
+    <cdr-text
+      tag="h2"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
+    >
+      Login Form Example
+    </cdr-text>
+
+    <form class="form-example" novalidate>
+
+      <cdr-input
+        :required="true"
+        v-model="email"
+        :error="emailErr"
+        label="Email"
+        type="email"
+      />
+      <cdr-input
+        :required="true"
+        v-model="password"
+        :error="passwordErr"
+        label="Password"
+        :type="passwordVisible ? 'text' : 'password'"
+      >
+        <cdr-tooltip slot="post-icon" class="cdr-input__button">
+          <cdr-button
+            slot="trigger"
+            :icon-only="true"
+            @click="passwordVisible = !passwordVisible"
+          >
+            <icon-x-stroke/>
+          </cdr-button>
+          {{ passwordVisible ? 'Hide' : 'Show' }} Password
+        </cdr-tooltip>
+      </cdr-input>
+      <cdr-button @click="validate" type="submit">
+        Save
+      </cdr-button>
+
+    </form>
+  </div>
+</template>
+
+<script>
+import * as Components from 'srcdir/index';
+
+export default {
+  name: 'Form',
+  components: {
+    ...Components,
+  },
+  data() {
+    return {
+      email: '',
+      emailErr: false,
+      password: '',
+      passwordErr: false,
+      passwordVisible: false,
+      backgroundColor: 'primary',
+    };
+  },
+  watch: {
+    $route(to) {
+      this.setBackground(to.query.background);
+    },
+  },
+  mounted() {
+    this.setBackground(this.$router.currentRoute.query.background);
+  },
+  methods: {
+    validate() {
+      // check if all the models have good content
+      // vue forms patterns?
+      if (!this.email.length) {
+        this.emailErr = 'Must enter an email';
+      }
+      // extremely naive email validation probably don't use this
+      if (!this.email.match(/\w+@\w+\.\w+/)) {
+        this.emailErr = 'Email must match the form "username@example.com"';
+      }
+
+      if (!this.password.length) {
+        this.passwordErr = 'Must enter a password';
+      }
+    },
+    setBackground(background) {
+      switch (background) {
+        case 'primary':
+          this.backgroundColor = 'primary';
+          break;
+        case 'secondary':
+          this.backgroundColor = 'secondary';
+          break;
+        default:
+          this.backgroundColor = 'primary';
+      }
+    },
+  },
+};
+</script>
+<style>
+/*
+TODO:
+- how to deal with width/layout...grid?
+
+
+
+*/
+.form-example {
+  width: 640px;
+}
+</style>

--- a/src/components/Form/PaymentForm.vue
+++ b/src/components/Form/PaymentForm.vue
@@ -1,0 +1,116 @@
+<template>
+  <div>
+    <cdr-text
+      tag="h2"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
+    >
+      Payment Form Example
+    </cdr-text>
+
+    <form class="form-example" novalidate>
+      <cdr-input
+        :required="true"
+        v-model="creditCard"
+        type="number"
+        label="Credit card"
+      />
+      <cdr-select
+        :required="true"
+        v-model="month"
+        :options="monthOpts"
+        prompt="Month"
+        label="Expiration Month"
+      />
+      <cdr-select
+        :required="true"
+        v-model="year"
+        :options="yearOpts"
+        label="Expiration year"
+      />
+      <cdr-input
+        :required="true"
+        v-model="securityCode"
+        label="Security Code"
+        type="number"
+      >
+        <template slot="info">
+          <cdr-popover>
+            <cdr-link slot="trigger" tag="button" modifier="standalone">Where?</cdr-link>
+            Where to find the magic numbers
+          </cdr-popover>
+        </template>
+      </cdr-input>
+
+      <cdr-button @click="validate">
+        Save
+      </cdr-button>
+    </form>
+  </div>
+</template>
+
+<script>
+import * as Components from 'srcdir/index';
+
+export default {
+  name: 'Form',
+  components: {
+    ...Components,
+  },
+  data() {
+    return {
+      monthOpts: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', "September", "October", "November", "December"],
+      yearOpts: ['2020', '2021', '2022', '2023', '2024', '2025', '2026', '2027', '2028', '2029', '2030'],
+      creditCard: '',
+      creditCardErr: '',
+      month: '',
+      monthErr: '',
+      year: '',
+      yearErr: '',
+      securityCode: '',
+      securityCodeErr: '',
+      backgroundColor: 'primary',
+    };
+  },
+  watch: {
+    $route(to) {
+      this.setBackground(to.query.background);
+    },
+  },
+  mounted() {
+    this.setBackground(this.$router.currentRoute.query.background);
+  },
+// HOW TTO put limit on zip/phone length?
+
+
+  methods: {
+    validate() {
+      // check if all the models have good content
+      // vue forms patterns?
+    },
+    setBackground(background) {
+      switch (background) {
+        case 'primary':
+          this.backgroundColor = 'primary';
+          break;
+        case 'secondary':
+          this.backgroundColor = 'secondary';
+          break;
+        default:
+          this.backgroundColor = 'primary';
+      }
+    },
+  },
+};
+</script>
+<style>
+/*
+TODO:
+- how to deal with width/layout...grid?
+
+
+
+*/
+.form-example {
+  width: 640px;
+}
+</style>

--- a/src/components/Form/PaymentForm.vue
+++ b/src/components/Form/PaymentForm.vue
@@ -7,7 +7,10 @@
       Payment Form Example
     </cdr-text>
 
-    <form class="form-example" novalidate>
+    <form
+      class="form-example"
+      novalidate
+    >
       <cdr-input
         :required="true"
         v-model="creditCard"
@@ -35,7 +38,13 @@
       >
         <template slot="info">
           <cdr-popover>
-            <cdr-link slot="trigger" tag="button" modifier="standalone">Where?</cdr-link>
+            <cdr-link
+              slot="trigger"
+              tag="button"
+              modifier="standalone"
+            >
+              Where?
+            </cdr-link>
             Where to find the magic numbers
           </cdr-popover>
         </template>
@@ -58,8 +67,14 @@ export default {
   },
   data() {
     return {
-      monthOpts: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', "September", "October", "November", "December"],
-      yearOpts: ['2020', '2021', '2022', '2023', '2024', '2025', '2026', '2027', '2028', '2029', '2030'],
+      monthOpts: [
+        'January', 'February', 'March', 'April', 'May', 'June',
+        'July', 'August', 'September', 'October', 'November', 'December',
+      ],
+      yearOpts: [
+        '2020', '2021', '2022', '2023', '2024', '2025',
+        '2026', '2027', '2028', '2029', '2030',
+      ],
       creditCard: '',
       creditCardErr: '',
       month: '',
@@ -79,13 +94,9 @@ export default {
   mounted() {
     this.setBackground(this.$router.currentRoute.query.background);
   },
-// HOW TTO put limit on zip/phone length?
-
-
   methods: {
     validate() {
-      // check if all the models have good content
-      // vue forms patterns?
+
     },
     setBackground(background) {
       switch (background) {
@@ -103,13 +114,6 @@ export default {
 };
 </script>
 <style>
-/*
-TODO:
-- how to deal with width/layout...grid?
-
-
-
-*/
 .form-example {
   width: 640px;
 }

--- a/src/components/Form/SurveyForm.vue
+++ b/src/components/Form/SurveyForm.vue
@@ -1,0 +1,111 @@
+<template>
+  <div>
+    <cdr-text
+      tag="h2"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
+    >
+      Survey Example
+    </cdr-text>
+
+    <form class="form-example" novalidate>
+
+      <cdr-select label="Rate your experience" prompt="Choose one" v-model="experience" :error="experienceErr" @change="experienceErr = false">
+        <option value="good">
+          Good
+        </option>
+        <option value="great">
+          Great
+        </option>
+        <option value="what">
+          What?
+        </option>
+      </cdr-select>
+
+      <cdr-form-group label="Which is most important?" :error="importantErr">
+        <cdr-radio name="important" @change="importantErr = false" v-model="important" :error="importantErr" custom-value="mind">Mind</cdr-radio>
+        <cdr-radio name="important" @change="importantErr = false" v-model="important" :error="importantErr" custom-value="body">Body</cdr-radio>
+        <cdr-radio name="important" @change="importantErr = false" v-model="important" :error="importantErr" custom-value="spirit">Spirit</cdr-radio>
+      </cdr-form-group>
+
+      <cdr-form-group label="What do you want more of?" :error="moreErr">
+        <cdr-checkbox v-model="more" @change="moreErr = false" custom-value="potatoes" :error="moreErr">Potatoes</cdr-checkbox>
+        <cdr-checkbox v-model="more" @change="moreErr = false" custom-value="apples" :error="moreErr">Apples</cdr-checkbox>
+        <cdr-checkbox v-model="more" @change="moreErr = false" custom-value="carrots" :error="moreErr">Carrots</cdr-checkbox>
+      </cdr-form-group>
+
+      <cdr-input :rows="3" label="Anything else we should know?"/>
+
+      <cdr-button @click="validate" type="submit">
+        Submit
+      </cdr-button>
+
+    </form>
+  </div>
+</template>
+
+<script>
+import * as Components from 'srcdir/index';
+
+export default {
+  name: 'Form',
+  components: {
+    ...Components,
+  },
+  data() {
+    return {
+      backgroundColor: 'primary',
+      important: '',
+      importantErr: false,
+      experience: '',
+      experienceErr: false,
+      more: [],
+      moreErr: false,
+    };
+  },
+  watch: {
+    $route(to) {
+      this.setBackground(to.query.background);
+    },
+  },
+  mounted() {
+    this.setBackground(this.$router.currentRoute.query.background);
+  },
+  methods: {
+    validate() {
+      if (!this.important.length) {
+        this.importantErr = 'Please tell us what is important to you';
+      }
+      if (!this.experience.length) {
+        this.experienceErr = 'Please tell us about your experience';
+      }
+      if (!this.more.length) {
+        this.moreErr = 'Please tell us what you want';
+      }
+    },
+    setBackground(background) {
+      switch (background) {
+        case 'primary':
+          this.backgroundColor = 'primary';
+          break;
+        case 'secondary':
+          this.backgroundColor = 'secondary';
+          break;
+        default:
+          this.backgroundColor = 'primary';
+      }
+    },
+  },
+};
+</script>
+<style>
+/*
+TODO:
+- how to deal with width/layout...grid?
+
+
+
+*/
+.form-example {
+  width: 640px;
+}
+</style>

--- a/src/components/Form/SurveyForm.vue
+++ b/src/components/Form/SurveyForm.vue
@@ -7,9 +7,18 @@
       Survey Example
     </cdr-text>
 
-    <form class="form-example" novalidate>
+    <form
+      class="form-example"
+      novalidate
+    >
 
-      <cdr-select label="Rate your experience" prompt="Choose one" v-model="experience" :error="experienceErr" @change="experienceErr = false">
+      <cdr-select
+        label="Rate your experience"
+        prompt="Choose one"
+        v-model="experience"
+        :error="experienceErr"
+        @change="experienceErr = false"
+      >
         <option value="good">
           Good
         </option>
@@ -21,21 +30,78 @@
         </option>
       </cdr-select>
 
-      <cdr-form-group label="Which is most important?" :error="importantErr">
-        <cdr-radio name="important" @change="importantErr = false" v-model="important" :error="importantErr" custom-value="mind">Mind</cdr-radio>
-        <cdr-radio name="important" @change="importantErr = false" v-model="important" :error="importantErr" custom-value="body">Body</cdr-radio>
-        <cdr-radio name="important" @change="importantErr = false" v-model="important" :error="importantErr" custom-value="spirit">Spirit</cdr-radio>
+      <cdr-form-group
+        label="Which is most important?"
+        :error="importantErr"
+      >
+        <cdr-radio
+          name="important"
+          @change="importantErr = false"
+          v-model="important"
+          :error="importantErr"
+          custom-value="mind"
+        >
+          Mind
+        </cdr-radio>
+        <cdr-radio
+          name="important"
+          @change="importantErr = false"
+          v-model="important"
+          :error="importantErr"
+          custom-value="body"
+        >
+          Body
+        </cdr-radio>
+        <cdr-radio
+          name="important"
+          @change="importantErr = false"
+          v-model="important"
+          :error="importantErr"
+          custom-value="spirit"
+        >
+          Spirit
+        </cdr-radio>
       </cdr-form-group>
 
-      <cdr-form-group label="What do you want more of?" :error="moreErr">
-        <cdr-checkbox v-model="more" @change="moreErr = false" custom-value="potatoes" :error="moreErr">Potatoes</cdr-checkbox>
-        <cdr-checkbox v-model="more" @change="moreErr = false" custom-value="apples" :error="moreErr">Apples</cdr-checkbox>
-        <cdr-checkbox v-model="more" @change="moreErr = false" custom-value="carrots" :error="moreErr">Carrots</cdr-checkbox>
+      <cdr-form-group
+        label="What do you want more of?"
+        :error="moreErr"
+      >
+        <cdr-checkbox
+          v-model="more"
+          @change="moreErr = false"
+          custom-value="potatoes"
+          :error="moreErr"
+        >
+          Potatoes
+        </cdr-checkbox>
+        <cdr-checkbox
+          v-model="more"
+          @change="moreErr = false"
+          custom-value="apples"
+          :error="moreErr"
+        >
+          Apples
+        </cdr-checkbox>
+        <cdr-checkbox
+          v-model="more"
+          @change="moreErr = false"
+          custom-value="carrots"
+          :error="moreErr"
+        >
+          Carrots
+        </cdr-checkbox>
       </cdr-form-group>
 
-      <cdr-input :rows="3" label="Anything else we should know?"/>
+      <cdr-input
+        :rows="3"
+        label="Anything else we should know?"
+      />
 
-      <cdr-button @click="validate" type="submit">
+      <cdr-button
+        @click="validate"
+        type="submit"
+      >
         Submit
       </cdr-button>
 
@@ -98,13 +164,6 @@ export default {
 };
 </script>
 <style>
-/*
-TODO:
-- how to deal with width/layout...grid?
-
-
-
-*/
 .form-example {
   width: 640px;
 }

--- a/src/components/button/CdrButton.jsx
+++ b/src/components/button/CdrButton.jsx
@@ -60,7 +60,7 @@ export default {
       return this.modifier ? undefined : this.modifyClassName(this.baseClass, 'primary');
     },
     buttonSizeClass() {
-      return !this.iconOnly ? this.sizeClass : null;
+      return !this.iconOnly ? this.sizeClass : this.style[`cdr-button--icon-only-${this.size}`];
     },
     iconClass() {
       const classes = [];

--- a/src/components/button/__tests__/CdrButton.spec.js
+++ b/src/components/button/__tests__/CdrButton.spec.js
@@ -43,14 +43,14 @@ describe('CdrButton', () => {
     expect(wrapper.classes()).toContain('cdr-button');
   });
 
-  it('does not add size class when icon only', () => {
+  it('adds custom size class when icon only', () => {
     const wrapper = shallowMount(CdrButton, {
       propsData: {
         size: 'large',
         iconOnly: true,
       },
     });
-    expect(wrapper.vm.buttonSizeClass).toBe(null);
+    expect(wrapper.vm.buttonSizeClass).toBe('cdr-button--icon-only-large');
   })
 
   it('does not add icon class when slot is unused', () => {

--- a/src/components/button/styles/CdrButton.scss
+++ b/src/components/button/styles/CdrButton.scss
@@ -86,6 +86,10 @@
     }
   }
 
+  &--icon-only-large {
+    padding: $cdr-space-three-quarter-x;
+  }
+
   &--with-background {
     @include cdr-button-with-background-mixin;
   }

--- a/src/components/checkbox/styles/CdrCheckbox.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.scss
@@ -69,8 +69,7 @@
     }
 
     & ~ .cdr-label-wrapper__content {
-      // TODO: add token
-      color: #b2ab9f;//$cdr-color-text-input-label-disabled;
+      color: $cdr-color-text-input-disabled;
     }
 
     /* Disabled + Checked
@@ -107,6 +106,11 @@
   /* Focus
   ========== */
   &__input:focus ~ .cdr-label-wrapper__figure {
-    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-focus;
+    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-active;
+    background-color: $cdr-color-background-input-default-focus;
+  }
+
+  &__input:focus:checked ~ .cdr-label-wrapper__figure {
+    background-color: $cdr-color-background-input-default-selected-focus;
   }
 }

--- a/src/components/checkbox/styles/CdrCheckbox.scss
+++ b/src/components/checkbox/styles/CdrCheckbox.scss
@@ -4,7 +4,7 @@
   /* Checked
   ========== */
   &__input:checked ~ .cdr-label-wrapper__figure {
-    box-shadow: 0 0 0 2px $cdr-color-border-input-default-selected;
+    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-selected;
     background-color: $cdr-color-background-input-default-selected;
     background-image: svg-load('node_modules/@rei/cedar-icons/dist/icons/check-lg.svg', fill="#{$cdr-color-icon-checkbox-default-selected}");
     background-repeat: no-repeat;
@@ -13,7 +13,7 @@
   // /* Indeterminate
   // ========== */
   &__input[indeterminate] ~ .cdr-label-wrapper__figure {
-    box-shadow: 0 0 0 1px $cdr-color-border-input-default-selected;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-selected;
 
     &::after {
       content: '';
@@ -33,7 +33,7 @@
   &:hover {
     .cdr-label-wrapper__figure {
       cursor: pointer;
-      box-shadow: 0 0 0 2px $cdr-color-border-input-default-hover;
+      box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-hover;
       background-color: $cdr-color-background-input-default-hover;
     }
 
@@ -41,7 +41,7 @@
       /* Hover + Checked
       ========== */
       &:checked ~ .cdr-label-wrapper__figure {
-        box-shadow: 0 0 0 2px $cdr-color-border-input-default-selected-hover;
+        box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-selected-hover;
         background-color: $cdr-color-background-input-default-selected-hover;
         background-image: svg-load('node_modules/@rei/cedar-icons/dist/icons/check-lg.svg', fill="#{$cdr-color-icon-checkbox-default-selected-hover}");
 
@@ -50,7 +50,7 @@
       /* Hover + Indeterminate
       ========== */
       &[indeterminate] ~ .cdr-label-wrapper__figure {
-        box-shadow: 0 0 0 2px $cdr-color-border-input-default-selected-hover;
+        box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-selected-hover;
         &::after {
           background-color: $cdr-color-icon-checkbox-default-selected-hover;
         }
@@ -63,7 +63,7 @@
   &__input:disabled {
 
     & ~ .cdr-label-wrapper__figure {
-      box-shadow: 0 0 0 1px $cdr-color-border-input-default-disabled !important;
+      box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled !important;
       background-color: $cdr-color-background-input-default-disabled !important;
       background-image: none !important;
     }
@@ -85,7 +85,7 @@
     ========== */
     &[indeterminate] {
       & ~ .cdr-label-wrapper__figure {
-        box-shadow: 0 0 0 1px $cdr-color-border-input-default-disabled !important;
+        box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled !important;
 
         &::after {
           background-color: $cdr-color-background-input-default-disabled !important;
@@ -98,7 +98,7 @@
   ========== */
   &:active {
     .cdr-label-wrapper__figure, .cdr-checkbox__input:checked ~ .cdr-label-wrapper__figure  {
-      box-shadow: 0 0 0 2px $cdr-color-border-input-default-active;
+      box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-active;
       background-color: $cdr-color-background-input-default-active;
       background-image: svg-load('node_modules/@rei/cedar-icons/dist/icons/check-lg.svg', fill="#{$cdr-color-icon-checkbox-default-selected-active}");
     }
@@ -107,6 +107,6 @@
   /* Focus
   ========== */
   &__input:focus ~ .cdr-label-wrapper__figure {
-    box-shadow: 0 0 0 2px $cdr-color-border-input-default-focus;
+    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-focus;
   }
 }

--- a/src/components/formGroup/CdrFormGroup.jsx
+++ b/src/components/formGroup/CdrFormGroup.jsx
@@ -35,8 +35,8 @@ export default {
       return this.error ? this.style['cdr-form-group--error'] : '';
     },
     disabledClass() {
-      return this.disabled ? this.style['cdr-form-group--disabled']: '';
-    }
+      return this.disabled ? this.style['cdr-form-group--disabled'] : '';
+    },
   },
   render() {
     return (<fieldset class={clsx(this.style[this.baseClass], this.disabledClass)}>

--- a/src/components/formGroup/CdrFormGroup.jsx
+++ b/src/components/formGroup/CdrFormGroup.jsx
@@ -39,34 +39,39 @@ export default {
     },
   },
   render() {
-    return (<fieldset class={clsx(this.style[this.baseClass], this.disabledClass)}>
-      <legend>
-        {this.$slots.label || this.label}
-        {this.required && (
-          <span
-            class={this.style['cdr-form-group__required']}
-            aria-label="required"
-          >
-            *
-          </span>
-        )}
+    return (
+      <fieldset
+        class={clsx(this.style[this.baseClass], this.disabledClass)}
+        disabled={this.disabled}
+      >
+        <legend>
+          {this.$slots.label || this.label}
+          {this.required && (
+            <span
+              class={this.style['cdr-form-group__required']}
+              aria-label="required"
+            >
+              *
+            </span>
+          )}
 
-        {this.optional && (
-          <span
-            class={this.style['cdr-form-group__optional']}
-          >
-            (optional)
-          </span>
-        )}
-      </legend>
-      <div class={clsx(this.style['cdr-form-group__wrapper'], this.errorClass)}>
-        {this.$slots.default}
-      </div>
-      {this.error && (
-        <div class={this.style['cdr-form-group__error-message']}>
-          {this.$slots.error || (<span><icon-error-stroke inherit-color/> {this.error}</span>)}
+          {this.optional && (
+            <span
+              class={this.style['cdr-form-group__optional']}
+            >
+              (optional)
+            </span>
+          )}
+        </legend>
+        <div class={clsx(this.style['cdr-form-group__wrapper'], this.errorClass)}>
+          {this.$slots.default}
         </div>
-      )}
-    </fieldset>);
+        {this.error && (
+          <div class={this.style['cdr-form-group__error-message']}>
+            {this.$slots.error || (<span><icon-error-stroke inherit-color/> {this.error}</span>)}
+          </div>
+        )}
+      </fieldset>
+    );
   },
 };

--- a/src/components/formGroup/CdrFormGroup.jsx
+++ b/src/components/formGroup/CdrFormGroup.jsx
@@ -20,6 +20,7 @@ export default {
     },
     required: Boolean,
     optional: Boolean,
+    disabled: Boolean,
   },
   data() {
     return {
@@ -33,9 +34,12 @@ export default {
     errorClass() {
       return this.error ? this.style['cdr-form-group--error'] : '';
     },
+    disabledClass() {
+      return this.disabled ? this.style['cdr-form-group--disabled']: '';
+    }
   },
   render() {
-    return (<fieldset class={this.style[this.baseClass]}>
+    return (<fieldset class={clsx(this.style[this.baseClass], this.disabledClass)}>
       <legend>
         {this.$slots.label || this.label}
         {this.required && (

--- a/src/components/formGroup/__tests__/CdrFormGroup.spec.js
+++ b/src/components/formGroup/__tests__/CdrFormGroup.spec.js
@@ -28,6 +28,16 @@ describe('CdrFormGroup', () => {
     expect(wrapper.find('.cdr-form-group__error-message').text()).toBe('whoops');
   });
 
+  test('renders disabled state', () => {
+    const wrapper = mount(CdrFormGroup, {
+      propsData: {
+        disabled: true
+      },
+    });
+
+    expect(wrapper.find('.cdr-form-group--disabledd').exists()).toBe(true);
+  });
+
   test('renders text when passed as error prop', () => {
     const wrapper = mount(CdrFormGroup, {
       propsData: {

--- a/src/components/formGroup/__tests__/CdrFormGroup.spec.js
+++ b/src/components/formGroup/__tests__/CdrFormGroup.spec.js
@@ -35,7 +35,7 @@ describe('CdrFormGroup', () => {
       },
     });
 
-    expect(wrapper.find('.cdr-form-group--disabledd').exists()).toBe(true);
+    expect(wrapper.find('.cdr-form-group--disabled').exists()).toBe(true);
   });
 
   test('renders text when passed as error prop', () => {

--- a/src/components/formGroup/examples/demo/Checkboxes.vue
+++ b/src/components/formGroup/examples/demo/Checkboxes.vue
@@ -80,6 +80,27 @@
         You must make a selection!
       </template>
     </cdr-form-group>
+
+    <cdr-form-group
+      label="Disabled example"
+      :disabled="true"
+    >
+      <cdr-checkbox
+        custom-value="A"
+        v-model="exGroup"
+        :disabled="true"
+      >A</cdr-checkbox>
+      <cdr-checkbox
+        custom-value="B"
+        v-model="exGroup"
+        :disabled="true"
+      >B</cdr-checkbox>
+      <cdr-checkbox
+        custom-value="C"
+        v-model="exGroup"
+        :disabled="true"
+      >C</cdr-checkbox>
+    </cdr-form-group>
   </div>
 </template>
 

--- a/src/components/formGroup/examples/demo/Radios.vue
+++ b/src/components/formGroup/examples/demo/Radios.vue
@@ -21,6 +21,32 @@
       >Sony</cdr-radio>
 
     </cdr-form-group>
+
+
+    <cdr-form-group label="Disabled Radio Example" :disabled="true">
+
+      <cdr-radio
+        name="example"
+        custom-value="casio"
+        v-model="ex"
+        :disabled="true"
+      >Casio</cdr-radio>
+
+      <cdr-radio
+        name="example"
+        custom-value="panasonic"
+        v-model="ex"
+        :disabled="true"
+      >Panasonic</cdr-radio>
+
+      <cdr-radio
+        name="example"
+        custom-value="sony"
+        v-model="ex"
+        :disabled="true"
+      >Sony</cdr-radio>
+
+    </cdr-form-group>
   </div>
 </template>
 

--- a/src/components/formGroup/examples/demo/Radios.vue
+++ b/src/components/formGroup/examples/demo/Radios.vue
@@ -22,8 +22,10 @@
 
     </cdr-form-group>
 
-
-    <cdr-form-group label="Disabled Radio Example" :disabled="true">
+    <cdr-form-group
+      label="Disabled Radio Example"
+      :disabled="true"
+    >
 
       <cdr-radio
         name="example"

--- a/src/components/formGroup/styles/CdrFormGroup.scss
+++ b/src/components/formGroup/styles/CdrFormGroup.scss
@@ -12,6 +12,13 @@
     }
   }
 
+  &--disabled {
+    cursor: not-allowed;
+    legend {
+      color: $cdr-color-text-disabled;
+    }
+  }
+
   &__error-message {
     @include cdr-text-utility-sans-300;
     color: $cdr-color-text-input-error;

--- a/src/components/formGroup/styles/CdrFormGroup.scss
+++ b/src/components/formGroup/styles/CdrFormGroup.scss
@@ -5,7 +5,7 @@
   @include cdr-form-group-base-mixin;
 
   &--error {
-    box-shadow: 0 0 0 1px $cdr-color-border-input-error;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-error;
     background-color: $cdr-color-background-input-error;
     &:hover {
       background-color: transparent;
@@ -14,7 +14,7 @@
 
   &--disabled {
     cursor: not-allowed;
-    legend {
+    legend, .cdr-form-group__optional, .cdr-form-group__required {
       color: $cdr-color-text-disabled;
     }
   }

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -89,12 +89,14 @@ export default {
       return 'cdr-input';
     },
     inputClass() {
+      const hasPostIcon = !!this.$slots['post-icon'];
+      const hasPostIcons = hasPostIcon && this.$slots['post-icon'].length > 1;
       return {
         [this.style['cdr-input']]: true,
         [this.style['cdr-input--multiline']]: this.rows > 1,
         [this.style['cdr-input--preicon']]: this.$slots['pre-icon'],
-        [this.style['cdr-input--posticon']]: this.$slots['post-icon'],
-        [this.style['cdr-input--posticons']]: this.$slots['post-icon'] && this.$slots['post-icon'].length > 1,
+        [this.style['cdr-input--posticon']]: hasPostIcon,
+        [this.style['cdr-input--posticons']]: hasPostIcons,
       };
     },
     wrapperClass() {

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -97,13 +97,13 @@ export default {
         [this.style['cdr-input--preicon']]: this.$slots['pre-icon'],
         [this.style['cdr-input--posticon']]: hasPostIcon,
         [this.style['cdr-input--posticons']]: hasPostIcons,
+        [this.style['cdr-input--error']]: this.error,
+        [this.style[`cdr-input--${this.background}`]]: true,
       };
     },
     wrapperClass() {
       return {
         [this.style['cdr-input-wrap']]: true,
-        [this.style[`cdr-input--${this.background}`]]: true,
-        [this.style['cdr-input--error']]: this.error,
         [this.style['cdr-input--focus']]: this.isFocused,
       };
     },

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -77,6 +77,7 @@ export default {
   data() {
     return {
       style,
+      isFocused: false,
     };
   },
   computed: {
@@ -101,6 +102,7 @@ export default {
         [this.style['cdr-input-wrap']]: true,
         [this.style[`cdr-input--${this.background}`]]: true,
         [this.style['cdr-input--error']]: this.error,
+        [this.style['cdr-input--focus']]: this.isFocused,
       };
     },
     inputListeners() {
@@ -111,6 +113,14 @@ export default {
         ...this.$listeners,
         input(event) {
           vm.$emit('input', event.target.value);
+        },
+        focus(event) {
+          vm.isFocused = true;
+          vm.$emit('focus', event);
+        },
+        blur(event) {
+          vm.isFocused = false;
+          vm.$emit('blur', event);
         },
       };
     },

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -77,7 +77,6 @@ export default {
   data() {
     return {
       style,
-      isFocused: false,
     };
   },
   computed: {
@@ -88,16 +87,13 @@ export default {
     baseClass() {
       return 'cdr-input';
     },
-    containerClass() {
-      return {
-        [this.style['cdr-input--focused']]: this.isFocused,
-      };
-    },
     inputClass() {
       return {
         [this.style['cdr-input']]: true,
         [this.style['cdr-input--multiline']]: this.rows > 1,
         [this.style['cdr-input--preicon']]: this.$slots['pre-icon'],
+        [this.style['cdr-input--posticon']]: this.$slots['post-icon'],
+        [this.style['cdr-input--posticons']]: this.$slots['post-icon'] && this.$slots['post-icon'].length > 1,
       };
     },
     wrapperClass() {
@@ -115,14 +111,6 @@ export default {
         ...this.$listeners,
         input(event) {
           vm.$emit('input', event.target.value);
-        },
-        focus(event) {
-          vm.isFocused = true;
-          vm.$emit('focus', event);
-        },
-        blur(event) {
-          vm.isFocused = false;
-          vm.$emit('blur', event);
         },
       };
     },
@@ -167,7 +155,7 @@ export default {
   },
   render() {
     return (
-      <div class={ this.containerClass }>
+      <div>
         <cdr-label-standalone
           for-id={ `${this.inputId}` }
           label={ this.label }
@@ -190,16 +178,15 @@ export default {
 
         <div class={this.style['cdr-input-outer-wrap']}>
           <div class={this.wrapperClass}>
-            <div class={this.style['cdr-input-inner-wrap']}>
-              {this.inputEl}
-              {this.$slots['pre-icon'] && (
-                <span
-                  class={this.style['cdr-input__pre-icon']}
-                >
-                  {this.$slots['pre-icon']}
-                </span>
-              )}
-            </div>
+            {this.inputEl}
+            {this.$slots['pre-icon'] && (
+              <span
+                class={this.style['cdr-input__pre-icon']}
+              >
+                {this.$slots['pre-icon']}
+              </span>
+            )}
+
             {this.$slots['post-icon'] && (
               <span
                 class={this.style['cdr-input__post-icon']}

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -215,10 +215,10 @@ describe('CdrInput', () => {
     const input = wrapper.findComponent({ ref: 'input' });
     input.trigger('focus')
     await wrapper.vm.$nextTick();
-    expect(wrapper.classes('cdr-input--focused')).toBeTruthy();
+    expect(wrapper.classes('cdr-input--focus')).toBeTruthy();
     input.trigger('blur')
     await wrapper.vm.$nextTick();
-    expect(wrapper.classes('cdr-input--focused')).toBeFalsy();
+    expect(wrapper.classes('cdr-input--focus')).toBeFalsy();
   });
 
   it('emits a paste event', () => {

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -301,6 +301,31 @@ describe('CdrInput', () => {
     expect(wrapper.find('.cdr-input__post-icon').text()).toBe('😎');
   });
 
+  it('adds spacing class when post-icon slot is present', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      slots: {
+        'post-icon': '😎',
+      },
+    });
+    expect(wrapper.find('.cdr-input--posticon').exists()).toBe(true);
+  });
+
+
+  it('adds spacing class when multiple elements are present in post-icon slot', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+      },
+      slots: {
+        'post-icon': '<div>😎</div><div>🤠</div>',
+      },
+    });
+    expect(wrapper.find('.cdr-input--posticons').exists()).toBe(true);
+  });
+
   it('renders info action slot', () => {
     const wrapper = shallowMount(CdrInput, {
       propsData: {

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -215,10 +215,10 @@ describe('CdrInput', () => {
     const input = wrapper.findComponent({ ref: 'input' });
     input.trigger('focus')
     await wrapper.vm.$nextTick();
-    expect(wrapper.classes('cdr-input--focus')).toBeTruthy();
+    expect(wrapper.find('.cdr-input--focus').exists()).toBeTruthy();
     input.trigger('blur')
     await wrapper.vm.$nextTick();
-    expect(wrapper.classes('cdr-input--focus')).toBeFalsy();
+    expect(wrapper.find('.cdr-input--focus').exists()).toBeFalsy();
   });
 
   it('emits a paste event', () => {

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -16,10 +16,10 @@ exports[`CdrInput renders correctly 1`] = `
     class="cdr-input-outer-wrap"
   >
     <div
-      class="cdr-input-wrap cdr-input--primary"
+      class="cdr-input-wrap"
     >
       <input
-        class="cdr-input"
+        class="cdr-input cdr-input--primary"
         id="renders"
         type="text"
       />

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CdrInput renders correctly 1`] = `
-<div
-  class=""
->
+<div>
   <div
     class="cdr-label-standalone-wrap"
   >
@@ -20,15 +18,11 @@ exports[`CdrInput renders correctly 1`] = `
     <div
       class="cdr-input-wrap cdr-input--primary"
     >
-      <div
-        class="cdr-input-inner-wrap"
-      >
-        <input
-          class="cdr-input"
-          id="renders"
-          type="text"
-        />
-      </div>
+      <input
+        class="cdr-input"
+        id="renders"
+        type="text"
+      />
     </div>
   </div>
 </div>

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -205,6 +205,50 @@
     </cdr-input>
 
     <cdr-input
+      class="demo-input"
+      :required="true"
+      v-model="megaModel"
+      :error="megaErr"
+      label="Everything at the same time"
+      @blur="megaErr = false"
+    >
+      <icon-map slot="pre-icon"/>
+      <template slot="helper-text-top">Hey im on top of the input!</template>
+      <template slot="helper-text-bottom">Hey im below the input!</template>
+      <template slot="info">
+        <cdr-link href="#" modifier="standalone">
+          Hey im also on top of the input!
+        </cdr-link>
+      </template>
+      <template slot="info-action">
+        <cdr-link tag="button" type="button">
+          <icon-check-lg inherit-color/>
+        </cdr-link>
+      </template>
+      <template slot="post-icon">
+        <cdr-tooltip slot="post-icon" class="cdr-input__button">
+          <cdr-button
+            slot="trigger"
+            :icon-only="true"
+            @click="megaErr = 'An error has occurred please fix it'"
+          >
+            <icon-x-stroke/>
+          </cdr-button>
+          I put the input into an error state!
+        </cdr-tooltip>
+        <cdr-popover slot="post-icon" class="cdr-input__button">
+          <cdr-button
+            slot="trigger"
+            :icon-only="true"
+          >
+            <icon-information-stroke/>
+          </cdr-button>
+          Hey What's Up?
+        </cdr-popover>
+      </template>
+    </cdr-input>
+
+    <cdr-input
       class="demo-input "
       v-model="multiRowModel"
       :rows="10"
@@ -251,6 +295,10 @@
     <div class="demo-input">
       Size Inputs Value = {{ sizeModel }}
     </div>
+
+    <div class="demo-input">
+      Mega Input Value = {{ megaModel }}
+    </div>
     <div class="demo-input">
       Master Inputs Value = {{ masterModel }}
     </div>
@@ -279,6 +327,8 @@ export default {
       sizeModel: '',
       formWithButtons: '',
       masterModel: '',
+      megaModel: '',
+      megaErr: false,
       backgroundColor: 'primary',
     };
   },
@@ -306,6 +356,7 @@ export default {
       this.helperValidationModel = value;
       this.multiRowModel = value;
       this.sizeModel = value;
+      this.megaModel = value;
     },
     setBackground(background) {
       switch (background) {

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -103,7 +103,7 @@
     >
       <template slot="info-action">
         <cdr-link>
-          <icon-information-stroke />
+          <icon-information-stroke inherit-color/>
           <span class="cdr-display-sr-only">Information!</span>
         </cdr-link>
       </template>
@@ -224,26 +224,29 @@
           tag="button"
           type="button"
         >
+          <span class="cdr-display-sr-only">I trigger some sort of action!</span>
           <icon-check-stroke inherit-color />
         </cdr-link>
       </template>
       <template slot="post-icon">
-        <cdr-tooltip class="cdr-input__button">
+        <cdr-tooltip class="cdr-input__button" id="mega-tooltip">
           <cdr-button
             slot="trigger"
             :icon-only="true"
             @click="megaErr = 'An error has occurred please fix it'"
             size="large"
+            aria-label="Click me to cause an error"
           >
             <icon-x-stroke />
           </cdr-button>
           I put the input into an error state!
         </cdr-tooltip>
-        <cdr-popover class="cdr-input__button">
+        <cdr-popover class="cdr-input__button" id="mega-popover">
           <cdr-button
             slot="trigger"
             :icon-only="true"
             size="large"
+            aria-label="Hello"
           >
             <icon-information-stroke />
           </cdr-button>

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -202,6 +202,7 @@
       :error="megaErr"
       label="Everything at the same time"
       @blur="megaErr = false"
+      size="large"
     >
       <icon-map slot="pre-icon"/>
       <template slot="helper-text-top">Hey im on top of the input!</template>

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -223,8 +223,9 @@
             slot="trigger"
             :icon-only="true"
             @click="megaErr = 'An error has occurred please fix it'"
+            size="large"
           >
-            <icon-x-stroke/>
+            <icon-x-stroke />
           </cdr-button>
           I put the input into an error state!
         </cdr-tooltip>
@@ -232,8 +233,9 @@
           <cdr-button
             slot="trigger"
             :icon-only="true"
+            size="large"
           >
-            <icon-information-stroke/>
+            <icon-information-stroke />
           </cdr-button>
           Hey What's Up?
         </cdr-popover>

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -103,20 +103,18 @@
     >
       <template slot="info-action">
         <cdr-link>
-          <icon-information-stroke inherit-color />
+          <icon-information-stroke/>
           <span class="cdr-display-sr-only">Information!</span>
         </cdr-link>
       </template>
       <template slot="pre-icon">
         <cdr-icon
           use="#twitter"
-          inherit-color
         />
       </template>
       <template slot="post-icon">
         <cdr-icon
           use="#check-lg"
-          inherit-color
         />
       </template>
       <template slot="helper-text">
@@ -139,7 +137,6 @@
         <template slot="pre-icon">
           <cdr-icon
             use="#twitter"
-            inherit-color
           />
         </template>
         <template slot="post-icon">
@@ -152,10 +149,7 @@
               slot="trigger"
               aria-label="navigate"
             >
-              <cdr-icon
-                use="#map"
-                inherit-color
-              />
+              <icon-map/>
             </cdr-button>
 
             hey where am i?
@@ -165,10 +159,7 @@
             class="cdr-input__button"
             aria-label="close"
           >
-            <cdr-icon
-              use="#x-lg"
-              inherit-color
-            />
+            <icon-x-lg/>
           </cdr-button>
         </template>
       </cdr-input>
@@ -222,11 +213,11 @@
       </template>
       <template slot="info-action">
         <cdr-link tag="button" type="button">
-          <icon-check-lg inherit-color/>
+          <icon-check-stroke inherit-color/>
         </cdr-link>
       </template>
       <template slot="post-icon">
-        <cdr-tooltip slot="post-icon" class="cdr-input__button">
+        <cdr-tooltip class="cdr-input__button">
           <cdr-button
             slot="trigger"
             :icon-only="true"
@@ -236,7 +227,7 @@
           </cdr-button>
           I put the input into an error state!
         </cdr-tooltip>
-        <cdr-popover slot="post-icon" class="cdr-input__button">
+        <cdr-popover class="cdr-input__button">
           <cdr-button
             slot="trigger"
             :icon-only="true"

--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -103,7 +103,7 @@
     >
       <template slot="info-action">
         <cdr-link>
-          <icon-information-stroke/>
+          <icon-information-stroke />
           <span class="cdr-display-sr-only">Information!</span>
         </cdr-link>
       </template>
@@ -149,7 +149,7 @@
               slot="trigger"
               aria-label="navigate"
             >
-              <icon-map/>
+              <icon-map />
             </cdr-button>
 
             hey where am i?
@@ -159,7 +159,7 @@
             class="cdr-input__button"
             aria-label="close"
           >
-            <icon-x-lg/>
+            <icon-x-lg />
           </cdr-button>
         </template>
       </cdr-input>
@@ -204,17 +204,27 @@
       @blur="megaErr = false"
       size="large"
     >
-      <icon-map slot="pre-icon"/>
-      <template slot="helper-text-top">Hey im on top of the input!</template>
-      <template slot="helper-text-bottom">Hey im below the input!</template>
+      <icon-map slot="pre-icon" />
+      <template slot="helper-text-top">
+        Hey im on top of the input!
+      </template>
+      <template slot="helper-text-bottom">
+        Hey im below the input!
+      </template>
       <template slot="info">
-        <cdr-link href="#" modifier="standalone">
+        <cdr-link
+          href="#"
+          modifier="standalone"
+        >
           Hey im also on top of the input!
         </cdr-link>
       </template>
       <template slot="info-action">
-        <cdr-link tag="button" type="button">
-          <icon-check-stroke inherit-color/>
+        <cdr-link
+          tag="button"
+          type="button"
+        >
+          <icon-check-stroke inherit-color />
         </cdr-link>
       </template>
       <template slot="post-icon">

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -53,7 +53,6 @@
 
 .cdr-input {
   @include cdr-input-base-mixin;
-  background-color: transparent;
   /* Style variants
     ========================================================================== */
 

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -71,7 +71,7 @@
     /* $input-pre-icon-default-width = 25px with the expectation that
         slot provided icon is close to that width */
     // TODO: use icon token here?
-    padding-left: calc(#{$cdr-space-half-x} + #{$cdr-space-quarter-x} + 25px);
+    padding-left: calc(#{$cdr-space-half-x} + #{$cdr-space-quarter-x} + 25px) !important;
   }
 // add right padding so input content does not overlap post-icon(s)
 // CHECK button icon width in safari?

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -53,7 +53,7 @@
   ========================================================================== */
 
 .cdr-input {
-  @include cdr-input-core-mixin;
+  @include cdr-input-base-mixin;
   background-color: transparent;
   /* Style variants
     ========================================================================== */
@@ -67,6 +67,15 @@
         slot provided icon is close to that width */
     // TODO: use icon token here?
     padding-left: calc(#{$cdr-space-half-x} + #{$cdr-space-quarter-x} + 25px);
+  }
+// add right padding so input content does not overlap post-icon(s)
+// CHECK button icon width in safari?
+  &--posticon {
+    padding-right: 40px;
+  }
+
+  &--posticons {
+    padding-right: 80px;
   }
 
   &--primary {
@@ -167,22 +176,18 @@
 /* ==========================================================================
    # INPUT WRAPPER
    ========================================================================== */
-// real cedar input wrapper
-.cdr-input-inner-wrap {
-  position: relative;
-  flex-grow: 1
-}
 
 .cdr-input-wrap {
   position: relative;
-  display: flex;
+  // display: flex;
   flex-grow: 1;
-  @include cdr-input-outline-mixin;
+  // TODO: apply fill to pre/post icons BUT ONLY if input is focused. can't focus-within :~(
+  // &:focus-within svg {
+  //   // TODO: token?
+  //   fill: $cdr-color-text-primary;
+  // }
 }
 
-.cdr-input--focused .cdr-input-wrap {
-  @include cdr-input-focus-mixin;
-}
 
 .cdr-input-outer-wrap {
   display: flex;

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -7,7 +7,6 @@
   ========================================================================== */
 
 :global(.cdr-input__button) {
-  fill: inherit;
   & ~ & {
     position: relative;
     margin-left: -4px;
@@ -57,6 +56,12 @@
   background-color: transparent;
   /* Style variants
     ========================================================================== */
+
+  &--focus {
+    svg {
+      fill: $cdr-color-text-primary !important;
+    }
+  }
 
   &--multiline {
     height: auto;
@@ -179,15 +184,8 @@
 
 .cdr-input-wrap {
   position: relative;
-  // display: flex;
   flex-grow: 1;
-  // TODO: apply fill to pre/post icons BUT ONLY if input is focused. can't focus-within :~(
-  // &:focus-within svg {
-  //   // TODO: token?
-  //   fill: $cdr-color-text-primary;
-  // }
 }
-
 
 .cdr-input-outer-wrap {
   display: flex;

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -1,17 +1,14 @@
-// base mixin used for component variables only
-@mixin cdr-input-base-mixin() {
-  @include cdr-input-core-mixin;
-  @include cdr-input-outline-mixin;
-  &:focus {
-    @include cdr-input-focus-mixin;
-  }
-}
 
-@mixin cdr-input-core-mixin() {
+
+@mixin cdr-input-base-mixin() {
   @include cdr-text-utility-sans-300;
   font-weight: 500;
   color: $cdr-color-text-input-default;
   border: 0;
+  background-color: $cdr-color-background-input-default;
+  box-shadow: 0 0 0 1px $cdr-color-border-input-default;
+  border-radius: $cdr-radius-softer;
+  fill: $cdr-color-icon-default;
   border-radius: $cdr-radius-softer;
   padding: $cdr-space-inset-half-x;
   height: 40px;
@@ -30,10 +27,10 @@
     appearance: none;
     margin: 0;
   }
-
   &:active,
   &:focus {
     outline: none;
+    box-shadow: inset 0 0 0 2px #20201d;// $cdr-color-border-input-default-active; TODO: fix me
   }
 
   &::placeholder {
@@ -58,12 +55,9 @@
   }
 }
 
-@mixin cdr-input-outline-mixin() {
-  background-color: $cdr-color-background-input-default;
-  box-shadow: inset 0 0 0 1px $cdr-color-border-input-default;
-  border-radius: $cdr-radius-softer;
-  fill: $cdr-color-icon-default;
-}
+// @mixin cdr-input-outline-mixin() {
+//
+// }
 
 @mixin cdr-input-primary-mixin() {
   background-color: $cdr-color-background-input-default;

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -4,7 +4,7 @@
   color: $cdr-color-text-input-default;
   border: 0;
   background-color: $cdr-color-background-input-default;
-  box-shadow: 0 0 0 1px $cdr-color-border-input-default;
+  box-shadow: inset 0 0 0 1px $cdr-color-border-input-default;
   border-radius: $cdr-radius-softer;
   fill: $cdr-color-icon-default;
   border-radius: $cdr-radius-softer;

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -1,5 +1,3 @@
-
-
 @mixin cdr-input-base-mixin() {
   @include cdr-text-utility-sans-300;
   font-weight: 500;
@@ -55,10 +53,6 @@
   }
 }
 
-// @mixin cdr-input-outline-mixin() {
-//
-// }
-
 @mixin cdr-input-primary-mixin() {
   background-color: $cdr-color-background-input-default;
   &:active,
@@ -72,14 +66,6 @@
   &:active,
   &:focus {
     background-color: $cdr-color-background-input-secondary-active;
-  }
-}
-
-@mixin cdr-input-focus-mixin() {
-  box-shadow: inset 0 0 0 2px #20201d;// $cdr-color-border-input-default-active; TODO: fix me
-  svg {
-    // TODO: token?
-    fill: $cdr-color-text-primary;
   }
 }
 

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -28,7 +28,7 @@
   &:active,
   &:focus {
     outline: none;
-    box-shadow: inset 0 0 0 2px #20201d, $cdr-prominence-raised;// $cdr-color-border-input-default-active; TODO: fix me
+    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-active, $cdr-prominence-raised;
   }
 
   &::placeholder {

--- a/src/components/input/styles/vars/CdrInput.vars.scss
+++ b/src/components/input/styles/vars/CdrInput.vars.scss
@@ -28,7 +28,7 @@
   &:active,
   &:focus {
     outline: none;
-    box-shadow: inset 0 0 0 2px #20201d;// $cdr-color-border-input-default-active; TODO: fix me
+    box-shadow: inset 0 0 0 2px #20201d, $cdr-prominence-raised;// $cdr-color-border-input-default-active; TODO: fix me
   }
 
   &::placeholder {

--- a/src/components/labelWrapper/styles/vars/CdrLabelWrapper.vars.scss
+++ b/src/components/labelWrapper/styles/vars/CdrLabelWrapper.vars.scss
@@ -5,7 +5,6 @@ $cdr-label-base-spacing: $cdr-space-one-x;
 $cdr-label-figure-size-small: 16px;
 $cdr-label-figure-size-medium: 16px;
 $cdr-label-figure-size-large: 20px;
-$cdr-label-figure-box-shadow: 0 0 8px 0 $cdr-color-border-input-default-active;
 
 $cdr-label-height-medium: $cdr-text-utility-sans-300-height;
 @mixin cdr-label-base-mixin() {

--- a/src/components/popup/styles/CdrPopup.scss
+++ b/src/components/popup/styles/CdrPopup.scss
@@ -53,15 +53,15 @@
 
   // Directional Logic
 
-  &--up,
-  &--down {
+  &--top,
+  &--bottom {
     .cdr-popup__content, .cdr-popup__arrow::before, .cdr-popup__arrow::after  {
       left: 50%;
       transform: translateX(-50%);
     }
   }
 
-  &--down {
+  &--bottom {
     &.cdr-popup--open {
       .cdr-popup__content {
         :global {
@@ -103,7 +103,7 @@
     }
   }
 
-  &--up {
+  &--top {
     &.cdr-popup--open {
       .cdr-popup__content {
         :global {

--- a/src/components/radio/styles/CdrRadio.scss
+++ b/src/components/radio/styles/CdrRadio.scss
@@ -25,7 +25,7 @@
   /* Checked
   ========== */
   &__input:checked ~ .cdr-label-wrapper__figure {
-    box-shadow: 0 0 0 1px $cdr-color-border-input-default-selected;
+    box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-selected;
     background-color: $cdr-color-background-input-default-selected;
 
     &::after {
@@ -37,12 +37,12 @@
   &:hover {
     .cdr-label-wrapper__figure {
       cursor: pointer;
-      box-shadow: 0 0 0 2px $cdr-color-border-input-default-hover;
+      box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-hover;
       background-color: $cdr-color-background-input-default-hover;
     }
 
     .cdr-radio__input:checked ~ .cdr-label-wrapper__figure {
-      box-shadow: 0 0 0 2px $cdr-color-border-input-default-selected-hover;
+      box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-selected-hover;
       background-color: $cdr-color-background-input-default-selected-hover;
     }
   }
@@ -51,7 +51,7 @@
   // ========== */
   &__input:disabled {
     & ~ .cdr-label-wrapper__figure {
-      box-shadow: 0 0 0 1px $cdr-color-border-input-default-disabled !important;
+      box-shadow: inset 0 0 0 1px $cdr-color-border-input-default-disabled !important;
       background-color: $cdr-color-background-input-default-disabled !important;
       &:after {
         background-color: $cdr-color-background-input-default-disabled !important;
@@ -77,7 +77,7 @@
   // /* Focus
   // ========== */
   &__input:focus ~ .cdr-label-wrapper__figure {
-    box-shadow: 0 0 0 2px $cdr-color-border-input-default-focus;
+    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-focus;
     background-color: $cdr-color-background-input-default-focus;
   }
 
@@ -90,7 +90,7 @@
   // ========== */
   &:active {
     .cdr-label-wrapper__figure, .cdr-radio__input:checked ~ .cdr-label-wrapper__figure {
-      box-shadow: 0 0 0 2px $cdr-color-border-input-default-active;
+      box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-active;
       background-color: $cdr-color-background-input-default-active;
       &::after {
         background-color: $cdr-color-icon-checkbox-default-selected-active;

--- a/src/components/radio/styles/CdrRadio.scss
+++ b/src/components/radio/styles/CdrRadio.scss
@@ -59,8 +59,7 @@
     }
 
     & ~ .cdr-label-wrapper__content {
-      // TODO: add token
-      color: #b2ab9f;//$cdr-color-text-input-label-disabled;
+      color: $cdr-color-text-input-disabled;
     }
     /* Disabled + Checked
     ========== */
@@ -77,7 +76,7 @@
   // /* Focus
   // ========== */
   &__input:focus ~ .cdr-label-wrapper__figure {
-    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-focus;
+    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-active;
     background-color: $cdr-color-background-input-default-focus;
   }
 

--- a/src/components/select/styles/vars/CdrSelect.vars.scss
+++ b/src/components/select/styles/vars/CdrSelect.vars.scss
@@ -39,7 +39,7 @@
   &:active,
   &:focus {
     background-color: $cdr-color-background-primary;
-    box-shadow: inset 0 0 0 3px $cdr-color-border-input-default-active;
+    box-shadow: inset 0 0 0 2px $cdr-color-border-input-default-active, $cdr-prominence-raised;
     outline: none;
   }
 }

--- a/src/components/tooltip/styles/CdrTooltip.scss
+++ b/src/components/tooltip/styles/CdrTooltip.scss
@@ -21,7 +21,7 @@
   }
 
   // set arrow color on popup
-  .cdr-popup--down .cdr-popup__arrow {
+  .cdr-popup--bottom .cdr-popup__arrow {
     &::before {
       border-bottom-color: $cdr-color-border-tooltip-default;
     }
@@ -31,7 +31,7 @@
     }
   }
 
-  .cdr-popup--up .cdr-popup__arrow {
+  .cdr-popup--top .cdr-popup__arrow {
     &::before {
       border-top-color: $cdr-color-border-tooltip-default;
     }

--- a/src/dev/router.js
+++ b/src/dev/router.js
@@ -64,7 +64,6 @@ const routes = [
   { path: '/align-utilities', component: AlignUtilities },
   { path: '/visibility-utilities', component: VisibilityUtilities },
 
-
   { path: '/address-form', component: AddressForm },
   { path: '/login-form', component: LoginForm },
   { path: '/survey-form', component: SurveyForm },

--- a/src/dev/router.js
+++ b/src/dev/router.js
@@ -17,6 +17,11 @@ import ContainerUtilities from 'componentsdir/Utilities/demos/container';
 import AlignUtilities from 'componentsdir/Utilities/demos/align';
 import VisibilityUtilities from 'componentsdir/Utilities/demos/visibility';
 
+import AddressForm from 'componentsdir/Form/AddressForm';
+import LoginForm from 'componentsdir/Form/LoginForm';
+import PaymentForm from 'componentsdir/Form/PaymentForm';
+import SurveyForm from 'componentsdir/Form/SurveyForm';
+
 const routes = [
   { path: '/', name: ' ', component: App },
   { path: '/kitchen-sink', name: 'KitchenSink', component: KitchenSink },
@@ -58,6 +63,12 @@ const routes = [
   { path: '/container-utilities', component: ContainerUtilities },
   { path: '/align-utilities', component: AlignUtilities },
   { path: '/visibility-utilities', component: VisibilityUtilities },
+
+
+  { path: '/address-form', component: AddressForm },
+  { path: '/login-form', component: LoginForm },
+  { path: '/survey-form', component: SurveyForm },
+  { path: '/payment-form', component: PaymentForm },
 ];
 
 export default routes;


### PR DESCRIPTION
- refactors input to remove one of the wrapper layers. 
- adds extra padding-right to ensure input post-icons don't clash with input content
- fix fill for icons inline in input
- fixes input pre-icon + size="large" combo 
- add disabled state to form group
- fix popup arrow CSS
- adds example forms to dev env