### PR TITLE
use innerWidth for JS breakpoint check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/mixins/breakpoints.js
+++ b/src/mixins/breakpoints.js
@@ -7,7 +7,7 @@ import {
 export default {
   methods: {
     getCurrentBreakpoint() {
-      const screenWidth = (window && window.outerWidth) || 0;
+      const screenWidth = (window && window.innerWidth) || 0;
       if (screenWidth >= CdrBreakpointSm && screenWidth < CdrBreakpointMd) {
         return 'sm';
       }


### PR DESCRIPTION
resolves CUS issue

- innerWidth matches the way media queries work better WRT viewports, zoom level, etc.
- chrome has a bug where outerWidth computes to 0 for tabs that are opened in the background
- we already use innerWidth for other breakpoint-in-JS logic in cedar (in modal, popover/tooltip)