### PR TITLE
primary fill color of inputs is inaccessible on some backgrounds -

### DIFF
--- a/src/components/input/examples/Inputs.vue
+++ b/src/components/input/examples/Inputs.vue
@@ -382,8 +382,11 @@ export default {
         case 'secondary':
           this.backgroundColor = 'secondary';
           break;
+        case 'error':
+          this.backgroundColor = 'error';
+          break;
         default:
-          this.backgroundColor = 'primary';
+          this.backgroundColor = 'secondary';
       }
     },
   },


### PR DESCRIPTION
 switching to secondary for the success, info, warning colors and error for the error bg

### Unit testing:
- [X] Sufficient unit test coverage (see unit test best practices for ideas)

### A11y:
- [X] Meets WCAG AA standards