### PR TITLE
Accorddion unwrapped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.0-beta.0",
+  "version": "8.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.0-beta.0",
+  "version": "8.0.0-beta.1",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/accordion/CdrAccordion.jsx
+++ b/src/components/accordion/CdrAccordion.jsx
@@ -9,7 +9,9 @@ export default {
     IconCaretDown,
   },
   mixins: [modifier],
-  inject: ['unwrap'],
+  inject: {
+    unwrap: { default: {value: false} }
+  },
   props: {
     /**
      * The unique id of an accordion.
@@ -69,11 +71,14 @@ export default {
 
       return styles.join(' ');
     },
+    unwrapClass() {
+      return this.unwrap.value ? this.modifyClassName(this.baseClass, 'unwrap') : null;
+    },
     focusedClass() {
       return this.focused ? this.modifyClassName(this.baseClass, 'focused') : null;
     },
     isOpenClass() {
-      return this.opened ? 'open' : 'closed';
+      return this.opened || this.unwrap.value ? 'open' : 'closed';
     },
   },
   watch: {
@@ -114,29 +119,25 @@ export default {
   },
   render() {
     const Heading = `h${this.level}`;
-    console.log(this.unwrap)
-    const HeadingContent = this.unwrap ? 'div' : 'button'
+    const HeadingContent = this.unwrap.value ? 'div' : 'button';
 
-// WHY does accordion group wrap this in a li rather than just chilling here?!?!?!
-// TODO: remove header/button class when unwrapped.
-// TODO: but...hmmmi guess theey can style text via the slot
-    return (<li
-      class={!this.unwrap && clsx(this.style[this.baseClass],
+    return (<div
+      class={!this.unwrap.value && clsx(this.style[this.baseClass],
         this.modifierClass,
         this.styleClass,
         this.focusedClass)}
       id={`${this.id}-accordion`}
       ref="accordion-container"
     >
-      <Heading class={!this.unwrap && this.style['cdr-accordion__header']}>
+      <Heading class={!this.unwrap.value && this.style['cdr-accordion__header']}>
         <HeadingContent
-          class={!this.unwrap && [this.style['cdr-accordion__button'], 'js-cdr-accordion-button']}
+          class={!this.unwrap.value && [this.style['cdr-accordion__button'], 'js-cdr-accordion-button']}
           id={this.id}
-          onClick={this.unwrap || this.onClick}
-          onFocus={this.unwrap || this.onFocus}
-          onBlur={this.unwrap || this.onBlur}
-          aria-expanded={`${this.opened}`}
-          aria-controls={`${this.id}-collapsible`}
+          onClick={this.unwrap.value || this.onClick}
+          onFocus={this.unwrap.value || this.onFocus}
+          onBlur={this.unwrap.value || this.onBlur}
+          aria-expanded={!this.unwrap.value && `${this.opened}`}
+          aria-controls={!this.unwrap.value && `${this.id}-collapsible`}
           >
           <span
             class={this.style['cdr-accordion__label']}
@@ -144,7 +145,7 @@ export default {
             >
             { this.$slots.label }
           </span>
-          { !this.unwrap && <icon-caret-down
+          { !this.unwrap.value && <icon-caret-down
             class={clsx(this.style['cdr-accordion__icon'], this.isOpenClass)}
             size={this.compact ? 'small' : null}
           /> }
@@ -152,11 +153,11 @@ export default {
       </Heading>
       <div
         class={clsx(this.style['cdr-accordion__content-container'], this.isOpenClass)}
-        style={ { maxHeight: this.unwrap ? 'auto' : this.maxHeight } }
+        style={ { maxHeight: this.unwrap.value ? 'auto' : this.maxHeight } }
       >
         <div
-          class={clsx(this.style['cdr-accordion__content'], this.isOpenClass)}
-          aria-hidden={`${!this.opened}`}
+          class={clsx(this.style['cdr-accordion__content'], this.isOpenClass, this.unwrap.valueClass)}
+          aria-hidden={!this.unwrap.value && `${!this.opened}`}
           id={`${this.id}-collapsible`}
           ref="accordion-content"
         >

--- a/src/components/accordion/CdrAccordion.jsx
+++ b/src/components/accordion/CdrAccordion.jsx
@@ -10,7 +10,7 @@ export default {
   },
   mixins: [modifier],
   inject: {
-    unwrap: { default: {value: false} }
+    unwrap: { default: { value: false } },
   },
   props: {
     /**
@@ -131,7 +131,10 @@ export default {
     >
       <Heading class={!this.unwrap.value && this.style['cdr-accordion__header']}>
         <HeadingContent
-          class={!this.unwrap.value && [this.style['cdr-accordion__button'], 'js-cdr-accordion-button']}
+          class={[
+            !this.unwrap.value && this.style['cdr-accordion__button'],
+            'js-cdr-accordion-button',
+          ]}
           id={this.id}
           onClick={this.unwrap.value || this.onClick}
           onFocus={this.unwrap.value || this.onFocus}
@@ -156,7 +159,7 @@ export default {
         style={ { maxHeight: this.unwrap.value ? 'auto' : this.maxHeight } }
       >
         <div
-          class={clsx(this.style['cdr-accordion__content'], this.isOpenClass, this.unwrap.valueClass)}
+          class={clsx(this.style['cdr-accordion__content'], this.isOpenClass, this.unwrapClass)}
           aria-hidden={!this.unwrap.value && `${!this.opened}`}
           id={`${this.id}-collapsible`}
           ref="accordion-content"

--- a/src/components/accordion/CdrAccordion.jsx
+++ b/src/components/accordion/CdrAccordion.jsx
@@ -9,6 +9,7 @@ export default {
     IconCaretDown,
   },
   mixins: [modifier],
+  inject: ['unwrap'],
   props: {
     /**
      * The unique id of an accordion.
@@ -113,22 +114,27 @@ export default {
   },
   render() {
     const Heading = `h${this.level}`;
+    console.log(this.unwrap)
+    const HeadingContent = this.unwrap ? 'div' : 'button'
 
-    return (<div
-      class={clsx(this.style[this.baseClass],
+// WHY does accordion group wrap this in a li rather than just chilling here?!?!?!
+// TODO: remove header/button class when unwrapped.
+// TODO: but...hmmmi guess theey can style text via the slot
+    return (<li
+      class={!this.unwrap && clsx(this.style[this.baseClass],
         this.modifierClass,
         this.styleClass,
         this.focusedClass)}
       id={`${this.id}-accordion`}
       ref="accordion-container"
     >
-      <Heading class={this.style['cdr-accordion__header']}>
-        <button
-          class={[this.style['cdr-accordion__button'], 'js-cdr-accordion-button']} // .js-accordion-button is for group focus management
+      <Heading class={!this.unwrap && this.style['cdr-accordion__header']}>
+        <HeadingContent
+          class={!this.unwrap && [this.style['cdr-accordion__button'], 'js-cdr-accordion-button']}
           id={this.id}
-          onClick={this.onClick}
-          onFocus={this.onFocus}
-          onBlur={this.onBlur}
+          onClick={this.unwrap || this.onClick}
+          onFocus={this.unwrap || this.onFocus}
+          onBlur={this.unwrap || this.onBlur}
           aria-expanded={`${this.opened}`}
           aria-controls={`${this.id}-collapsible`}
           >
@@ -138,15 +144,15 @@ export default {
             >
             { this.$slots.label }
           </span>
-          <icon-caret-down
+          { !this.unwrap && <icon-caret-down
             class={clsx(this.style['cdr-accordion__icon'], this.isOpenClass)}
             size={this.compact ? 'small' : null}
-            />
-        </button>
+          /> }
+        </HeadingContent>
       </Heading>
       <div
         class={clsx(this.style['cdr-accordion__content-container'], this.isOpenClass)}
-        style={ { maxHeight: this.maxHeight } }
+        style={ { maxHeight: this.unwrap ? 'auto' : this.maxHeight } }
       >
         <div
           class={clsx(this.style['cdr-accordion__content'], this.isOpenClass)}

--- a/src/components/accordion/CdrAccordionGroup.jsx
+++ b/src/components/accordion/CdrAccordionGroup.jsx
@@ -6,6 +6,7 @@ import style from './styles/CdrAccordionGroup.scss';
 
 export default {
   name: 'CdrAccordionGroup',
+  mixins: [breakpoints],
   props: {
     unwrap: {
       type: [String, Boolean],
@@ -22,14 +23,13 @@ export default {
       },
     },
   },
-  mixins: [breakpoints],
   data() {
     return {
       style,
       accordionButtons: [],
       currentIdx: 0,
       isUnwrapped: {
-        value: this.unwrap.indexOf(this.getCurrentBreakpoint()) !== -1
+        value: this.unwrap || this.unwrap.toString().indexOf(this.getCurrentBreakpoint()) !== -1,
       },
     };
   },
@@ -49,6 +49,7 @@ export default {
     },
   },
   mounted() {
+    console.log(this.$el);
     // get all of the buttons in the group
     this.accordionButtons = this.$el.querySelectorAll('.js-cdr-accordion-button');
     if (typeof this.unwrap === 'string') {

--- a/src/components/accordion/CdrAccordionGroup.jsx
+++ b/src/components/accordion/CdrAccordionGroup.jsx
@@ -1,24 +1,41 @@
+import debounce from 'lodash-es/debounce';
 import clsx from 'clsx';
+import propValidator from '../../utils/propValidator';
+import breakpoints from '../../mixins/breakpoints';
 import style from './styles/CdrAccordionGroup.scss';
 
 export default {
   name: 'CdrAccordionGroup',
+  props: {
+    unwrap: {
+      type: [String, Boolean],
+      default: false,
+      validator: (value) => {
+        if (typeof value === 'string') {
+          return propValidator(
+            value,
+            ['@xs', '@sm', '@md', '@lg'],
+            false,
+          );
+        }
+        return typeof value === 'boolean';
+      },
+    },
+  },
+  mixins: [breakpoints],
   data() {
     return {
       style,
       accordionButtons: [],
       currentIdx: 0,
+      isUnwrapped: {
+        value: this.unwrap.indexOf(this.getCurrentBreakpoint()) !== -1
+      },
     };
-  },
-  props: {
-    unwrap: {
-      type: [String, Boolean],
-      default: false,
-    }
   },
   provide() {
     return {
-      unwrap: this.unwrap,
+      unwrap: this.isUnwrapped,
     };
   },
   computed: {
@@ -34,6 +51,12 @@ export default {
   mounted() {
     // get all of the buttons in the group
     this.accordionButtons = this.$el.querySelectorAll('.js-cdr-accordion-button');
+    if (typeof this.unwrap === 'string') {
+      this.isUnwrapped.value = this.unwrap.indexOf(this.getCurrentBreakpoint()) !== -1;
+      window.addEventListener('resize', debounce(() => {
+        this.isUnwrapped.value = this.unwrap.indexOf(this.getCurrentBreakpoint()) !== -1;
+      }, 300));
+    }
   },
   methods: {
     handleKeyDown(e) {

--- a/src/components/accordion/CdrAccordionGroup.jsx
+++ b/src/components/accordion/CdrAccordionGroup.jsx
@@ -10,6 +10,17 @@ export default {
       currentIdx: 0,
     };
   },
+  props: {
+    unwrap: {
+      type: [String, Boolean],
+      default: false,
+    }
+  },
+  provide() {
+    return {
+      unwrap: this.unwrap,
+    };
+  },
   computed: {
     nextIdx() {
       const idx = this.currentIdx + 1;

--- a/src/components/accordion/__tests__/CdrAccordionGroup.spec.js
+++ b/src/components/accordion/__tests__/CdrAccordionGroup.spec.js
@@ -25,6 +25,24 @@ describe('CdrAccordionGroup', () => {
     expect(wrapper.element).toMatchSnapshot()
   });
 
+  it('renders correctly unwrapped', () => {
+    const wrapper = mount(CdrAccordionGroup, {
+      stubs: {
+        'cdr-accordion': CdrAccordion,
+      },
+      propsData: {
+        unwrap: true
+      },
+      slots: {
+        default: [
+          '<cdr-accordion id="tab1" level="2"><template slot="label">label1</template></cdr-accordion>',
+          '<cdr-accordion id="tab2" level="2"><template slot="label">label2</template></cdr-accordion>'
+        ]
+      },
+    });
+    expect(wrapper.element).toMatchSnapshot()
+  });
+
   it('has correct a11y', async () => {
     const elem = document.createElement('div')
     if (document.body) {

--- a/src/components/accordion/__tests__/__snapshots__/CdrAccordionGroup.spec.js.snap
+++ b/src/components/accordion/__tests__/__snapshots__/CdrAccordionGroup.spec.js.snap
@@ -96,3 +96,78 @@ exports[`CdrAccordionGroup renders correctly 1`] = `
   </li>
 </ul>
 `;
+
+exports[`CdrAccordionGroup renders correctly unwrapped 1`] = `
+<ul
+  class="cdr-accordion-group"
+>
+  <li>
+    <div
+      class=""
+      id="tab1-accordion"
+    >
+      <h2
+        class=""
+      >
+        <div
+          aria-controls="tab1-collapsible"
+          aria-expanded="false"
+          class=""
+          id="tab1"
+        >
+          <span
+            class="cdr-accordion__label"
+            id="tab1-label"
+          >
+            label1
+          </span>
+        </div>
+      </h2>
+      <div
+        class="cdr-accordion__content-container open"
+        style="max-height: auto;"
+      >
+        <div
+          aria-hidden="true"
+          class="cdr-accordion__content open cdr-accordion--unwrap"
+          id="tab1-collapsible"
+        />
+      </div>
+    </div>
+  </li>
+  <li>
+    <div
+      class=""
+      id="tab2-accordion"
+    >
+      <h2
+        class=""
+      >
+        <div
+          aria-controls="tab2-collapsible"
+          aria-expanded="false"
+          class=""
+          id="tab2"
+        >
+          <span
+            class="cdr-accordion__label"
+            id="tab2-label"
+          >
+            label2
+          </span>
+        </div>
+      </h2>
+      <div
+        class="cdr-accordion__content-container open"
+        style="max-height: auto;"
+      >
+        <div
+          aria-hidden="true"
+          class="cdr-accordion__content open cdr-accordion--unwrap"
+          id="tab2-collapsible"
+        />
+      </div>
+    </div>
+  </li>
+</ul>
+`;

--- a/src/components/accordion/__tests__/__snapshots__/CdrAccordionGroup.spec.js.snap
+++ b/src/components/accordion/__tests__/__snapshots__/CdrAccordionGroup.spec.js.snap
@@ -110,9 +110,7 @@ exports[`CdrAccordionGroup renders correctly unwrapped 1`] = `
         class=""
       >
         <div
-          aria-controls="tab1-collapsible"
-          aria-expanded="false"
-          class=""
+          class="js-cdr-accordion-button"
           id="tab1"
         >
           <span
@@ -128,7 +126,6 @@ exports[`CdrAccordionGroup renders correctly unwrapped 1`] = `
         style="max-height: auto;"
       >
         <div
-          aria-hidden="true"
           class="cdr-accordion__content open cdr-accordion--unwrap"
           id="tab1-collapsible"
         />
@@ -144,9 +141,7 @@ exports[`CdrAccordionGroup renders correctly unwrapped 1`] = `
         class=""
       >
         <div
-          aria-controls="tab2-collapsible"
-          aria-expanded="false"
-          class=""
+          class="js-cdr-accordion-button"
           id="tab2"
         >
           <span
@@ -162,7 +157,6 @@ exports[`CdrAccordionGroup renders correctly unwrapped 1`] = `
         style="max-height: auto;"
       >
         <div
-          aria-hidden="true"
           class="cdr-accordion__content open cdr-accordion--unwrap"
           id="tab2-collapsible"
         />

--- a/src/components/accordion/examples/Accordion.vue
+++ b/src/components/accordion/examples/Accordion.vue
@@ -7,6 +7,64 @@
       Accordion
     </cdr-text>
 
+
+    <cdr-accordion-group :unwrap="true">
+      <cdr-accordion
+        id="default"
+        level="3"
+        :opened="accordionDefault"
+        @accordion-toggle="accordionDefault = !accordionDefault"
+      >
+        <template slot="label">
+          A short label
+        </template>
+        <cdr-text
+          modifier="body-300"
+        >
+          This is some text. It's in a
+          <cdr-text
+            tag="strong"
+            modifier="body-strong-300"
+          >cdr-text paragraph with a modifier of <code>body-300</code></cdr-text> element as
+          thats how you assign the correct font and line-height for text dislpay on REI.
+          does not include margin or add space to the container. Lorem ipsum dolor
+          sit amet, consectetur adipiscing elit. Sed dictum fermentum tortor posuere
+          fermentum. Sed interdum vel urna at tempor. Nullam vel sapien odio. Class
+          aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos
+          himenaeos. Fusce venenatis ex ut ultricies tincidunt. Suspendisse potenti.
+          Sed ut euismod mi, sit amet porta augue. Proin dictum laoreet blandit. Nulla
+          tempus tellus id ligula sodales ultrices. Proin lacus diam, ornare at libero
+          nec, eleifend vulputate mi. Praesent vestibulum accumsan erat id dapibus.
+          Suspendisse ut laoreet nunc, et tempor eros. Etiam vel commodo velit. Proin
+          egestas fringilla elit et lacinia. Praesent et vehicula massa. Fusce ac purus neque.
+        </cdr-text>
+      </cdr-accordion>
+      <cdr-accordion
+        :unwrap="true"
+        id="default-long-label"
+        level="3"
+        :opened="accordionDefault2"
+        @accordion-toggle="accordionDefault2 = !accordionDefault2"
+      >
+        <template slot="label">
+          Label with multiple words, so many words in fact
+          that this content may wrap to several lines
+        </template>
+        <cdr-list modifier="unordered">
+          <li>This is a cdr-list item inside an accordion.</li>
+          <li>It includes no extra styling</li>
+          <li>I'm adding a bunch of items</li>
+          <li>to this list because</li>
+          <li>I want to see what it's like</li>
+          <li>when animated!</li>
+        </cdr-list>
+      </cdr-accordion>
+    </cdr-accordion-group>
+
+
+
+
+
     <cdr-text
       tag="h3"
       modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"

--- a/src/components/accordion/examples/Accordion.vue
+++ b/src/components/accordion/examples/Accordion.vue
@@ -7,64 +7,6 @@
       Accordion
     </cdr-text>
 
-
-    <cdr-accordion-group :unwrap="true">
-      <cdr-accordion
-        id="default"
-        level="3"
-        :opened="accordionDefault"
-        @accordion-toggle="accordionDefault = !accordionDefault"
-      >
-        <template slot="label">
-          A short label
-        </template>
-        <cdr-text
-          modifier="body-300"
-        >
-          This is some text. It's in a
-          <cdr-text
-            tag="strong"
-            modifier="body-strong-300"
-          >cdr-text paragraph with a modifier of <code>body-300</code></cdr-text> element as
-          thats how you assign the correct font and line-height for text dislpay on REI.
-          does not include margin or add space to the container. Lorem ipsum dolor
-          sit amet, consectetur adipiscing elit. Sed dictum fermentum tortor posuere
-          fermentum. Sed interdum vel urna at tempor. Nullam vel sapien odio. Class
-          aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos
-          himenaeos. Fusce venenatis ex ut ultricies tincidunt. Suspendisse potenti.
-          Sed ut euismod mi, sit amet porta augue. Proin dictum laoreet blandit. Nulla
-          tempus tellus id ligula sodales ultrices. Proin lacus diam, ornare at libero
-          nec, eleifend vulputate mi. Praesent vestibulum accumsan erat id dapibus.
-          Suspendisse ut laoreet nunc, et tempor eros. Etiam vel commodo velit. Proin
-          egestas fringilla elit et lacinia. Praesent et vehicula massa. Fusce ac purus neque.
-        </cdr-text>
-      </cdr-accordion>
-      <cdr-accordion
-        :unwrap="true"
-        id="default-long-label"
-        level="3"
-        :opened="accordionDefault2"
-        @accordion-toggle="accordionDefault2 = !accordionDefault2"
-      >
-        <template slot="label">
-          Label with multiple words, so many words in fact
-          that this content may wrap to several lines
-        </template>
-        <cdr-list modifier="unordered">
-          <li>This is a cdr-list item inside an accordion.</li>
-          <li>It includes no extra styling</li>
-          <li>I'm adding a bunch of items</li>
-          <li>to this list because</li>
-          <li>I want to see what it's like</li>
-          <li>when animated!</li>
-        </cdr-list>
-      </cdr-accordion>
-    </cdr-accordion-group>
-
-
-
-
-
     <cdr-text
       tag="h3"
       modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
@@ -249,6 +191,66 @@
         </cdr-accordion>
       </cdr-accordion-group>
     </div>
+
+    <cdr-text
+      tag="h3"
+      modifier="heading-sans-400 heading-sans-500@md heading-sans-500@lg"
+    >
+      Unwrapped Standalone
+    </cdr-text>
+
+    <cdr-accordion-group unwrap="@md @lg">
+      <cdr-accordion
+        id="default-unwrap"
+        level="3"
+        :opened="accordionDefault"
+        @accordion-toggle="accordionDefault = !accordionDefault"
+      >
+        <template slot="label">
+          A short label
+        </template>
+        <cdr-text
+          modifier="body-300"
+        >
+          This is some text. It's in a
+          <cdr-text
+            tag="strong"
+            modifier="body-strong-300"
+          >cdr-text paragraph with a modifier of <code>body-300</code></cdr-text> element as
+          thats how you assign the correct font and line-height for text dislpay on REI.
+          does not include margin or add space to the container. Lorem ipsum dolor
+          sit amet, consectetur adipiscing elit. Sed dictum fermentum tortor posuere
+          fermentum. Sed interdum vel urna at tempor. Nullam vel sapien odio. Class
+          aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos
+          himenaeos. Fusce venenatis ex ut ultricies tincidunt. Suspendisse potenti.
+          Sed ut euismod mi, sit amet porta augue. Proin dictum laoreet blandit. Nulla
+          tempus tellus id ligula sodales ultrices. Proin lacus diam, ornare at libero
+          nec, eleifend vulputate mi. Praesent vestibulum accumsan erat id dapibus.
+          Suspendisse ut laoreet nunc, et tempor eros. Etiam vel commodo velit. Proin
+          egestas fringilla elit et lacinia. Praesent et vehicula massa. Fusce ac purus neque.
+        </cdr-text>
+      </cdr-accordion>
+      <cdr-accordion
+        id="default-long-label-unwrap"
+        level="3"
+        :opened="accordionDefault2"
+        @accordion-toggle="accordionDefault2 = !accordionDefault2"
+      >
+        <template slot="label">
+          Label with multiple words, so many words in fact
+          that this content may wrap to several lines
+        </template>
+        <cdr-list modifier="unordered">
+          <li>This is a cdr-list item inside an accordion.</li>
+          <li>It includes no extra styling</li>
+          <li>I'm adding a bunch of items</li>
+          <li>to this list because</li>
+          <li>I want to see what it's like</li>
+          <li>when animated!</li>
+        </cdr-list>
+      </cdr-accordion>
+    </cdr-accordion-group>
+
   </div>
 </template>
 

--- a/src/components/accordion/styles/CdrAccordion.scss
+++ b/src/components/accordion/styles/CdrAccordion.scss
@@ -91,7 +91,9 @@ $accordion-border: 1px solid $cdr-color-border-primary;
 
   /* Style variants
     ========================================================================== */
-
+  &--unwrap {
+    padding: 0;
+  }
   /* Border-Aligned
      ========== */
   &--border-aligned {

--- a/src/components/accordion/styles/CdrAccordion.scss
+++ b/src/components/accordion/styles/CdrAccordion.scss
@@ -35,7 +35,6 @@ $accordion-border: 1px solid $cdr-color-border-primary;
   }
 
   &__label {
-    cursor: pointer;
     margin-bottom: 0;
   }
 

--- a/src/components/chip/examples/Chip.vue
+++ b/src/components/chip/examples/Chip.vue
@@ -12,8 +12,7 @@
     <cdr-chip
       modifier="default"
       @click="toggle"
-      role="switch"
-      :aria-checked="toggled ? 'true' : 'false'"
+      :aria-pressed="toggled ? 'true' : 'false'"
     >
       <icon-heart-stroke
         slot="icon-left"

--- a/src/components/chip/styles/vars/CdrChip.vars.scss
+++ b/src/components/chip/styles/vars/CdrChip.vars.scss
@@ -10,12 +10,12 @@ $cdr-color-border-chip-default-selected-rest-inset: #B8B8B8;
 $cdr-color-border-chip-default-selected-hover-focus: #616161;
 $cdr-color-border-chip-default-selected-hover-focus-inset: #B8B8B8;
 
-$cdr-color-background-chip-default-rest: #F7F7F7;
+$cdr-color-background-chip-default: #F7F7F7;
 $cdr-color-background-chip-default-active: #616161;
 $cdr-color-background-chip-default-selected: #4E4D49;
 $cdr-color-background-chip-default-selected-hover-focus: #616161;
 
-$cdr-color-text-chip-default-rest: #4E4D49;
+$cdr-color-text-chip-default: #4E4D49;
 $cdr-color-text-chip-default-active: #F7F7F7;
 $cdr-color-text-chip-default-selected: #F7F7F7;
 
@@ -29,20 +29,16 @@ $cdr-color-border-chip-emphasis-selected-rest: #999999;
 $cdr-color-border-chip-emphasis-selected-hover: #B8B8B8;
 $cdr-color-border-chip-emphasis-selected-focus: #616161;
 
-$cdr-color-background-chip-emphasis-rest: #4E4D49;
+$cdr-color-background-chip-emphasis: #4E4D49;
 $cdr-color-background-chip-emphasis-active: #F7F7F7;
 
 $cdr-color-background-chip-emphasis-selected-rest: #F9F8F6;
 $cdr-color-background-chip-emphasis-selected-hover-focus: #F7F7F7;
 
-$cdr-color-text-chip-emphasis-rest: #FFFFFF;
+$cdr-color-text-chip-emphasis: #FFFFFF;
 $cdr-color-text-chip-emphasis-active: #616161;
 $cdr-color-text-chip-emphasis-selected: #616161;
 $cdr-color-text-chip-emphasis-selected-hover-focus: #4E4D49;
-
-
-
-
 
 
 @mixin cdr-chip-base-mixin() {
@@ -59,7 +55,10 @@ $cdr-color-text-chip-emphasis-selected-hover-focus: #4E4D49;
   letter-spacing: -0.08px;
 
   transition: color $cdr-duration-2-x $cdr-timing-function-ease, fill $cdr-duration-2-x $cdr-timing-function-ease, background-color $cdr-duration-2-x $cdr-timing-function-ease, border $cdr-duration-2-x $cdr-timing-function-ease;
-
+  &:focus {
+    outline: none;
+    outline-offset: 0;
+  }
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
@@ -75,9 +74,9 @@ $cdr-color-text-chip-emphasis-selected-hover-focus: #4E4D49;
 }
 
 @mixin cdr-chip-default-mixin() {
-  color: $cdr-color-text-chip-default-rest;
-  fill: $cdr-color-text-chip-default-rest;
-  background-color: $cdr-color-background-chip-default-rest;
+  color: $cdr-color-text-chip-default;
+  fill: $cdr-color-text-chip-default;
+  background-color: $cdr-color-background-chip-default;
   box-shadow: inset 0 0 0 1px $cdr-color-border-chip-default-rest;
 
   &:hover {
@@ -109,9 +108,9 @@ $cdr-color-text-chip-emphasis-selected-hover-focus: #4E4D49;
 }
 
 @mixin cdr-chip-emphasis-mixin() {
-  color: $cdr-color-text-chip-emphasis-rest;
-  fill: $cdr-color-text-chip-emphasis-rest;
-  background-color: $cdr-color-background-chip-emphasis-rest;
+  color: $cdr-color-text-chip-emphasis;
+  fill: $cdr-color-text-chip-emphasis;
+  background-color: $cdr-color-background-chip-emphasis;
   box-shadow: inset 0 0 0 1px $cdr-color-border-chip-emphasis-rest;
 
   &:hover {

--- a/src/components/chip/styles/vars/CdrChip.vars.scss
+++ b/src/components/chip/styles/vars/CdrChip.vars.scss
@@ -94,14 +94,17 @@ $cdr-color-text-chip-emphasis-selected-hover-focus: #4E4D49;
     fill: $cdr-color-text-chip-default-active;
   }
 
-  &[aria-checked="true"] {
+  &[aria-pressed="true"], &[aria-checked="true"] {
     background-color: $cdr-color-background-chip-default-selected;
     box-shadow: inset 0 0 0 2px $cdr-color-border-chip-default-selected-rest, inset 0 0 0 4px $cdr-color-border-chip-default-selected-rest-inset;
     color: $cdr-color-text-chip-default-selected;
     fill: $cdr-color-text-chip-default-selected;
   }
 
-  &[aria-checked="true"]:hover, &[aria-checked="true"]:focus  {
+  &[aria-pressed="true"]:hover,
+  &[aria-pressed="true"]:focus,
+  &[aria-checked="true"]:hover,
+  &[aria-checked="true"]:focus  {
     box-shadow: inset 0 0 0 2px $cdr-color-border-chip-default-selected-hover-focus, inset 0 0 0 4px $cdr-color-border-chip-default-selected-hover-focus-inset, $cdr-prominence-elevated;
   }
 
@@ -128,11 +131,7 @@ $cdr-color-text-chip-emphasis-selected-hover-focus: #4E4D49;
     fill: $cdr-color-text-chip-emphasis-active;
   }
 
-  // $cdr-color-text-chip-emphasis: #FFFFFF;
-  // $cdr-color-text-chip-emphasis-active: #616161;
-  // $cdr-color-text-chip-emphasis-selected: #4E4D49;
-  // : #616161;
-  &[aria-checked="true"] {
+  &[aria-pressed="true"], &[aria-checked="true"] {
     // TODO: checked rest state
     background-color: $cdr-color-background-chip-emphasis-selected-rest;
     box-shadow: inset 0 0 0 2px $cdr-color-border-chip-emphasis-selected-rest;
@@ -140,16 +139,19 @@ $cdr-color-text-chip-emphasis-selected-hover-focus: #4E4D49;
     fill: $cdr-color-text-chip-emphasis-selected;
   }
 
-  &[aria-checked="true"]:hover, &[aria-checked="true"]:focus {
+  &[aria-pressed="true"]:hover,
+  &[aria-pressed="true"]:focus,
+  &[aria-checked="true"]:hover,
+  &[aria-checked="true"]:focus {
     box-shadow: inset 0 0 0 2px $cdr-color-border-chip-emphasis-selected-focus, $cdr-prominence-raised;
     color: $cdr-color-text-chip-emphasis-selected-hover-focus;
   }
 
-  &[aria-checked="true"]:hover {
+  &[aria-pressed="true"]:hover, &[aria-checked="true"]:hover {
     box-shadow: inset 0 0 0 2px $cdr-color-border-chip-emphasis-selected-hover, $cdr-prominence-raised;
   }
 
-  &[aria-checked="true"]:focus {
+  &[aria-pressed="true"]:focus, &[aria-checked="true"]:hover {
     box-shadow: inset 0 0 0 2px $cdr-color-border-chip-emphasis-selected-focus, $cdr-prominence-raised;
   }
 

--- a/src/mixins/breakpoints.js
+++ b/src/mixins/breakpoints.js
@@ -1,0 +1,24 @@
+import {
+  CdrBreakpointSm,
+  CdrBreakpointMd,
+  CdrBreakpointLg,
+} from '@rei/cdr-tokens/dist/js/cdr-tokens.esm';
+
+export default {
+  methods: {
+    getCurrentBreakpoint() {
+      const screenWidth = window.outerWidth || 0;
+      if (screenWidth >= CdrBreakpointSm && screenWidth < CdrBreakpointMd) {
+        return 'sm';
+      }
+      if (screenWidth >= CdrBreakpointMd && screenWidth < CdrBreakpointLg) {
+        return 'md';
+      }
+      if (screenWidth >= CdrBreakpointLg) {
+        return 'lg';
+      }
+
+      return 'xs';
+    },
+  },
+};


### PR DESCRIPTION
- remove focus ring from chippies
- add `unwrap` prop to accordion group which renders the accordions in an unwrapped state with no buttons/padding/etc.
- `unwrap` accepts a boolean or a list of breakpoints