### PR TITLE
feat(chips): create chip group component

### DIFF
--- a/src/components/chip/CdrChipGroup.jsx
+++ b/src/components/chip/CdrChipGroup.jsx
@@ -1,0 +1,71 @@
+import style from './styles/CdrChipGroup.scss';
+
+export default {
+  name: 'CdrChipGroup',
+  data() {
+    return {
+      style,
+      chips: [],
+      currentIdx: 0,
+    };
+  },
+  computed: {
+    nextIdx() {
+      const idx = this.currentIdx + 1;
+      return idx >= this.chips.length ? 0 : idx; // if at last, go to first
+    },
+    prevIdx() {
+      const idx = this.currentIdx - 1;
+      return idx <= -1 ? (this.chips.length - 1) : idx; // if at first, go to last
+    },
+  },
+  mounted() {
+    // get all of the chips in the group
+    this.chips = this.$el.children;
+    this.currentIdx = Array.prototype.findIndex.call(this.chips,
+      (chip) => chip.getAttribute('aria-checked') === 'true');
+  },
+  methods: {
+    handleKeyDown(e) {
+      // something besides the button is focused
+      if (this.currentIdx === -1) return;
+
+      const { key } = e;
+      switch (key) {
+        case 'Home':
+          e.preventDefault();
+          this.chips[0].focus();
+          break;
+        case 'End':
+          e.preventDefault();
+          this.chips[this.chips.length - 1].focus();
+          break;
+        case 'ArrowDown':
+        case 'Down':
+          e.preventDefault();
+          this.chips[this.nextIdx].focus();
+          break;
+        case 'ArrowUp':
+        case 'Up':
+          e.preventDefault();
+          this.chips[this.prevIdx].focus();
+          break;
+        default: break;
+      }
+    },
+    focusin(e) {
+      // find out which, if any, button is focused
+      this.currentIdx = Array.prototype.indexOf.call(this.chips, e.target);
+    },
+  },
+  render() {
+    return (<div
+      class={this.style['cdr-chip-group']}
+      onFocusin={this.focusin}
+      onKeydown={this.handleKeyDown}
+      role="radiogroup"
+    >
+      { this.$slots.default }
+    </div>);
+  },
+};

--- a/src/components/chip/__tests__/CdrChipGroup.spec.js
+++ b/src/components/chip/__tests__/CdrChipGroup.spec.js
@@ -1,0 +1,93 @@
+import { shallowMount, mount } from '@vue/test-utils';
+import CdrChipGroup from 'componentdir/chip/CdrChipGroup';
+import CdrChip from 'componentdir/chip/CdrChip';
+
+describe('CdrChipGroup', () => {
+  it('renders correctly', () => {
+    const wrapper = mount(CdrChipGroup, {
+      stubs: {
+        'cdr-chip': CdrChip,
+      },
+      slots: {
+        default: [
+          '<cdr-chip aria-checked="true" tabindex="0" role="radio">chip 1</cdr-chip>',
+          '<cdr-chip aria-checked="false" tabindex="-1" role="radio">chip 2</cdr-chip>'
+        ]
+      },
+    });
+    expect(wrapper.element).toMatchSnapshot()
+  });
+
+  it('sets current index on mount', () => {
+    const wrapper = mount(CdrChipGroup, {
+      stubs: {
+        'cdr-chip': CdrChip,
+      },
+      slots: {
+        default: [
+          '<cdr-chip aria-checked="false" tabindex="-1" role="radio">chip 1</cdr-chip>',
+          '<cdr-chip aria-checked="true" tabindex="0" role="radio">chip 2</cdr-chip>'
+        ]
+      },
+    });
+    expect(wrapper.vm.currentIdx).toBe(1);
+  });
+
+  it('has correct a11y', async () => {
+    const elem = document.createElement('div')
+    if (document.body) {
+      document.body.appendChild(elem)
+    }
+    const wrapper = mount(CdrChipGroup, {
+      stubs: {
+        'cdr-chip': CdrChip,
+      },
+      slots: {
+        default: [
+          '<cdr-chip aria-checked="true" tabindex="0" role="radio">chip 1</cdr-chip>',
+          '<cdr-chip aria-checked="false" tabindex="-1" role="radio">chip 2</cdr-chip>',
+          '<cdr-chip aria-checked="false" tabindex="-1" role="radio">chip 3</cdr-chip>'
+        ]
+      },
+      attachTo: elem,
+    });
+
+    expect(wrapper.attributes('role')).toBe('radiogroup');
+    /* keyboard nav tests
+      `focusin` doesn't fire outside of the browser environment so it's faked by just doing the logic
+      manually instead with setData. The proper focus logic is still checked via document.activeElement
+    */
+    const chips = wrapper.vm.chips;
+    // Up (first to last)
+    wrapper.trigger('keydown', { key: 'ArrowUp' });
+    wrapper.setData({ currentIdx: 2 });
+    await wrapper.vm.$nextTick();
+    expect(chips[2]).toBe(document.activeElement);
+    // Down (last to first)
+    wrapper.trigger('keydown', { key: 'ArrowDown' });
+    wrapper.setData({ currentIdx: 0 });
+    await wrapper.vm.$nextTick();
+    expect(chips[0]).toBe(document.activeElement);
+    // Down
+    wrapper.trigger('keydown', { key: 'ArrowDown' });
+    wrapper.setData({ currentIdx: 1 });
+    await wrapper.vm.$nextTick();
+    expect(chips[1]).toBe(document.activeElement);
+    // Up
+    wrapper.trigger('keydown', { key: 'ArrowUp' });
+    wrapper.setData({ currentIdx: 0 });
+    await wrapper.vm.$nextTick();
+    expect(chips[0]).toBe(document.activeElement);
+    // End
+    wrapper.trigger('keydown', { key: 'End' });
+    wrapper.setData({ currentIdx: 2 });
+    await wrapper.vm.$nextTick();
+    expect(chips[2]).toBe(document.activeElement);
+    // Home
+    wrapper.trigger('keydown', { key: 'Home' });
+    wrapper.setData({ currentIdx: 0 });
+    await wrapper.vm.$nextTick();
+    expect(chips[0]).toBe(document.activeElement);
+    wrapper.destroy();
+  });
+});

--- a/src/components/chip/__tests__/__snapshots__/CdrChipGroup.spec.js.snap
+++ b/src/components/chip/__tests__/__snapshots__/CdrChipGroup.spec.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdrChipGroup renders correctly 1`] = `
+<div
+  role="radiogroup"
+>
+  <button
+    aria-checked="true"
+    class="cdr-chip cdr-chip--default"
+    role="radio"
+    tabindex="0"
+  >
+    chip 1
+  </button>
+  <button
+    aria-checked="false"
+    class="cdr-chip cdr-chip--default"
+    role="radio"
+    tabindex="-1"
+  >
+    chip 2
+  </button>
+</div>
+`;

--- a/src/components/chip/examples/Chip.vue
+++ b/src/components/chip/examples/Chip.vue
@@ -54,7 +54,7 @@
     <hr>
     <h3>chip group</h3>
     <!-- TODO: chip group wrapper for keydown/tabindex?? -->
-    <div role="radiogroup">
+    <cdr-chip-group>
       <cdr-chip
         modifier="default"
         v-for="month in months"
@@ -62,10 +62,11 @@
         @click="selectMonth(month)"
         :aria-checked="selectedMonth === month"
         role="radio"
+        :tabindex="selectedMonth === month ? '0' : '-1'"
       >
         {{ month }}
       </cdr-chip>
-    </div>
+    </cdr-chip-group>
 
     <hr>
 

--- a/src/components/chip/styles/CdrChipGroup.scss
+++ b/src/components/chip/styles/CdrChipGroup.scss
@@ -1,0 +1,6 @@
+@import '../../../css/settings/index.scss';
+@import './vars/CdrChipGroup.vars.scss';
+
+.cdr-chip-group {
+  @include cdr-chip-group-base-mixin;
+}

--- a/src/components/chip/styles/vars/CdrChipGroup.vars.scss
+++ b/src/components/chip/styles/vars/CdrChipGroup.vars.scss
@@ -1,0 +1,3 @@
+@mixin cdr-chip-group-base-mixin() {
+
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export { default as CdrCaption } from './components/caption/CdrCaption';
 export { default as CdrCard } from './components/card/CdrCard';
 export { default as CdrCheckbox } from './components/checkbox/CdrCheckbox';
 export { default as CdrChip } from './components/chip/CdrChip';
+export { default as CdrChipGroup } from './components/chip/CdrChipGroup';
 export { default as CdrCol } from './components/grid/CdrCol';
 export { default as CdrFormGroup } from './components/formGroup/CdrFormGroup';
 export { default as CdrGrid } from './components/gridTwo/CdrGridTwo';


### PR DESCRIPTION
manages keyboard logic for a group of chips acting as a radio group. 

Currently has no styling, might need some spacing but i assume this is just gonna be a transparent wrapper.

This is more or less identical to CdrAccordionGroup (and what should maybe be happening in CdrFormGroup too?). The wrapper is simple and it's not much code so i'd rather duplicate than try to abstract right now.