### PR TITLE
feat(grid): create css-grid prototype component

### DIFF
--- a/src/components/examples.js
+++ b/src/components/examples.js
@@ -7,6 +7,7 @@ import card from 'componentsdir/card/examples/Cards';
 import checkbox from 'componentsdir/checkbox/examples/checkboxes';
 import cta from 'componentsdir/cta/examples/Cta';
 import formGroup from 'componentsdir/formGroup/examples/FormGroup';
+import gridTwo from 'componentsdir/gridTwo/examples/GridTwo';
 import grid from 'componentsdir/grid/examples/Grid';
 import icon from 'componentsdir/icon/examples/Icons';
 import image from 'componentsdir/image/examples/Images';
@@ -38,6 +39,7 @@ export default {
   cta,
   formGroup,
   grid,
+  gridTwo,
   icon,
   image,
   input,

--- a/src/components/gridTwo/CdrGridTwo.backstop.js
+++ b/src/components/gridTwo/CdrGridTwo.backstop.js
@@ -1,0 +1,5 @@
+module.exports = [{
+  url: 'http://localhost:3000/#/grid-two',
+  label: 'GridTwo',
+  responsive: true,
+}];

--- a/src/components/gridTwo/CdrGridTwo.jsx
+++ b/src/components/gridTwo/CdrGridTwo.jsx
@@ -1,0 +1,17 @@
+import style from './styles/CdrGridTwo.scss';
+
+export default {
+  name: 'CdrGridTwo',
+  data() {
+    return {
+      style,
+    };
+  },
+  render() {
+    return (
+      <div class={this.style['cdr-grid-two']}>
+        {this.$slots.default}
+      </div>
+    );
+  },
+};

--- a/src/components/gridTwo/__tests__/CdrGridTwo.spec.js
+++ b/src/components/gridTwo/__tests__/CdrGridTwo.spec.js
@@ -1,0 +1,13 @@
+import { shallowMount } from '@vue/test-utils';
+import CdrGridTwo from 'componentdir/gridTwo/CdrGridTwo';
+
+describe('CdrGridTwo', () => {
+  it('matches snapshot', () => {
+    const wrapper = shallowMount(CdrGridTwo);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  // it('has a failing test by default so you remember to do them', () => {
+  //   expect(false).toBe(true);
+  // });
+});

--- a/src/components/gridTwo/__tests__/__snapshots__/CdrGridTwo.spec.js.snap
+++ b/src/components/gridTwo/__tests__/__snapshots__/CdrGridTwo.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdrGridTwo matches snapshot 1`] = `
+<div
+  class="cdr-grid-two"
+/>
+`;

--- a/src/components/gridTwo/examples/GridTwo.vue
+++ b/src/components/gridTwo/examples/GridTwo.vue
@@ -1,0 +1,37 @@
+<template>
+  <cdr-grid class="custom-grid">
+    <div
+      v-for="item in items"
+      class="grid-item"
+      :key="item"
+    >
+      {{ item }}
+    </div>
+  </cdr-grid>
+</template>
+
+<script>
+import * as Components from 'srcdir/index';
+
+export default {
+  name: 'GridTwo',
+  components: {
+    ...Components,
+  },
+  data() {
+    return {
+      items: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    };
+  },
+};
+</script>
+
+<style>
+.custom-grid {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.grid-item {
+
+}
+</style>

--- a/src/components/gridTwo/examples/GridTwo.vue
+++ b/src/components/gridTwo/examples/GridTwo.vue
@@ -26,12 +26,20 @@ export default {
 };
 </script>
 
-<style>
+<style lang="scss">
 .custom-grid {
+  // 3 column at md or lg
   grid-template-columns: 1fr 1fr 1fr;
+
+  @include cdr-sm-mq-down {
+    // 1 column at xs or sm
+    grid-template-columns: 1fr;
+  }
 }
 
 .grid-item {
-
+  border: 1px solid black;
+  text-align: center;
+  padding: $cdr-space-one-x;
 }
 </style>

--- a/src/components/gridTwo/styles/CdrGridTwo.scss
+++ b/src/components/gridTwo/styles/CdrGridTwo.scss
@@ -1,0 +1,6 @@
+@import '../../../css/settings/index.scss';
+@import './vars/CdrGridTwo.vars.scss';
+
+.cdr-grid-two {
+  @include cdr-grid-two-base-mixin;
+}

--- a/src/components/gridTwo/styles/vars/CdrGridTwo.vars.scss
+++ b/src/components/gridTwo/styles/vars/CdrGridTwo.vars.scss
@@ -3,6 +3,6 @@
   gap: $cdr-space-one-x $cdr-space-one-x;
 
   @include cdr-md-mq-up {
-    gap: $cdr-space-one-x $cdr-space-one-x;
+    gap: $cdr-space-two-x $cdr-space-two-x;
   }
 }

--- a/src/components/gridTwo/styles/vars/CdrGridTwo.vars.scss
+++ b/src/components/gridTwo/styles/vars/CdrGridTwo.vars.scss
@@ -1,0 +1,8 @@
+@mixin cdr-grid-two-base-mixin() {
+  display: grid;
+  gap: $cdr-space-one-x $cdr-space-one-x;
+
+  @include cdr-md-mq-up {
+    gap: $cdr-space-one-x $cdr-space-one-x;
+  }
+}

--- a/src/dev/router.js
+++ b/src/dev/router.js
@@ -37,6 +37,7 @@ const routes = [
   { path: '/formGroups', name: 'Form Groups', component: Examples.formGroup },
   { path: '/form', name: 'Form Patterns', component: Examples.form },
   { path: '/grids', name: 'Grids', component: Examples.grid },
+  { path: '/grid-two', name: 'Grid v2', component: Examples.gridTwo },
   { path: '/icons', name: 'Icons', component: Examples.icon },
   { path: '/images', name: 'Images', component: Examples.image },
   { path: '/inputs', name: 'Input', component: Examples.input },

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export { default as CdrCheckbox } from './components/checkbox/CdrCheckbox';
 export { default as CdrCol } from './components/grid/CdrCol';
 export { default as CdrCta } from './components/cta/CdrCta';
 export { default as CdrFormGroup } from './components/formGroup/CdrFormGroup';
+export { default as CdrGrid } from './components/gridTwo/CdrGridTwo';
 // export all single icon components
 export * from './components/icon/index';
 export { default as CdrIcon } from './components/icon/CdrIcon';


### PR DESCRIPTION
<img width="1217" alt="Screen Shot 2020-12-16 at 11 32 30 AM" src="https://user-images.githubusercontent.com/48567940/102397203-6a87ec80-3f92-11eb-8a7d-b1237b270cba.png">

creates basic css-grid wrapper component so i can start working on doc site examples for parity with row/col.

https://css-tricks.com/snippets/css/complete-guide-grid/