### PR TITLE
fix(modal): force hardware acceleration on all modal children to bypass safari scroll bug

### DIFF
--- a/src/components/modal/styles/CdrModal.scss
+++ b/src/components/modal/styles/CdrModal.scss
@@ -3,6 +3,13 @@
 $modal-animation-duration: 150ms;
 
 .cdr-modal {
+  & * {
+    // Safari iOS hack: force hardware acceleration on all elements inside modal
+    //     otherwise content that is offscreen will flicker/disappear when scrolling
+    // Issue has to do with scrolling inside a position: fixed or relative container
+   -webkit-transform: translate3d(0,0,0);
+  }
+
   bottom: 0;
   height: 100%;
   left: 0;

--- a/src/components/modal/styles/CdrModal.scss
+++ b/src/components/modal/styles/CdrModal.scss
@@ -3,11 +3,13 @@
 $modal-animation-duration: 150ms;
 
 .cdr-modal {
-  & * {
-    // Safari iOS hack: force hardware acceleration on all elements inside modal
-    //     otherwise content that is offscreen will flicker/disappear when scrolling
-    // Issue has to do with scrolling inside a position: fixed or relative container
-   -webkit-transform: translate3d(0,0,0);
+  @supports (-webkit-touch-callout: none) {
+    & * {
+      // Safari iOS hack: force hardware acceleration on all elements inside modal
+      //     otherwise content that is offscreen will flicker/disappear when scrolling
+      // Issue has to do with scrolling inside a position: fixed or relative container
+      -webkit-transform: translate3d(0,0,0);
+    }
   }
 
   bottom: 0;


### PR DESCRIPTION
https://web.archive.org/web/20131005175118/http://cantina.co/2012/03/06/ios-5-native-scrolling-grins-and-gothcas/ 

long term we should re-write the modal to avoid relative/fixed positioning
any scrollable content inside a fixed or relative container may trigger this bug in iOS safari IF ` -webkit-overflow-scrolling: touch;` is active. seems like iOS does some optimization that results in offscreen elements not being rendered, however that conflicts with fixed/relative positioning for some reason.

the solution is to force hardware acceleration on all child elements of such a container, which seems like it has been the solution to this bug for the past 9 years 😬 

The hardware acceleration hack is wrapped in a `@supports` query and targets a -webkit property so this should ideally only run on iOS safari devices