### PR TITLE
Custom trigger popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "7.0.0-alpha.6",
+  "version": "7.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "7.0.0-alpha.6",
+  "version": "7.0.0-beta.0",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/button/styles/vars/CdrButton.vars.scss
+++ b/src/components/button/styles/vars/CdrButton.vars.scss
@@ -25,8 +25,6 @@
   line-height: 24px;
 }
 
-/* start of mixins/component variables*/
-
 @mixin cdr-button-base-mixin() {
   @include cdr-button-base-text-mixin-medium;
 
@@ -45,9 +43,6 @@
 
   transition: box-shadow $cdr-duration-2-x $cdr-timing-function-ease, background-color $cdr-duration-2-x $cdr-timing-function-ease, color $cdr-duration-2-x $cdr-timing-function-ease;
 
-
-  /* States
-    ---------- */
   &:hover, &:active, &:focus {
     outline: none;
     outline-offset: 0;
@@ -69,9 +64,6 @@
   box-shadow: inset 0 0 0 1px $cdr-color-border-button-primary-rest;
   color: $cdr-color-text-button-primary;
   fill: $cdr-color-text-button-primary;
-
-  /* States
-    ---------- */
 
   &:hover,
   &:focus {
@@ -101,9 +93,6 @@
   box-shadow: inset 0 0 0 1px $cdr-color-border-button-secondary-rest;
   color: $cdr-color-text-button-secondary;
   fill: $cdr-color-icon-default;
-
-  /* States
-  ---------- */
 
   &:hover,
   &:focus {

--- a/src/components/link/styles/vars/CdrLink.vars.scss
+++ b/src/components/link/styles/vars/CdrLink.vars.scss
@@ -15,9 +15,6 @@
   text-decoration: underline;
   vertical-align: top;
 
-  /* States
-    ---------- */
-
   &:active,
   &:focus {
     color: $cdr-color-text-link-active;

--- a/src/components/list/styles/vars/CdrList.vars.scss
+++ b/src/components/list/styles/vars/CdrList.vars.scss
@@ -3,8 +3,6 @@
   padding: 0;
   margin: 0;
 
-  /* spacing
-    ---------- */
   & > li + li {
     margin-top: $cdr-space-half-x;
   }
@@ -16,21 +14,16 @@
   list-style-type: none;
 }
 
-
-/* compact */
 @mixin cdr-list-compact-mixin() {
   & > li + li {
     margin-top: $cdr-space-quarter-x;
   }
 }
 
-/* compact nested */
 @mixin cdr-list-compact-nested-mixin() {
   margin-top: $cdr-space-quarter-x;
 }
 
-
-/* ordered */
 @mixin cdr-list-ordered-mixin() {
   list-style-type: decimal;
   padding-left: 1.5em;
@@ -70,7 +63,6 @@
   }
 }
 
-/* unordered nested */
 @mixin cdr-list-unordered-nested-mixin() {
   position: relative;
   padding-left: 1em;

--- a/src/components/popover/CdrPopover.jsx
+++ b/src/components/popover/CdrPopover.jsx
@@ -1,4 +1,5 @@
 import tabbable from 'tabbable';
+import clsx from 'clsx';
 import style from './styles/CdrPopover.scss';
 import propValidator from '../../utils/propValidator';
 import IconXSm from '../icon/comps/x-sm';
@@ -39,14 +40,28 @@ export default {
       type: String,
       required: false,
     },
+    open: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
   },
   data() {
     return {
       style,
-      open: false,
+      isOpen: false,
       openHandler: undefined,
       lastActive: undefined,
     };
+  },
+  watch: {
+    open() {
+      if (this.open) {
+        this.openPopover();
+      } else {
+        this.closePopover();
+      }
+    },
   },
   mounted() {
     this.addHandlers();
@@ -62,7 +77,7 @@ export default {
       const { activeElement } = document;
 
       this.lastActive = activeElement;
-      this.open = true;
+      this.isOpen = true;
       this.$emit('opened', e);
       this.$nextTick(() => {
         const tabbables = tabbable(this.$refs.popup.$el);
@@ -70,7 +85,7 @@ export default {
       });
     },
     closePopover(e) {
-      this.open = false;
+      this.isOpen = false;
       this.$emit('closed', e);
       if (this.lastActive) this.lastActive.focus();
     },
@@ -84,7 +99,10 @@ export default {
   },
   render() {
     return (
-      <div class={this.style['cdr-popover--wrapper']}>
+      <div class={clsx(
+        this.style['cdr-popover--wrapper'],
+        this.$slots.trigger ? this.style['cdr-popover--position'] : '',
+      )}>
         <div ref="trigger">
           { this.$slots.trigger }
         </div>
@@ -94,9 +112,9 @@ export default {
           ref="popup"
           position={ this.position }
           autoPosition={ this.autoPosition }
-          opened={ this.open }
+          opened={ this.isOpen }
           onClosed={ this.closePopover }
-          aria-expanded={ `${this.open}` }
+          aria-expanded={ `${this.isOpen}` }
           id={ this.id }
           contentClass={ this.contentClass }
         >

--- a/src/components/popover/__tests__/__snapshots__/CdrPopover.spec.js.snap
+++ b/src/components/popover/__tests__/__snapshots__/CdrPopover.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrPopover matches snapshot 1`] = `
 <div
-  class="cdr-popover--wrapper"
+  class="cdr-popover--wrapper cdr-popover--position"
 >
   <div>
     <button

--- a/src/components/popover/examples/Popover.vue
+++ b/src/components/popover/examples/Popover.vue
@@ -95,6 +95,38 @@
         Thanks for stopping by. What a lovely day it is today. Please come back again soon.
       </cdr-text>
     </cdr-popover>
+
+    <hr>
+
+    <div style="clear: both" />
+    <div
+      style="position: relative; width: max-content;"
+      :class="containerClass"
+    >
+      <cdr-button
+        :icon-only="true"
+        aria-label="information"
+        @click="open = !open"
+        aria-controls="popover-custom-test"
+        aria-haspopup="dialog"
+      >
+        <icon-brand-rei-ice-axes />
+      </cdr-button>
+      <cdr-popover
+        :position="position"
+        :auto-position="autoPos"
+        :label="title"
+        :open="open"
+        content-class="popover-override"
+        id="popover-custom-test"
+        @opened="popupHandler"
+        @closed="popupHandler"
+      >
+        <cdr-text>
+          This is an example of a popover where the trigger is not passed into the component
+        </cdr-text>
+      </cdr-popover>
+    </div>
   </div>
 </template>
 

--- a/src/components/popover/styles/CdrPopover.scss
+++ b/src/components/popover/styles/CdrPopover.scss
@@ -4,9 +4,10 @@
 @import '../../../css/settings/index.scss';
 
 .cdr-popover{
-
-  &--wrapper {
+  &--position {
     position: relative;
+  }
+  &--wrapper {
     width: max-content;
     height: max-content;
 

--- a/src/components/select/styles/vars/CdrSelect.vars.scss
+++ b/src/components/select/styles/vars/CdrSelect.vars.scss
@@ -1,5 +1,3 @@
-/* select base */
-
 @mixin cdr-select-base-mixin() {
   @include cdr-text-utility-sans-300;
   font-weight: 500;
@@ -44,8 +42,6 @@
     color: $cdr-color-text-input-disabled;
   }
 }
-
-/* --large */
 @mixin cdr-select-large-mixin() {
   @include cdr-text-utility-sans-400;
   height: $cdr-form-input-height-large;

--- a/src/components/tooltip/CdrTooltip.jsx
+++ b/src/components/tooltip/CdrTooltip.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import style from './styles/CdrTooltip.scss';
 import CdrPopup from '../popup/CdrPopup';
 import propValidator from '../../utils/propValidator';
@@ -29,15 +30,29 @@ export default {
       type: String,
       required: false,
     },
+    open: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
   },
   data() {
     return {
       style,
-      open: false,
+      isOpen: false,
       openHandler: undefined,
       closeHandler: undefined,
       timeout: undefined,
     };
+  },
+  watch: {
+    open() {
+      if (this.open) {
+        this.openTooltip();
+      } else {
+        this.closeTooltip();
+      }
+    },
   },
   mounted() {
     this.addHandlers();
@@ -47,12 +62,12 @@ export default {
   methods: {
     openTooltip(e) {
       if (this.timeout) clearTimeout(this.timeout);
-      this.open = true;
+      this.isOpen = true;
       this.$emit('opened', e);
     },
     closeTooltip(e) {
       this.timeout = setTimeout(() => {
-        this.open = false;
+        this.isOpen = false;
         this.$emit('closed', e);
       }, 250);
     },
@@ -76,9 +91,10 @@ export default {
   },
   render() {
     return (
-      <div
-        class={this.style['cdr-tooltip--wrapper']}
-      >
+      <div class={clsx(
+        this.style['cdr-tooltip--wrapper'],
+        this.$slots.trigger ? this.style['cdr-tooltip--position'] : '',
+      )}>
         <div ref="trigger">
           { this.$slots.trigger }
         </div>
@@ -89,7 +105,7 @@ export default {
           ref="popup"
           position={ this.position }
           autoPosition={ this.autoPosition }
-          opened={ this.open }
+          opened={ this.isOpen }
           id={this.id}
           onClosed={ this.closeTooltip }
         >

--- a/src/components/tooltip/__tests__/__snapshots__/CdrTooltip.spec.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/CdrTooltip.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CdrTooltip matches snapshot 1`] = `
 <div
-  class="cdr-tooltip--wrapper"
+  class="cdr-tooltip--wrapper cdr-tooltip--position"
 >
   <div>
     <button

--- a/src/components/tooltip/examples/Tooltip.vue
+++ b/src/components/tooltip/examples/Tooltip.vue
@@ -74,6 +74,38 @@
         We're using the internet right now!
       </div>
     </cdr-tooltip>
+
+    <hr>
+
+    <div
+      style="position: relative; width: max-content"
+      :class="containerClass"
+    >
+      <cdr-button
+        @mouseover="open = true"
+        @mouseleave="open = false"
+        @focus="open = true"
+        @blur="open = false"
+        aria-describedby="tooltip-custom-test"
+      >
+        tooltip with custom trigger
+      </cdr-button>
+      <cdr-tooltip
+        :position="position"
+        :auto-position="autoPos"
+        content-class="tooltip-override"
+        :open="open"
+        id="tooltip-custom-test"
+        @opened="tooltipHandler"
+        @closed="tooltipHandler"
+      >
+        <div>
+          Hello! This tooltip contains important information about the web site you are visiting!
+          We're using the internet right now!
+        </div>
+      </cdr-tooltip>
+
+    </div>
   </div>
 </template>
 
@@ -90,6 +122,7 @@ export default {
       position: 'top',
       autoPos: true,
       trigger: 'center',
+      open: false,
     };
   },
   computed: {

--- a/src/components/tooltip/styles/CdrTooltip.scss
+++ b/src/components/tooltip/styles/CdrTooltip.scss
@@ -1,9 +1,11 @@
 @import '../../../css/settings/index.scss';
 @import url('@rei/cedar/dist/style/cdr-popup.css');
 
+.cdr-tooltip--position {
+  position: relative;
+}
 
 .cdr-tooltip--wrapper {
-  position: relative;
   width: max-content;
   height: max-content;
 

--- a/src/css/settings/_options.vars.scss
+++ b/src/css/settings/_options.vars.scss
@@ -1,13 +1,1 @@
-/* ==========================================================================/*
-* Token option variables
-*
-* these are temporary variables, providing
-* cedar components mappings to previously available tokens.
-* These varables should be removed as tokens are available
-*
-=============================================================== */
-
-/* ---------------------
-* Outline
-* ------------------- */
 $default-outline: 0.2rem solid Highlight;


### PR DESCRIPTION
Adds ability to control open/close state of popover/tooltip programmatically rather than passing in a trigger slot. This will allow us to support the adventures use case where they mount their popover to a button that already exists in the thymeleaf template (https://git.rei.com/projects/FEDCOMP/repos/adventures-nav-popover/browse/src/AdventuresNavPopover.vue#159-165). 

Most consumers will not use this feature, but it should make these components more flexible without impacting the normal functionality.