### PR TITLE
refactor(image): refactor image to use object-fit/position

### DIFF
--- a/src/components/image/CdrImg.jsx
+++ b/src/components/image/CdrImg.jsx
@@ -4,8 +4,8 @@ import style from './styles/CdrImg.scss';
 
 export default {
   name: 'CdrImg',
-  inheritAttrs: false,
   mixins: [modifier],
+  inheritAttrs: false,
   props: {
     /**
      * Required. Image source url.
@@ -39,7 +39,7 @@ export default {
         '16-9'].indexOf(value) >= 0) || false,
     },
     /**
-     * Requires a `ratio`. Area to crop the image overflow to. {top, y-center, bottom} {left, x-center, right}
+     * Requires a `ratio`. Area to crop the image overflow to. {left, center, right} {top, center, bottom}
      */
     crop: {
       type: String,
@@ -72,9 +72,6 @@ export default {
     radiusClass() {
       return this.radius ? this.style[`cdr-image--${this.radius}`] : '';
     },
-    ratioClass() {
-      return this.ratio ? this.style[`cdr-image-ratio--${this.ratio}`] : '';
-    },
     coverClass() {
       const classObj = {};
       classObj[this.style['cdr-image-ratio__cover']] = true;
@@ -87,12 +84,23 @@ export default {
         objectPosition: this.crop,
       };
     },
+    ratioPct() {
+      if (this.ratio === 'square') {
+        return '100%';
+      }
+      if (this.ratio) {
+        const [x, y] = this.ratio.split('-');
+        return `${(y / x) * 100}%`;
+      }
+      return '0%';
+    },
   },
   render() {
     if (this.ratio) {
       return (
         <div
-          class={clsx(this.style['cdr-image-ratio'], this.ratioClass)}
+          style={{ '--ratio': this.ratioPct }}
+          class={this.style['cdr-image-ratio']}
         >
           <img
             style={this.cropObject}

--- a/src/components/image/CdrImg.jsx
+++ b/src/components/image/CdrImg.jsx
@@ -4,6 +4,7 @@ import style from './styles/CdrImg.scss';
 
 export default {
   name: 'CdrImg',
+  inheritAttrs: false,
   mixins: [modifier],
   props: {
     /**
@@ -21,19 +22,6 @@ export default {
       default: '',
     },
     /**
-     * Enable lazy loading.
-     */
-    lazy: {
-      type: Boolean,
-    },
-    /**
-     * Object of lazy options
-     */
-    lazyOpts: {
-      type: Object,
-      default: () => {},
-    },
-    /**
      * Aspect ratio of the media container. {auto, square, 1-2, 2-3, 3-4, 9-16, 2-1, 3-2, 4-3, 16-9}
      */
     ratio: {
@@ -48,33 +36,6 @@ export default {
         '2-1',
         '3-2',
         '4-3',
-        '16-9'].indexOf(value) >= 0) || false,
-    },
-    /**
-     * sm breakpoint and above
-     */
-    ratioSm: {
-      type: String,
-      validator: (value) => ([
-        'auto', 'square', '1-2', '2-3', '3-4', '9-16', '2-1', '3-2', '4-3',
-        '16-9'].indexOf(value) >= 0) || false,
-    },
-    /**
-     * md breakpoint and above
-     */
-    ratioMd: {
-      type: String,
-      validator: (value) => ([
-        'auto', 'square', '1-2', '2-3', '3-4', '9-16', '2-1', '3-2', '4-3',
-        '16-9'].indexOf(value) >= 0) || false,
-    },
-    /**
-     * lg breakpoint and above
-     */
-    ratioLg: {
-      type: String,
-      validator: (value) => ([
-        'auto', 'square', '1-2', '2-3', '3-4', '9-16', '2-1', '3-2', '4-3',
         '16-9'].indexOf(value) >= 0) || false,
     },
     /**
@@ -108,78 +69,42 @@ export default {
     baseClass() {
       return 'cdr-image';
     },
-    lazyClass() {
-      const classObj = {};
-      classObj['lazy-image'] = this.lazy;
-      return classObj;
-    },
     radiusClass() {
-      const classObj = {};
-      classObj[this.style[`cdr-image--${this.radius}`]] = this.radius;
-      return classObj;
+      return this.radius ? this.style[`cdr-image--${this.radius}`] : '';
     },
     ratioClass() {
-      const classObj = {};
-      classObj[this.style[`cdr-media-frame--${this.ratio}`]] = this.ratio;
-      classObj[this.style[`cdr-media-frame--${this.ratioSm}@sm`]] = this.ratioSm;
-      classObj[this.style[`cdr-media-frame--${this.ratioMd}@md`]] = this.ratioMd;
-      classObj[this.style[`cdr-media-frame--${this.ratioLg}@lg`]] = this.ratioLg;
-      return classObj;
+      return this.ratio ? this.style[`cdr-image-ratio--${this.ratio}`] : '';
     },
     coverClass() {
       const classObj = {};
-      classObj[this.style['cdr-media-frame__cover']] = true;
-      classObj[this.style['cdr-media-frame__cover--crop']] = this.crop;
-      classObj[this.style['cdr-media-frame__cover--cover']] = this.cover;
+      classObj[this.style['cdr-image-ratio__cover']] = true;
+      classObj[this.style['cdr-image-ratio__cover--crop']] = this.crop;
+      classObj[this.style['cdr-image-ratio__cover--cover']] = this.cover;
       return classObj;
     },
-    cropClass() {
-      const base = 'cdr-media-frame';
-      const cropArr = this.crop ? this.crop.split(' ') : [];
-      let final = [];
-
-      final = final.concat(cropArr.map((mod) => this.modifyClassName(base, mod)));
-
-      return final.join(' ');
-    },
-    styleObject() {
+    cropObject() {
       return {
-        backgroundImage: `url(${this.src})`,
+        objectPosition: this.crop,
       };
-    },
-    lazyAttrs() {
-      const attrObj = {};
-      if (this.lazy) {
-        Object.keys(this.lazyOpts).forEach((opt) => {
-          attrObj[`data-${opt}`] = this.lazyOpts[opt];
-        });
-      }
-      return attrObj;
     },
   },
   render() {
     if (this.ratio) {
       return (
         <div
-          class={clsx(this.style['cdr-media-frame'], this.ratioClass, this.cropClass)}
+          class={clsx(this.style['cdr-image-ratio'], this.ratioClass)}
         >
-          <div
-            class={clsx(this.coverClass, this.lazyClass, this.radiusClass)}
-            style={this.styleObject}
-            aria-hidden="true"
-            {...{ attrs: this.lazyAttrs }}
-          />
           <img
+            style={this.cropObject}
             class={clsx(
-              this.style['cdr-media-frame__image'],
-              this.style['cdr-media-frame__image--hidden'],
               this.style[this.baseClass],
               this.modifierClass,
               this.radiusClass,
+              this.coverClass,
             )}
             src={this.src}
             alt={this.alt}
-            {...{ on: this.$listeners }}
+            {...{ attrs: this.$attrs, on: this.$listeners }}
           />
         </div>
       );
@@ -191,7 +116,7 @@ export default {
             this.lazyClass)}
           src={this.src}
           alt={this.alt}
-          {...{ attrs: this.lazyAttrs, on: this.$listeners }}
+          {...{ attrs: this.$attrs, on: this.$listeners }}
         />);
   },
 };

--- a/src/components/image/__tests__/CdrImg.spec.js
+++ b/src/components/image/__tests__/CdrImg.spec.js
@@ -47,18 +47,15 @@ describe('CdrImg', () => {
     expect(wrapper.find('img').attributes().alt).toBe('test alt');
   });
 
-  it('adds lazy class and attrs', () => {
-    const wrapper = shallowMount(CdrImg, {
+  it('passes arbitrary HTML attrs through to image', () => {
+    const wrapper = mount(CdrImg, {
       propsData: {
         src: 'http://via.placeholder.com/350x150',
-        lazy: true,
-        lazyOpts: {
-          'src-lazy': 'http://via.placeholder.com/350',
-        },
+        loading: 'lazy',
+        ratio: 'square'
       }
     });
-    expect(wrapper.classes()).toContain('lazy-image');
-    expect(wrapper.attributes()['data-src-lazy']).toBe('http://via.placeholder.com/350');
+    expect(wrapper.find('img').attributes()['loading']).toBe('lazy');
   });
 
 

--- a/src/components/image/__tests__/__snapshots__/CdrImg.spec.js.snap
+++ b/src/components/image/__tests__/__snapshots__/CdrImg.spec.js.snap
@@ -10,17 +10,13 @@ exports[`CdrImg renders correctly 1`] = `
 
 exports[`CdrImg renders crop/ratio correctly 1`] = `
 <div
-  class="cdr-media-frame cdr-media-frame--square cdr-media-frame--left"
+  class="cdr-image-ratio cdr-image-ratio--square"
 >
-  <div
-    aria-hidden="true"
-    class="cdr-media-frame__cover cdr-media-frame__cover--crop cdr-media-frame__cover--cover"
-    style="background-image: url(http://placehold.it/1920x1080);"
-  />
   <img
     alt="crop left"
-    class="cdr-media-frame__image cdr-media-frame__image--hidden cdr-image"
+    class="cdr-image cdr-image-ratio__cover cdr-image-ratio__cover--crop cdr-image-ratio__cover--cover"
     src="http://placehold.it/1920x1080"
+    style="object-position: left;"
   />
 </div>
 `;

--- a/src/components/image/__tests__/__snapshots__/CdrImg.spec.js.snap
+++ b/src/components/image/__tests__/__snapshots__/CdrImg.spec.js.snap
@@ -10,7 +10,8 @@ exports[`CdrImg renders correctly 1`] = `
 
 exports[`CdrImg renders crop/ratio correctly 1`] = `
 <div
-  class="cdr-image-ratio cdr-image-ratio--square"
+  class="cdr-image-ratio"
+  style="--ratio: 100%;"
 >
   <img
     alt="crop left"

--- a/src/components/image/examples/demos/Cropping.vue
+++ b/src/components/image/examples/demos/Cropping.vue
@@ -31,7 +31,7 @@
           <cdr-img
             ratio="square"
             cover
-            crop="x-center"
+            crop="center"
             alt="crop x-center"
             src="http://placehold.it/1920x1080"
           />
@@ -84,7 +84,7 @@
           <cdr-img
             ratio="square"
             cover
-            crop="y-center"
+            crop="center"
             alt="crop y-center"
             src="http://placehold.it/1080x1920"
           />
@@ -148,7 +148,7 @@
           </cdr-text>
           <cdr-img
             ratio="16-9"
-            crop="top x-center"
+            crop="top center"
             alt="crop top x-center"
             :src="testImage"
           />
@@ -174,7 +174,7 @@
           </cdr-text>
           <cdr-img
             ratio="16-9"
-            crop="y-center left"
+            crop="center left"
             alt="crop y-center left"
             :src="testImage"
           />
@@ -187,7 +187,7 @@
           </cdr-text>
           <cdr-img
             ratio="16-9"
-            crop="y-center x-center"
+            crop="center center"
             alt="crop y-center x-center"
             :src="testImage"
           />
@@ -200,7 +200,7 @@
           </cdr-text>
           <cdr-img
             ratio="16-9"
-            crop="y-center right"
+            crop="center right"
             alt="crop y-center right"
             :src="testImage"
           />
@@ -213,7 +213,7 @@
           </cdr-text>
           <cdr-img
             ratio="16-9"
-            crop="bottom left"
+            crop="left bottom"
             alt="crop bottom left"
             :src="testImage"
           />
@@ -226,7 +226,7 @@
           </cdr-text>
           <cdr-img
             ratio="16-9"
-            crop="bottom x-center"
+            crop="center bottom"
             alt="crop bottom x-center"
             :src="testImage"
           />
@@ -239,7 +239,7 @@
           </cdr-text>
           <cdr-img
             ratio="16-9"
-            crop="bottom right"
+            crop="right bottom"
             alt="crop bottom right"
             :src="testImage"
           />

--- a/src/components/image/examples/demos/Mods.vue
+++ b/src/components/image/examples/demos/Mods.vue
@@ -18,6 +18,7 @@
             class="cdr-img-test"
             ratio="4-3"
             modifier="responsive"
+            loading="lazy"
             alt="ratio responsive"
             src="http://placehold.it/200x200"
           />

--- a/src/components/image/styles/CdrImg.scss
+++ b/src/components/image/styles/CdrImg.scss
@@ -1,30 +1,4 @@
 @import '../../../css/settings/index.scss';
-/* ==========================================================================
-  # CdrImg
-  
-  All values should map to variables in
-  vars/CdrImg.vars.pcss
-  in order to allow for theming
-
-  TOC:
-
-    :Base - Image
-      :Modifiers
-        :Style Variants
-    :Base - Media Frame
-      :Modifiers
-        :Aspect Ratios
-          :normal
-          :@small
-          :@medium
-          :@large
-        :Cropping
-      :Elements
-========================================================================== */
-
-/* ==========================================================================
-   # Image
-   ========================================================================== */
 
 .cdr-image {
   max-width: 100%;
@@ -61,7 +35,7 @@
    # MEDIA FRAME
    ========================================================================== */
 
-.cdr-media-frame {
+.cdr-image-ratio {
   position: relative;
   overflow: hidden;
 
@@ -114,198 +88,20 @@
     padding-bottom: 56.25%;
   }
 
-  /* Aspect ratios @ small
-    ========== */
-  @include cdr-sm-mq {
-    &--auto\@sm::before {
-      padding-bottom: 0;
-    }
-
-    &--square\@sm::before {
-      padding-bottom: 100%;
-    }
-
-    &--1-2\@sm::before {
-      padding-bottom: 200%;
-    }
-
-    &--2-3\@sm::before {
-      padding-bottom: 150%;
-    }
-
-    &--3-4\@sm::before {
-      padding-bottom: 133.33333333333%;
-    }
-
-    &--9-16\@sm::before {
-      padding-bottom: 177.77777777778%;
-    }
-
-    &--2-1\@sm::before {
-      padding-bottom: 50%;
-    }
-
-    &--3-2\@sm::before {
-      padding-bottom: 66.6666666667%;
-    }
-
-    &--4-3\@sm::before {
-      padding-bottom: 75%;
-    }
-
-    &--16-9\@sm::before {
-      padding-bottom: 56.25%;
-    }
-  }
-
-  /* Aspect ratios @ medium
-    ========== */
-  @include cdr-md-mq {
-    &--auto\@md::before {
-      padding-bottom: 0;
-    }
-
-    &--square\@md::before {
-      padding-bottom: 100%;
-    }
-
-    &--1-2\@md::before {
-      padding-bottom: 200%;
-    }
-
-    &--2-3\@md::before {
-      padding-bottom: 150%;
-    }
-
-    &--3-4\@md::before {
-      padding-bottom: 133.33333333333%;
-    }
-
-    &--9-16\@md::before {
-      padding-bottom: 177.77777777778%;
-    }
-
-    &--2-1\@md::before {
-      padding-bottom: 50%;
-    }
-
-    &--3-2\@md::before {
-      padding-bottom: 66.6666666667%;
-    }
-
-    &--4-3\@md::before {
-      padding-bottom: 75%;
-    }
-
-    &--16-9\@md::before {
-      padding-bottom: 56.25%;
-    }
-  }
-
-  /* Aspect ratios @ large
-    ========== */
-  @include cdr-lg-mq {
-    &--auto\@lg::before {
-      padding-bottom: 0;
-    }
-
-    &--square\@lg::before {
-      padding-bottom: 100%;
-    }
-
-    &--1-2\@lg::before {
-      padding-bottom: 200%;
-    }
-
-    &--2-3\@lg::before {
-      padding-bottom: 150%;
-    }
-
-    &--3-4\@lg::before {
-      padding-bottom: 133.33333333333%;
-    }
-
-    &--9-16\@lg::before {
-      padding-bottom: 177.77777777778%;
-    }
-
-    &--2-1\@lg::before {
-      padding-bottom: 50%;
-    }
-
-    &--3-2\@lg::before {
-      padding-bottom: 66.6666666667%;
-    }
-
-    &--4-3\@lg::before {
-      padding-bottom: 75%;
-    }
-
-    &--16-9\@lg::before {
-      padding-bottom: 56.25%;
-    }
-  }
-
-  /* Cropping variants
-    ========================================================================== */
-
-  &--x-center > &__cover {
-    background-position-x: center;
-  }
-
-  &--y-center > &__cover {
-    background-position-y: center;
-  }
-
-  &--left > &__cover {
-    background-position-x: left;
-  }
-
-  &--right > &__cover {
-    background-position-x: right;
-  }
-
-  &--top > &__cover {
-    background-position-y: top;
-  }
-
-  &--bottom > &__cover {
-    background-position-y: bottom;
-  }
-
-  /* Block elements
-    ========================================================================== */
-
-  &__image {
-    z-index: -1;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-
-    /* Hide image when only used for a11y */
-    &--hidden {
-      opacity: 0;
-    }
-  }
-
   &__cover {
     position: absolute;
     top: 0;
     left: 0;
     height: 100%;
     width: 100%;
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center;
+    object-fit: contain;
 
     &--crop {
-      background-size: auto;
+      object-fit: none;
     }
 
     &--cover {
-      background-size: cover;
+      object-fit: cover;
     }
   }
 }

--- a/src/components/image/styles/CdrImg.scss
+++ b/src/components/image/styles/CdrImg.scss
@@ -43,49 +43,7 @@
     content: '';
     height: 0;
     display: block;
-  }
-
-  /* Aspect ratios
-    ========================================================================== */
-
-  &--auto::before {
-    padding-bottom: 0;
-  }
-
-  &--square::before {
-    padding-bottom: 100%;
-  }
-
-  &--1-2::before {
-    padding-bottom: 200%;
-  }
-
-  &--2-3::before {
-    padding-bottom: 150%;
-  }
-
-  &--3-4::before {
-    padding-bottom: 133.33333333333%;
-  }
-
-  &--9-16::before {
-    padding-bottom: 177.77777777778%;
-  }
-
-  &--2-1::before {
-    padding-bottom: 50%;
-  }
-
-  &--3-2::before {
-    padding-bottom: 66.6666666667%;
-  }
-
-  &--4-3::before {
-    padding-bottom: 75%;
-  }
-
-  &--16-9::before {
-    padding-bottom: 56.25%;
+    padding-bottom: var(--ratio);
   }
 
   &__cover {


### PR DESCRIPTION
- refactors image to use object-fit/position on an actual image instead of a background-image on a div. Enables lazy loading or any other native image features.
- we still end up needing a wrapper div to forcibly set an aspect ratio of an image. Object-fit is good at letting you maintain the aspect ratio of an image, maybe srcset/sizes obviates the need to forcibly set an aspect ratio? Consumers may be able to migrate away from ratio to use less markup, will need to investigate more in some actual projects.
- removes responsive ratio options. i checked bitbucket and they aren't used anywhere
- removes lazy loading props. These are hardcoded to match the API of an older "rei-lazy-loader" package. Consumers can set any attrs they need on the image.

old: 8kb JS, 5kb CSS
new: 6kb JS, 0.69kb CSS

~7kb smaller (!!!!!)