### PR TITLE
fix naming of aria-describedby property

### DIFF
--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -29,7 +29,7 @@ export default {
       required: false,
       default: true,
     },
-    ariaDescribedbBy: {
+    ariaDescribedby: {
       type: String,
       required: false,
       default: null,
@@ -64,7 +64,7 @@ export default {
   computed: {
     dialogAttrs() {
       return {
-        'aria-describedby': this.ariaDescribedBy,
+        'aria-describedby': this.ariaDescribedby,
         'aria-modal': 'true',
         id: this.id,
       };


### PR DESCRIPTION
this should make it so people can do `aria-describedby: 'foobar'` and have it work as expected