### PR TITLE
feat(grid): add tag option to grid to support list markup

### DIFF
--- a/src/components/gridTwo/CdrGridTwo.jsx
+++ b/src/components/gridTwo/CdrGridTwo.jsx
@@ -18,6 +18,10 @@ export default {
       ),
       default: 'medium@xs medium@sm large@md large@lg',
     },
+    tag: {
+      type: String,
+      default: 'div',
+    },
   },
   data() {
     return {
@@ -36,10 +40,11 @@ export default {
     },
   },
   render() {
+    const Component = this.tag;
     return (
-      <div class={clsx(this.style['cdr-grid-two'], this.gutterClass)}>
+      <Component class={clsx(this.style['cdr-grid-two'], this.gutterClass)}>
         {this.$slots.default}
-      </div>
+      </Component>
     );
   },
 };

--- a/src/components/gridTwo/__tests__/CdrGridTwo.spec.js
+++ b/src/components/gridTwo/__tests__/CdrGridTwo.spec.js
@@ -7,7 +7,17 @@ describe('CdrGridTwo', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  // it('has a failing test by default so you remember to do them', () => {
-  //   expect(false).toBe(true);
-  // });
+
+  it('complex example matches snapshot', () => {
+    const wrapper = shallowMount(CdrGridTwo, {
+      propsData: {
+        gutter: 'none@xs large@sm medium@md small@sm',
+        tag: 'ul'
+      },
+      slots: {
+        default: '<li>hey</li>'
+      }
+    });
+    expect(wrapper.element).toMatchSnapshot();
+  });
 });

--- a/src/components/gridTwo/__tests__/__snapshots__/CdrGridTwo.spec.js.snap
+++ b/src/components/gridTwo/__tests__/__snapshots__/CdrGridTwo.spec.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CdrGridTwo complex example matches snapshot 1`] = `
+<ul
+  class="cdr-grid-two cdr-grid-two--gutter-none@xs cdr-grid-two--gutter-large@sm cdr-grid-two--gutter-medium@md cdr-grid-two--gutter-small@sm"
+>
+  <li>
+    hey
+  </li>
+</ul>
+`;
+
 exports[`CdrGridTwo matches snapshot 1`] = `
 <div
   class="cdr-grid-two cdr-grid-two--gutter-medium@xs cdr-grid-two--gutter-medium@sm cdr-grid-two--gutter-large@md cdr-grid-two--gutter-large@lg"

--- a/src/components/gridTwo/examples/GridTwo.vue
+++ b/src/components/gridTwo/examples/GridTwo.vue
@@ -1,13 +1,37 @@
 <template>
-  <cdr-grid class="custom-grid">
-    <div
-      v-for="item in items"
-      class="grid-item"
-      :key="item"
-    >
-      {{ item }}
-    </div>
-  </cdr-grid>
+  <div>
+    <cdr-grid class="custom-grid">
+      <div
+        v-for="item in items"
+        class="grid-item"
+        :key="item"
+      >
+        {{ item }}
+      </div>
+    </cdr-grid>
+
+    <h2>Gutter Example</h2>
+    <cdr-grid class="custom-grid" gutter="none@xs small@sm medium@md large@lg">
+      <div
+        v-for="item in items"
+        class="grid-item"
+        :key="item"
+      >
+        {{ item }}
+      </div>
+    </cdr-grid>
+
+    <h2>List Based Example</h2>
+    <cdr-grid class="custom-grid" tag="ul">
+      <li
+        v-for="item in items"
+        class="grid-item"
+        :key="item"
+      >
+        {{ item }}
+      </li>
+    </cdr-grid>
+  </div>
 </template>
 
 <script>

--- a/src/components/gridTwo/styles/vars/CdrGridTwo.vars.scss
+++ b/src/components/gridTwo/styles/vars/CdrGridTwo.vars.scss
@@ -1,5 +1,8 @@
 @mixin cdr-grid-two-base-mixin() {
   display: grid;
+  list-style: none;
+  margin: 0;
+  padding: 0;
   gap: $cdr-space-one-x $cdr-space-one-x;
 }
 


### PR DESCRIPTION
CdrRow/CdrCol had a `type` option that could be set to `list` which would turn it into a `ul`/`li` structure. Seems to make more sense to accept any tag here.