### PR TITLE
Scope cdr text

### DIFF
--- a/src/components/quote/styles/CdrQuote.scss
+++ b/src/components/quote/styles/CdrQuote.scss
@@ -1,3 +1,4 @@
+@import url('@rei/cedar/dist/style/cdr-text.css');
 @import '../../../css/settings/index.scss';
 @import './vars/CdrQuote.vars.scss';
 

--- a/src/components/text/CdrText.jsx
+++ b/src/components/text/CdrText.jsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import style from './styles/CdrText.scss';
 import modifier from '../../mixins/modifier';
 
 /**
@@ -22,9 +23,14 @@ export default {
       return 'cdr-text';
     },
   },
+  data() {
+    return {
+      style,
+    }
+  },
   render() {
     const Component = this.tag;
-    return (<Component class={clsx(this.baseClass, this.modifierClass)}>
+    return (<Component class={clsx(this.style[this.baseClass], this.modifierClass)}>
       {this.$slots.default}
     </Component>);
   },

--- a/src/components/text/CdrText.jsx
+++ b/src/components/text/CdrText.jsx
@@ -25,12 +25,12 @@ export default {
   },
   data() {
     return {
-      style,
+      s: style, // named `s` not `style` so that modifierClass works for text utils
     }
   },
   render() {
     const Component = this.tag;
-    return (<Component class={clsx(this.style[this.baseClass], this.modifierClass)}>
+    return (<Component class={clsx(this.s[this.baseClass], this.modifierClass)}>
       {this.$slots.default}
     </Component>);
   },

--- a/src/components/text/CdrText.jsx
+++ b/src/components/text/CdrText.jsx
@@ -26,7 +26,7 @@ export default {
   data() {
     return {
       s: style, // named `s` not `style` so that modifierClass works for text utils
-    }
+    };
   },
   render() {
     const Component = this.tag;

--- a/src/components/text/styles/CdrText.scss
+++ b/src/components/text/styles/CdrText.scss
@@ -1,12 +1,6 @@
 @import '../../../css/settings/index.scss';
 
-.cdr-text,
-h1.cdr-text,
-h2.cdr-text,
-h3.cdr-text,
-h4.cdr-text,
-h5.cdr-text,
-h6.cdr-text {
+.cdr-text {
   @include cdr-text-default;
   margin: 0;
 }


### PR DESCRIPTION
since we decoupled the cdr-text base styling from the utility classes, we can now scope the base class and delete all the weird specificity stuff we had to avoid c1 clashes. 

This makes it easier for consumers to style cdr-text elements, as otherwise you'd have to do like `h3.whatever-class {@include cdr-text-something;}` to apply a mixin to a `<cdr-text tag="h3" class="whatever-class">`.

We need to name the style object `s`(or anything that is not `style`)  in cdr-text because otherwise buildClass will try to module-ize the modifierClass which is actually a text utility https://github.com/rei/rei-cedar/blob/next/src/mixins/buildClass.js#L40-L44
