### PR TITLE
fix(input): fix issue with popover/tooltip in input info-action slot

### DIFF
--- a/src/components/chip/styles/vars/CdrChip.vars.scss
+++ b/src/components/chip/styles/vars/CdrChip.vars.scss
@@ -1,4 +1,7 @@
 @mixin cdr-chip-base-mixin() {
+  display: flex;
+  align-items: center;
+
   margin: $cdr-space-half-x;
   width: max-content;
   padding: $cdr-space-half-x $cdr-space-three-quarter-x;

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -166,14 +166,11 @@
   }
 
   &__info-action {
-    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 40px;
     width: 40px;
-    & > * {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
   }
 }
 


### PR DESCRIPTION
<img width="357" alt="Screen Shot 2021-03-04 at 2 42 05 PM" src="https://user-images.githubusercontent.com/48567940/110137196-6d220300-7d85-11eb-9042-5338553b6436.png">

apparently putting an element that does lots of `transform` weirdness like popover/tooltip into a slot that also uses `transform` to center it's content can cause issues 😆 