### PR TITLE
Winter buggies

### DIFF
--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -3,6 +3,8 @@ import CdrIcon from '../icon/CdrIcon';
 import modifier from '../../mixins/modifier';
 import style from './styles/CdrBreadcrumb.scss';
 
+// BREADCRUMB ISSUE!!!
+
 export default {
   name: 'CdrBreadcrumb',
   components: {
@@ -125,9 +127,9 @@ export default {
   methods: {
     handleEllipsisClick() {
       this.truncate = false;
-      this.$nextTick(() => {
+      setTimeout(() => {
         this.$el.querySelector('li *').focus();
-      });
+      }, 1);
     },
   },
   render() {

--- a/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
+++ b/src/components/breadcrumb/__tests__/CdrBreadcrumb.spec.js
@@ -133,7 +133,7 @@ describe('CdrBreadcrumb', () => {
     expect(wrapper.text()).toBe('http://rei.com TEST Scoped cdr-breadcrumb__link');
   });
 
-  it('applies focus to first breadcrumb on ellipsis click', async () => {
+  it('applies focus to first breadcrumb on ellipsis click', async (done) => {
     const elem = document.createElement('div')
     if (document.body) {
       document.body.appendChild(elem)
@@ -145,9 +145,12 @@ describe('CdrBreadcrumb', () => {
       attachTo: elem, // enables focus testing
     });
     wrapper.vm.handleEllipsisClick();
-    await wrapper.vm.$nextTick();
-    expect(document.activeElement.textContent).toBe(itemsA[0].item.name);
-    wrapper.destroy();
+    return setTimeout(function() {
+
+      expect(document.activeElement.textContent).toBe(itemsA[0].item.name);
+      wrapper.destroy();
+      done();
+    }, 2)
   });
 
 });

--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -9,6 +9,9 @@ import onTransitionEnd from './onTransitionEnd';
 import CdrButton from '../button/CdrButton';
 import IconXLg from '../icon/comps/x-lg';
 
+// TODO: simplify transitionEnd logic
+// DO NOT manipulate open/close in transitionend use another variable
+
 export default {
   name: 'CdrModal',
   components: {
@@ -54,7 +57,6 @@ export default {
       keyHandler: null,
       lastActive: null,
       focusHandler: null,
-      reallyClosed: !this.opened,
       isOpening: false,
       offset: null,
       headerHeight: 0,
@@ -152,7 +154,6 @@ export default {
       const { activeElement } = document;
       this.addNoScroll();
       this.isOpening = true;
-      this.reallyClosed = false;
       this.lastActive = activeElement;
 
       this.$nextTick(() => {
@@ -184,7 +185,6 @@ export default {
           this.unsubscribe();
           this.removeNoScroll();
           this.unsubscribe = null;
-          this.reallyClosed = true;
 
           // handle scroll-behavior: smooth
           if (documentElement) documentElement.style.scrollBehavior = 'auto';
@@ -253,7 +253,6 @@ export default {
       wrapperClass,
       overlayClass,
       contentClass,
-      reallyClosed,
     } = this;
     return (
       <div
@@ -287,7 +286,7 @@ export default {
           >
             {this.$slots.modal || (<div
               class={clsx(this.style['cdr-modal__innerWrap'], contentClass)}
-              style={reallyClosed
+              style={!opened
                 ? { display: 'none' }
                 : undefined
               }

--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -61,8 +61,6 @@ export default {
       offset: null,
       headerHeight: 0,
       totalHeight: 0,
-      scrollHeight: 0,
-      offsetHeight: 0,
       fullscreen: false,
     };
   },
@@ -87,9 +85,6 @@ export default {
       return this.totalHeight
         - this.headerHeight
         - this.verticalSpace;
-    },
-    scrolling() {
-      return this.scrollHeight > this.offsetHeight;
     },
   },
   watch: {
@@ -123,8 +118,6 @@ export default {
         this.totalHeight = window.innerHeight;
         this.fullscreen = window.innerWidth < CdrBreakpointSm;
         this.headerHeight = this.$refs.header.offsetHeight;
-        this.scrollHeight = this.$refs.content.scrollHeight;
-        this.offsetHeight = this.$refs.content.offsetHeight;
       });
     },
     handleKeyDown({ key }) {
@@ -334,13 +327,6 @@ export default {
                     >
                       {this.$slots.default}
                     </div>
-                    {
-                      this.scrolling && (
-                        <div
-                        class={this.style['cdr-modal__text-fade']}
-                      />
-                      )
-                    }
                   </div>
                 </div>
               </section>

--- a/src/components/modal/__tests__/CdrModal.spec.js
+++ b/src/components/modal/__tests__/CdrModal.spec.js
@@ -25,15 +25,6 @@ describe('CdrModal.vue', () => {
     });
 
     expect(wrapper.element).toMatchSnapshot();
-    expect(wrapper.find('.cdr-modal__text-fade').exists()).toBe(true);
-
-    wrapper.setProps({ opened: false });
-    await wrapper.vm.$nextTick();
-
-    setTimeout(() => {
-      expect(wrapper.vm.reallyClosed).toBe(true);
-      wrapper.destroy();
-    }, 500);
   });
 
   it('leaves optional slots empty, handleOpened', async () => {
@@ -226,7 +217,6 @@ describe('CdrModal.vue', () => {
     await wrapper.vm.$nextTick();
 
     setTimeout(() => {
-      expect(wrapper.vm.reallyClosed).toBe(true);
       expect(wrapper.vm.unsubscribe).toBe(null);
       wrapper.destroy();
     }, 500);

--- a/src/components/modal/__tests__/CdrModal.spec.js
+++ b/src/components/modal/__tests__/CdrModal.spec.js
@@ -5,7 +5,7 @@ import Vue from 'vue';
 import CdrButton from 'componentdir/button/CdrButton';
 
 describe('CdrModal.vue', () => {
-  it('default open, scrolling', async () => {
+  it('default open', async () => {
     const elem = document.createElement('div')
     if (document.body) {
       document.body.appendChild(elem)
@@ -17,9 +17,6 @@ describe('CdrModal.vue', () => {
       },
       slots: {
         default: 'Sticky content',
-      },
-      computed: {
-        scrolling: () => true,
       },
       attachTo: elem,
     });
@@ -96,7 +93,7 @@ describe('CdrModal.vue', () => {
     wrapper.destroy();
   });
 
-  it('scrolling and fullscreen snapshot', () => {
+  it('fullscreen snapshot', () => {
     const elem = document.createElement('div')
     if (document.body) {
       document.body.appendChild(elem)
@@ -109,8 +106,6 @@ describe('CdrModal.vue', () => {
       },
       data() {
         return {
-          offsetHeight: 400,
-          scrollHeight: 500,
           fullscreen: true,
         };
       },
@@ -123,7 +118,6 @@ describe('CdrModal.vue', () => {
       attachTo: elem,
     });
 
-    expect(wrapper.vm.scrolling).toBe(true);
     expect(wrapper.element).toMatchSnapshot();
     wrapper.destroy();
   });

--- a/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
+++ b/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CdrModal.vue default open, scrolling 1`] = `
+exports[`CdrModal.vue default open 1`] = `
 <div
   class="cdr-modal"
 >
@@ -67,8 +67,82 @@ exports[`CdrModal.vue default open, scrolling 1`] = `
               >
                 Sticky content
               </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    <div
+      tabindex="0"
+    />
+  </div>
+</div>
+`;
+
+exports[`CdrModal.vue fullscreen snapshot 1`] = `
+<div
+  class="cdr-modal"
+>
+  <div
+    class="cdr-modal__outerWrap"
+  >
+    <div
+      aria-hidden="true"
+      class="cdr-modal__overlay"
+    />
+    <div
+      tabindex="0"
+    />
+    <div
+      aria-label="Label is the modal title"
+      aria-modal="true"
+      class="cdr-modal__contentWrap cdr-modal__dialog"
+      role="dialog"
+      tabindex="-1"
+    >
+      <div
+        class="cdr-modal__innerWrap"
+      >
+        <section>
+          <div
+            class="cdr-modal__content"
+          >
+            <div
+              class="cdr-modal__header"
+            >
               <div
-                class="cdr-modal__text-fade"
+                class="cdr-modal__title"
+              >
+                <h1>
+                  Label is the modal title
+                </h1>
+              </div>
+              <button
+                aria-label="Close"
+                class="cdr-button cdr-button--primary cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="cdr-icon cdr-icon--inherit-color"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.415 12.006l5.295-5.292a1 1 0 00-1.414-1.415L12 10.591 6.71 5.296A1 1 0 005.295 6.71l5.292 5.295-5.295 5.292a1 1 0 101.414 1.414l5.295-5.292 5.292 5.295a1 1 0 001.414-1.414l-5.292-5.294z"
+                    role="presentation"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              class="cdr-modal__text"
+              role="document"
+            >
+              <div
+                class="cdr-modal__text-content"
+                style="max-height: -32px;"
+                tabindex="0"
               />
             </div>
           </div>
@@ -150,86 +224,6 @@ exports[`CdrModal.vue leaves optional slots empty, handleOpened 1`] = `
               >
                 Main content
               </div>
-            </div>
-          </div>
-        </section>
-      </div>
-    </div>
-    <div
-      tabindex="0"
-    />
-  </div>
-</div>
-`;
-
-exports[`CdrModal.vue scrolling and fullscreen snapshot 1`] = `
-<div
-  class="cdr-modal"
->
-  <div
-    class="cdr-modal__outerWrap"
-  >
-    <div
-      aria-hidden="true"
-      class="cdr-modal__overlay"
-    />
-    <div
-      tabindex="0"
-    />
-    <div
-      aria-label="Label is the modal title"
-      aria-modal="true"
-      class="cdr-modal__contentWrap cdr-modal__dialog"
-      role="dialog"
-      tabindex="-1"
-    >
-      <div
-        class="cdr-modal__innerWrap"
-      >
-        <section>
-          <div
-            class="cdr-modal__content"
-          >
-            <div
-              class="cdr-modal__header"
-            >
-              <div
-                class="cdr-modal__title"
-              >
-                <h1>
-                  Label is the modal title
-                </h1>
-              </div>
-              <button
-                aria-label="Close"
-                class="cdr-button cdr-button--primary cdr-button--icon-only cdr-button--with-background cdr-modal__close-button"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="cdr-icon cdr-icon--inherit-color"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13.415 12.006l5.295-5.292a1 1 0 00-1.414-1.415L12 10.591 6.71 5.296A1 1 0 005.295 6.71l5.292 5.295-5.295 5.292a1 1 0 101.414 1.414l5.295-5.292 5.292 5.295a1 1 0 001.414-1.414l-5.292-5.294z"
-                    role="presentation"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="cdr-modal__text"
-              role="document"
-            >
-              <div
-                class="cdr-modal__text-content"
-                style="max-height: -32px;"
-                tabindex="0"
-              />
-              <div
-                class="cdr-modal__text-fade"
-              />
             </div>
           </div>
         </section>

--- a/src/components/modal/styles/CdrModal.scss
+++ b/src/components/modal/styles/CdrModal.scss
@@ -103,17 +103,6 @@ $modal-animation-duration: 150ms;
     position: relative;
   }
 
-  &__text-fade {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    height: $cdr-space-two-x;
-    /* full transparency doesn't fly on safari */
-    background: linear-gradient(rgba(255,255,255,0.001), rgba(255,255,255,1));
-    background-attachment: scroll;
-    width: 100%;
-  }
-
   @media (min-width: $cdr-breakpoint-sm) {
     &__outerWrap {
       padding: $cdr-space-one-x;

--- a/src/components/pagination/CdrPagination.jsx
+++ b/src/components/pagination/CdrPagination.jsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import IconCaretLeft from '../icon/comps/caret-left';
 import IconCaretRight from '../icon/comps/caret-right';
 import CdrSelect from '../select/CdrSelect';
+import propValidator from '../../utils/propValidator';
 import style from './styles/CdrPagination.scss';
 
 export default {
@@ -46,9 +47,13 @@ export default {
         return result;
       },
     },
-    nested: {
-      type: Boolean,
-      default: false,
+    linkTag: {
+      type: String,
+      default: 'a',
+      validator: (value) => propValidator(
+        value,
+        ['a', 'button'],
+      ),
     },
     forLabel: {
       type: String,
@@ -67,9 +72,6 @@ export default {
     };
   },
   computed: {
-    linkTag() {
-      return this.nested ? 'button' : 'a';
-    },
     // track value internally (for use with select vmodel) and update external value when internal changes
     innerValue: {
       get() {

--- a/src/components/pagination/CdrPagination.jsx
+++ b/src/components/pagination/CdrPagination.jsx
@@ -46,6 +46,14 @@ export default {
         return result;
       },
     },
+    nested: {
+      type: Boolean,
+      default: false,
+    },
+    forLabel: {
+      type: String,
+      default: '',
+    },
     /** @ignore used for binding v-model, represents the current page */
     value: {
       type: Number,
@@ -59,6 +67,9 @@ export default {
     };
   },
   computed: {
+    linkTag() {
+      return this.nested ? 'button' : 'a';
+    },
     // track value internally (for use with select vmodel) and update external value when internal changes
     innerValue: {
       get() {
@@ -80,6 +91,9 @@ export default {
     },
     nextPageIdx() {
       return this.currentIdx + 1;
+    },
+    ariaLabel() {
+      return this.forLabel || 'Pagination';
     },
     /**
      * Creates an array of the pages that should be shown as links with logic for truncation.
@@ -165,13 +179,14 @@ export default {
       };
     },
     prevEl() {
+      const LinkTag = this.linkTag;
       return this.innerValue > this.pages[0].page ? (
         <li>
           {this.$scopedSlots.prevLink
             ? this.$scopedSlots.prevLink(this.prevElAttrs)
-            : (<a
+            : (<LinkTag
               {... { attrs: this.prevElAttrs.attrs }}
-              href={this.prevElAttrs.href}
+              href={LinkTag === 'a' && this.prevElAttrs.href}
               ref={this.prevElAttrs.attrs.ref}
               onClick={this.prevElAttrs.click}
             >
@@ -179,7 +194,7 @@ export default {
                 class={this.prevElAttrs.iconClass}
               />
               {this.prevElAttrs.content}
-            </a>)
+            </LinkTag>)
           }
         </li>
       ) : (
@@ -220,13 +235,14 @@ export default {
       };
     },
     nextEl() {
+      const LinkTag = this.linkTag;
       return this.innerValue < this.pages[this.totalPageData - 1].page ? (
         <li>
           {this.$scopedSlots.nextLink
             ? this.$scopedSlots.nextLink(this.nextElAttrs)
-            : (<a
+            : (<LinkTag
               {... { attrs: this.nextElAttrs.attrs }}
-              href={this.nextElAttrs.href}
+              href={LinkTag === 'a' && this.nextElAttrs.href}
               ref={this.nextElAttrs.attrs.ref}
               onClick={this.nextElAttrs.click}
             >
@@ -234,7 +250,7 @@ export default {
               <this.nextElAttrs.iconComponent
                 class={this.nextElAttrs.iconClass}
               />
-            </a>)
+            </LinkTag>)
           }
 
         </li>
@@ -368,19 +384,20 @@ export default {
         content: n.page,
       };
 
+      const LinkTag = this.linkTag;
       return (this.$scopedSlots.link ? this.$scopedSlots.link(linkData)
-        : <a
+        : <LinkTag
           {... { attrs: linkData.attrs } }
-          href={linkData.href}
+          href={LinkTag === 'a' && linkData.href}
           onClick={linkData.click}
           ref={linkData.attrs.ref}
-        >{ linkData.content }</a>
+        >{ linkData.content }</LinkTag>
       );
     },
   },
   render() {
     return (
-      <nav aria-label="Pagination">
+      <nav aria-label={this.ariaLabel}>
         <ol class={this.style['cdr-pagination']}>
           {this.prevEl}
           {this.desktopEl}

--- a/src/components/pagination/__tests__/CdrPagination.spec.js
+++ b/src/components/pagination/__tests__/CdrPagination.spec.js
@@ -43,12 +43,12 @@ describe('CdrPagination', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('renders nested pagination correctly', async () => {
+  it('renders button pagination correctly', async () => {
     const wrapper = mount(CdrPagination, {
       propsData: {
         pages: makePages(20),
         value: 1,
-        nested: true,
+        linkTag: 'button',
       },
     });
     wrapper.setData({ componentID: 'test1' });
@@ -135,12 +135,12 @@ describe('CdrPagination', () => {
     expect(wrapper.attributes('aria-label')).toBe('Pagination for reviews');
   });
 
-  it('renders links instead of buttons when nested', () => {
+  it('can render buttons instead of links', () => {
     const wrapper = shallowMount(CdrPagination, {
       propsData: {
         pages: makePages(20),
         value: 1,
-        nested: true,
+        linkTag: 'button',
       },
     });
     expect(wrapper.findAll('li a').length).toBe(0);

--- a/src/components/pagination/__tests__/CdrPagination.spec.js
+++ b/src/components/pagination/__tests__/CdrPagination.spec.js
@@ -43,6 +43,19 @@ describe('CdrPagination', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
+  it('renders nested pagination correctly', async () => {
+    const wrapper = mount(CdrPagination, {
+      propsData: {
+        pages: makePages(20),
+        value: 1,
+        nested: true,
+      },
+    });
+    wrapper.setData({ componentID: 'test1' });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
   it('renders scoped slot correctly', async () => {
     const wrapper = mount(CdrPagination, {
       propsData: {
@@ -99,6 +112,39 @@ describe('CdrPagination', () => {
       },
     });
     expect(wrapper.element.tagName).toBe('NAV');
+  });
+
+  it('sets default pagination aria-label', () => {
+    const wrapper = shallowMount(CdrPagination, {
+      propsData: {
+        pages: makePages(20),
+        value: 1,
+      },
+    });
+    expect(wrapper.attributes('aria-label')).toBe('Pagination');
+  });
+
+  it('allows for aria-label override', () => {
+    const wrapper = shallowMount(CdrPagination, {
+      propsData: {
+        pages: makePages(20),
+        value: 1,
+        forLabel: 'Pagination for reviews'
+      },
+    });
+    expect(wrapper.attributes('aria-label')).toBe('Pagination for reviews');
+  });
+
+  it('renders links instead of buttons when nested', () => {
+    const wrapper = shallowMount(CdrPagination, {
+      propsData: {
+        pages: makePages(20),
+        value: 1,
+        nested: true,
+      },
+    });
+    expect(wrapper.findAll('li a').length).toBe(0);
+    expect(wrapper.findAll('li button').length).toBe(7);
   });
 
   it('sorts 20 pages correctly', async () => {

--- a/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
@@ -1,5 +1,197 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CdrPagination renders button pagination correctly 1`] = `
+<nav
+  aria-label="Pagination"
+>
+  <ol
+    class="cdr-pagination"
+  >
+    <li
+      aria-hidden="true"
+    >
+      <span
+        aria-disabled="true"
+        class="cdr-pagination__link cdr-pagination__prev cdr-pagination__link--disabled"
+      >
+        <svg
+          aria-hidden="true"
+          class="cdr-icon cdr-icon--inherit-color cdr-pagination__caret--prev"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 12c0 .273.11.521.288.702l5.005 5.005a1 1 0 001.414-1.414L10.415 12l4.295-4.295a1 1 0 00-1.417-1.412l-4.98 4.98A.997.997 0 008 12z"
+            role="presentation"
+          />
+        </svg>
+        Prev
+      </span>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-current="page"
+        aria-label="Current page, page 1"
+        class="cdr-pagination__link current"
+        ref="page-link-1-test1"
+      >
+        1
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 2"
+        class="cdr-pagination__link"
+        ref="page-link-2-test1"
+      >
+        2
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 3"
+        class="cdr-pagination__link"
+        ref="page-link-3-test1"
+      >
+        3
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 4"
+        class="cdr-pagination__link"
+        ref="page-link-4-test1"
+      >
+        4
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 5"
+        class="cdr-pagination__link"
+        ref="page-link-5-test1"
+      >
+        5
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <span
+        class="cdr-pagination__ellipse"
+      >
+        …
+      </span>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 20"
+        class="cdr-pagination__link"
+        ref="page-link-20-test1"
+      >
+        20
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--select"
+    >
+      <div>
+        <div
+          class="cdr-label-standalone"
+        />
+        <div
+          class="cdr-select-outer-wrap"
+        >
+          <div
+            class="cdr-select-wrap"
+          >
+            <select
+              aria-label="Navigate to page"
+              class="cdr-select cdr-select--primary"
+              id="select-test1"
+            >
+              <option
+                value="1"
+              >
+                Page 1
+              </option>
+              <option
+                value="2"
+              >
+                Page 2
+              </option>
+              <option
+                value="3"
+              >
+                Page 3
+              </option>
+              <option
+                value="4"
+              >
+                Page 4
+              </option>
+              <option
+                value="5"
+              >
+                Page 5
+              </option>
+              <option
+                value="20"
+              >
+                Page 20
+              </option>
+            </select>
+            <svg
+              aria-hidden="true"
+              class="cdr-icon cdr-select__caret"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 16c.273 0 .521-.11.702-.288l5.005-5.005a1 1 0 00-1.414-1.414L12 13.586 7.705 9.29a1 1 0 00-1.412 1.417l4.98 4.98c.182.193.44.313.727.313z"
+                role="presentation"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li>
+      <button
+        aria-label="Go to next page"
+        class="cdr-pagination__link cdr-pagination__next"
+        ref="next-link-test1"
+      >
+        Next
+        <svg
+          aria-hidden="true"
+          class="cdr-icon cdr-pagination__caret--next"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 12a.997.997 0 00-.288-.702l-5.005-5.005a1 1 0 00-1.414 1.414L13.585 12 9.29 16.295a1 1 0 001.417 1.412l4.98-4.98A.997.997 0 0016 12z"
+            role="presentation"
+          />
+        </svg>
+      </button>
+    </li>
+  </ol>
+</nav>
+`;
+
 exports[`CdrPagination renders correctly 1`] = `
 <nav
   aria-label="Pagination"
@@ -194,198 +386,6 @@ exports[`CdrPagination renders correctly 1`] = `
           />
         </svg>
       </a>
-    </li>
-  </ol>
-</nav>
-`;
-
-exports[`CdrPagination renders nested pagination correctly 1`] = `
-<nav
-  aria-label="Pagination"
->
-  <ol
-    class="cdr-pagination"
-  >
-    <li
-      aria-hidden="true"
-    >
-      <span
-        aria-disabled="true"
-        class="cdr-pagination__link cdr-pagination__prev cdr-pagination__link--disabled"
-      >
-        <svg
-          aria-hidden="true"
-          class="cdr-icon cdr-icon--inherit-color cdr-pagination__caret--prev"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M8 12c0 .273.11.521.288.702l5.005 5.005a1 1 0 001.414-1.414L10.415 12l4.295-4.295a1 1 0 00-1.417-1.412l-4.98 4.98A.997.997 0 008 12z"
-            role="presentation"
-          />
-        </svg>
-        Prev
-      </span>
-    </li>
-    <li
-      class="cdr-pagination__li--links"
-    >
-      <button
-        aria-current="page"
-        aria-label="Current page, page 1"
-        class="cdr-pagination__link current"
-        ref="page-link-1-test1"
-      >
-        1
-      </button>
-    </li>
-    <li
-      class="cdr-pagination__li--links"
-    >
-      <button
-        aria-label="Go to page 2"
-        class="cdr-pagination__link"
-        ref="page-link-2-test1"
-      >
-        2
-      </button>
-    </li>
-    <li
-      class="cdr-pagination__li--links"
-    >
-      <button
-        aria-label="Go to page 3"
-        class="cdr-pagination__link"
-        ref="page-link-3-test1"
-      >
-        3
-      </button>
-    </li>
-    <li
-      class="cdr-pagination__li--links"
-    >
-      <button
-        aria-label="Go to page 4"
-        class="cdr-pagination__link"
-        ref="page-link-4-test1"
-      >
-        4
-      </button>
-    </li>
-    <li
-      class="cdr-pagination__li--links"
-    >
-      <button
-        aria-label="Go to page 5"
-        class="cdr-pagination__link"
-        ref="page-link-5-test1"
-      >
-        5
-      </button>
-    </li>
-    <li
-      class="cdr-pagination__li--links"
-    >
-      <span
-        class="cdr-pagination__ellipse"
-      >
-        …
-      </span>
-    </li>
-    <li
-      class="cdr-pagination__li--links"
-    >
-      <button
-        aria-label="Go to page 20"
-        class="cdr-pagination__link"
-        ref="page-link-20-test1"
-      >
-        20
-      </button>
-    </li>
-    <li
-      class="cdr-pagination__li--select"
-    >
-      <div>
-        <div
-          class="cdr-label-standalone"
-        />
-        <div
-          class="cdr-select-outer-wrap"
-        >
-          <div
-            class="cdr-select-wrap"
-          >
-            <select
-              aria-label="Navigate to page"
-              class="cdr-select cdr-select--primary"
-              id="select-test1"
-            >
-              <option
-                value="1"
-              >
-                Page 1
-              </option>
-              <option
-                value="2"
-              >
-                Page 2
-              </option>
-              <option
-                value="3"
-              >
-                Page 3
-              </option>
-              <option
-                value="4"
-              >
-                Page 4
-              </option>
-              <option
-                value="5"
-              >
-                Page 5
-              </option>
-              <option
-                value="20"
-              >
-                Page 20
-              </option>
-            </select>
-            <svg
-              aria-hidden="true"
-              class="cdr-icon cdr-select__caret"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 16c.273 0 .521-.11.702-.288l5.005-5.005a1 1 0 00-1.414-1.414L12 13.586 7.705 9.29a1 1 0 00-1.412 1.417l4.98 4.98c.182.193.44.313.727.313z"
-                role="presentation"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </li>
-    <li>
-      <button
-        aria-label="Go to next page"
-        class="cdr-pagination__link cdr-pagination__next"
-        ref="next-link-test1"
-      >
-        Next
-        <svg
-          aria-hidden="true"
-          class="cdr-icon cdr-pagination__caret--next"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M16 12a.997.997 0 00-.288-.702l-5.005-5.005a1 1 0 00-1.414 1.414L13.585 12 9.29 16.295a1 1 0 001.417 1.412l4.98-4.98A.997.997 0 0016 12z"
-            role="presentation"
-          />
-        </svg>
-      </button>
     </li>
   </ol>
 </nav>

--- a/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
@@ -199,6 +199,198 @@ exports[`CdrPagination renders correctly 1`] = `
 </nav>
 `;
 
+exports[`CdrPagination renders nested pagination correctly 1`] = `
+<nav
+  aria-label="Pagination"
+>
+  <ol
+    class="cdr-pagination"
+  >
+    <li
+      aria-hidden="true"
+    >
+      <span
+        aria-disabled="true"
+        class="cdr-pagination__link cdr-pagination__prev cdr-pagination__link--disabled"
+      >
+        <svg
+          aria-hidden="true"
+          class="cdr-icon cdr-icon--inherit-color cdr-pagination__caret--prev"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 12c0 .273.11.521.288.702l5.005 5.005a1 1 0 001.414-1.414L10.415 12l4.295-4.295a1 1 0 00-1.417-1.412l-4.98 4.98A.997.997 0 008 12z"
+            role="presentation"
+          />
+        </svg>
+        Prev
+      </span>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-current="page"
+        aria-label="Current page, page 1"
+        class="cdr-pagination__link current"
+        ref="page-link-1-test1"
+      >
+        1
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 2"
+        class="cdr-pagination__link"
+        ref="page-link-2-test1"
+      >
+        2
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 3"
+        class="cdr-pagination__link"
+        ref="page-link-3-test1"
+      >
+        3
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 4"
+        class="cdr-pagination__link"
+        ref="page-link-4-test1"
+      >
+        4
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 5"
+        class="cdr-pagination__link"
+        ref="page-link-5-test1"
+      >
+        5
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <span
+        class="cdr-pagination__ellipse"
+      >
+        …
+      </span>
+    </li>
+    <li
+      class="cdr-pagination__li--links"
+    >
+      <button
+        aria-label="Go to page 20"
+        class="cdr-pagination__link"
+        ref="page-link-20-test1"
+      >
+        20
+      </button>
+    </li>
+    <li
+      class="cdr-pagination__li--select"
+    >
+      <div>
+        <div
+          class="cdr-label-standalone"
+        />
+        <div
+          class="cdr-select-outer-wrap"
+        >
+          <div
+            class="cdr-select-wrap"
+          >
+            <select
+              aria-label="Navigate to page"
+              class="cdr-select cdr-select--primary"
+              id="select-test1"
+            >
+              <option
+                value="1"
+              >
+                Page 1
+              </option>
+              <option
+                value="2"
+              >
+                Page 2
+              </option>
+              <option
+                value="3"
+              >
+                Page 3
+              </option>
+              <option
+                value="4"
+              >
+                Page 4
+              </option>
+              <option
+                value="5"
+              >
+                Page 5
+              </option>
+              <option
+                value="20"
+              >
+                Page 20
+              </option>
+            </select>
+            <svg
+              aria-hidden="true"
+              class="cdr-icon cdr-select__caret"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 16c.273 0 .521-.11.702-.288l5.005-5.005a1 1 0 00-1.414-1.414L12 13.586 7.705 9.29a1 1 0 00-1.412 1.417l4.98 4.98c.182.193.44.313.727.313z"
+                role="presentation"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li>
+      <button
+        aria-label="Go to next page"
+        class="cdr-pagination__link cdr-pagination__next"
+        ref="next-link-test1"
+      >
+        Next
+        <svg
+          aria-hidden="true"
+          class="cdr-icon cdr-pagination__caret--next"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 12a.997.997 0 00-.288-.702l-5.005-5.005a1 1 0 00-1.414 1.414L13.585 12 9.29 16.295a1 1 0 001.417 1.412l4.98-4.98A.997.997 0 0016 12z"
+            role="presentation"
+          />
+        </svg>
+      </button>
+    </li>
+  </ol>
+</nav>
+`;
+
 exports[`CdrPagination renders scoped slot correctly 1`] = `
 <nav
   aria-label="Pagination"

--- a/src/components/pagination/examples/Pagination.vue
+++ b/src/components/pagination/examples/Pagination.vue
@@ -14,6 +14,17 @@
     />
 
     <hr>
+    <p>nested/intra-page pagination using buttons</p>
+    <cdr-pagination
+      v-model="page"
+      :pages="pages"
+      :total-pages="10"
+      :nested="true"
+      for-label="potatoes"
+      data-backstop="pagination-default"
+      @navigate="preventNavigate"
+    />
+    <hr>
 
     <div
       v-for="datam in paginationData.example1[ex1Page]"

--- a/src/components/pagination/examples/Pagination.vue
+++ b/src/components/pagination/examples/Pagination.vue
@@ -14,12 +14,12 @@
     />
 
     <hr>
-    <p>nested/intra-page pagination using buttons</p>
+    <p>intra-page pagination using buttons</p>
     <cdr-pagination
       v-model="page"
       :pages="pages"
       :total-pages="10"
-      :nested="true"
+      link-tag="button"
       for-label="potatoes"
       data-backstop="pagination-default"
       @navigate="preventNavigate"

--- a/src/components/pagination/styles/CdrPagination.scss
+++ b/src/components/pagination/styles/CdrPagination.scss
@@ -26,6 +26,9 @@
   &__link {
     @include cdr-text-utility-sans-300;
 
+    background-color: transparent;
+    border: none;
+    padding: 0;
     color: $cdr-color-text-primary;
     fill: $cdr-color-text-primary;
     display: block;


### PR DESCRIPTION
- [x] fix modal safari ios bug (need to verify once this is on staging)
- [x] remove text fade from modal
- [x] breadcrumb a11y expanded bug
- [x] non-linked pagination


modal safari bug is propbably due to `transitionend` being weird in ios. i think with this fix the modal content display logic should no longer be tied to anything CSS animation related. Also deleted the overflow text fade stuff since we know it's a violation and anyone overflowing modals is doing something weird and un-user friendly anyways.

breadcrumb a11y bug seems to be a NVDA bug with focusing elements that just entered the page. will see if a timeout instead of a nextTick solve the issues. 

Seems like for pagination as long as we allow customizing the aria-label (to set it to be "Pagination for reviews section" or something in the UGC case) then we can render buttons instead of links and the rest of the markup should just work. Will need to double check that later.
