### PR TITLE
feat(number): better support for numeric input, default autocorrect off

### DIFF
--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -87,6 +87,18 @@ export default {
     baseClass() {
       return 'cdr-input';
     },
+    inputAttrs() {
+      const isNum = this.type === 'number';
+      return {
+        pattern: isNum && '[0-9]*',
+        inputmode: isNum && 'numeric',
+        novalidate: isNum,
+        autocorrect: 'off',
+        spellcheck: 'false',
+        autocapitalize: 'off',
+        ...this.$attrs,
+      };
+    },
     inputClass() {
       const hasPostIcon = !!this.$slots['post-icon'];
       const hasPostIcons = hasPostIcon && this.$slots['post-icon'].length > 1;
@@ -139,7 +151,7 @@ export default {
             required={this.required}
             aria-label={this.hideLabel ? this.label : null}
             ref="input"
-            {...{ attrs: this.$attrs, on: this.inputListeners }}
+            {...{ attrs: this.inputAttrs, on: this.inputListeners }}
             vModel={this.value}
           />
         );
@@ -156,7 +168,7 @@ export default {
             required={this.required}
             aria-label={this.hideLabel ? this.label : null}
             ref="input"
-            {...{ attrs: this.$attrs, on: this.inputListeners }}
+            {...{ attrs: this.inputAttrs, on: this.inputListeners }}
             vModel={this.value}
           />
       );

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -13,6 +13,17 @@ describe('CdrInput', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
+  it('renders number input correctly', () => {
+    const wrapper = mount(CdrInput, {
+      propsData: {
+        label: 'Label Test',
+        id: 'renders',
+        type: 'number',
+      },
+    });
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
   it('generates an id correctly', () => {
     const wrapper = shallowMount(CdrInput, {
       propsData: {
@@ -73,6 +84,19 @@ describe('CdrInput', () => {
       },
     });
     expect(wrapper.vm.$refs.input.hasAttribute('required')).toBe(true);
+  });
+
+  it('sets attrs for numeric inputt', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+        required: true,
+        type: 'number'
+      },
+    });
+    expect(wrapper.vm.$refs.input.hasAttribute('novalidate')).toBe(true);
+    expect(wrapper.vm.$refs.input.hasAttribute('pattern')).toBe(true);
+    expect(wrapper.vm.$refs.input.hasAttribute('inputmode')).toBe(true);
   });
 
   it('sets input autofocus attribute correctly', () => {

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -19,9 +19,46 @@ exports[`CdrInput renders correctly 1`] = `
       class="cdr-input-wrap"
     >
       <input
+        autocapitalize="off"
+        autocorrect="off"
         class="cdr-input cdr-input--primary"
         id="renders"
+        spellcheck="false"
         type="text"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CdrInput renders number input correctly 1`] = `
+<div>
+  <div
+    class="cdr-label-standalone cdr-label-standalone--spacing"
+  >
+    <label
+      class="cdr-label-standalone__label"
+      for="renders"
+    >
+      Label Test
+    </label>
+  </div>
+  <div
+    class="cdr-input-outer-wrap"
+  >
+    <div
+      class="cdr-input-wrap"
+    >
+      <input
+        autocapitalize="off"
+        autocorrect="off"
+        class="cdr-input cdr-input--primary"
+        id="renders"
+        inputmode="numeric"
+        novalidate="novalidate"
+        pattern="[0-9]*"
+        spellcheck="false"
+        type="number"
       />
     </div>
   </div>


### PR DESCRIPTION
Enhances support for numeric inputs:

- for some reason `<input type="number">` neither creates a number-only input, nor does it auto-launch the "number" keyboard on mobile browsers. 
- instead we need to use `pattern` to restrict to numbers only, along with `novalidate` so that the pattern doesn't trigger native input validation
- we can use `inputmode` "numeric" to ensure the proper numeric keyboard is launched on mobile.

Adds default auto-correct attrs:
- Almost all of the form pattern examples specify that auto-correct/auto-capitalize should be disabled. I think it makes sense to default these attributes off and let consumers override them if needed. (`autocorrect`, `autocapitalize`, `spellcheck`)

Not sure if there are any a11y concerns here? 