### PR TITLE
feat(input): add numeric prop to input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.2",
+  "version": "9.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.2",
+  "version": "9.0.0-beta.0",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -56,6 +56,11 @@ export default {
      * Removes the label element but sets the input `aria-label` to `label` text for a11y.
     */
     hideLabel: Boolean,
+    // sets default attrs for inputs that should use a numeric keyboard but are not strictly "numbers" (security code, CC number, postal code)
+    numeric: {
+      type: Boolean,
+      default: false,
+    },
     /**
      * Number of rows for input.  Converts component to text-area if rows greater than 1.
     */
@@ -96,7 +101,7 @@ export default {
       return 'cdr-input';
     },
     inputAttrs() {
-      const isNum = this.type === 'number';
+      const isNum = this.numeric || this.type === 'number';
       return {
         pattern: isNum && '[0-9]*',
         inputmode: isNum && 'numeric',

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -86,7 +86,7 @@ describe('CdrInput', () => {
     expect(wrapper.vm.$refs.input.hasAttribute('required')).toBe(true);
   });
 
-  it('sets attrs for numeric inputt', () => {
+  it('sets attrs for number type input', () => {
     const wrapper = shallowMount(CdrInput, {
       propsData: {
         label: 'test',
@@ -94,9 +94,24 @@ describe('CdrInput', () => {
         type: 'number'
       },
     });
-    expect(wrapper.vm.$refs.input.hasAttribute('novalidate')).toBe(true);
-    expect(wrapper.vm.$refs.input.hasAttribute('pattern')).toBe(true);
-    expect(wrapper.vm.$refs.input.hasAttribute('inputmode')).toBe(true);
+    expect(wrapper.find('input').attributes('novalidate')).toBe('novalidate');
+    expect(wrapper.find('input').attributes('pattern')).toBe('[0-9]*');
+    expect(wrapper.find('input').attributes('inputmode')).toBe('numeric');
+    expect(wrapper.find('input').attributes('type')).toBe('number');
+  });
+
+  it('sets attrs for numeric freeform input', () => {
+    const wrapper = shallowMount(CdrInput, {
+      propsData: {
+        label: 'test',
+        required: true,
+        numeric: true
+      },
+    });
+    expect(wrapper.find('input').attributes('novalidate')).toBe('novalidate');
+    expect(wrapper.find('input').attributes('pattern')).toBe('[0-9]*');
+    expect(wrapper.find('input').attributes('inputmode')).toBe('numeric');
+    expect(wrapper.find('input').attributes('type')).toBe('text');
   });
 
   it('sets input autofocus attribute correctly', () => {


### PR DESCRIPTION
this feature exists at the intersection of cross-browser HTML implementation bugs and philosophical explorations of what is a "number"

`type="number"` is really designed for things that are actually numbers (like a quantity of something). If you use a number type input, it will wipe its content if the value of the input becomes anything that is not expressible as a number which becomes problematic for just about every number-ish thing on our form patterns docs page.

Things like credit card numbers, postal or security codes, month/year may be constructed out of numerical characters but are not strictly "numbers" in the same sense. For example the credit card number `5555 4444 3333 2222` is not equivalent to the number `5,555,444,433,332,222`. You might also have things like a month/year combo which looks like `05/22` but the "/" is invalid to a number type input and who knows what "0522" gets turned into. These sorts of numerical values are more in the philosophical category of an "identifier", which creates lots of fun for us to navigate :) 

Using a combo of `inputmode="numeric"` and `pattern="[0-9]*"` with `type="text"` seems to resolve these issues for inputs that are made of numbers but are not "numbers" themselves, as it creates an input that launches the correct keyboard on mobile, and also works properly with things like `maxlength`. It does not restrict the input to only numbers, as that would break the use of input masking libraries to insert things like `()-` in phone numbers etc. However consumers can add such a restriction using an @input listener (`@input="() => {this.defaultModel = this.defaultModel.replace(/\D/g, '')}"`. 

https://css-tricks.com/finger-friendly-numerical-inputs-with-inputmode/ more info here