### PR TITLE
fix(form): fix SSR inheritAtttrs bug on radio/checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.0-beta.7",
+  "version": "8.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.0-beta.7",
+  "version": "8.0.0-beta.8",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/labelWrapper/CdrLabelWrapper.jsx
+++ b/src/components/labelWrapper/CdrLabelWrapper.jsx
@@ -7,6 +7,7 @@ import propValidator from '../../utils/propValidator';
 export default {
   name: 'CdrLabelWrapper',
   mixins: [modifier, size],
+  inheritAttrs: false,
   props: {
     labelClass: String,
     contentClass: String,

--- a/src/components/labelWrapper/__tests__/CdrLabelWrapper.spec.js
+++ b/src/components/labelWrapper/__tests__/CdrLabelWrapper.spec.js
@@ -8,6 +8,8 @@ describe('CdrLabelWrapper', () => {
         labelClass: 'custom-label-class',
         contentClass: 'custom-content-class',
         name: 'testName',
+        class: 'foo',
+        'data-ui': 'wrapper',
         modifier: 'hide-figure',
         size: 'medium'
       },

--- a/src/components/labelWrapper/__tests__/__snapshots__/CdrLabelWrapper.spec.js.snap
+++ b/src/components/labelWrapper/__tests__/__snapshots__/CdrLabelWrapper.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`CdrLabelWrapper matches snapshot 1`] = `
 <div
   class="cdr-label-wrapper__container"
-  name="testName"
 >
   <label
     class="cdr-label-wrapper cdr-label-wrapper--primary cdr-label-wrapper--hide-figure cdr-label-wrapper--medium custom-label-class"


### PR DESCRIPTION
CUS link: https://rei.slack.com/archives/CA58YCGN4/p1615240231027000

Seems to be an SSR related issue: https://github.com/vuejs/vue/issues/11297

can't repro this in sink or docsite because both are client rendered. But we can see it in our snapshot test for labelWrapper (`name="testName"` no longer showing up). 

Good to know our snapshot tests verify SSR works 😂 