### PR TITLE
fix(modal): add additional padding to modal content to accomodate scroll

### DIFF
--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -63,7 +63,6 @@ export default {
       offset: null,
       headerHeight: 0,
       totalHeight: 0,
-      scrollHeight: 0,
       isScrolling: false,
       hasScrollbar: false,
       fullscreen: false,

--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -63,6 +63,9 @@ export default {
       offset: null,
       headerHeight: 0,
       totalHeight: 0,
+      scrollHeight: 0,
+      isScrolling: false,
+      hasScrollbar: false,
       fullscreen: false,
     };
   },
@@ -73,6 +76,16 @@ export default {
         'aria-modal': 'true',
         id: this.id,
       };
+    },
+    scrollPadding() {
+      if (this.isScrolling && this.hasScrollbar) {
+        // content is scrolling, scrollbar is always present
+        return 4;
+      } if (this.isScrolling) {
+        // content is scrolling, scrollbar only appears on scroll
+        return 12;
+      }
+      return 0;
     },
     verticalSpace() {
       // contentWrap vertical padding
@@ -120,6 +133,8 @@ export default {
         this.totalHeight = window.innerHeight;
         this.fullscreen = window.innerWidth < CdrBreakpointSm;
         this.headerHeight = this.$refs.header.offsetHeight;
+        this.isScrolling = this.$refs.content.scrollHeight > this.$refs.content.offsetHeight;
+        this.hasScrollbar = (this.$refs.content.offsetWidth - this.$refs.content.clientWidth) > 0;
       });
     },
     handleKeyDown({ key }) {
@@ -323,7 +338,10 @@ export default {
                   >
                     <div
                       class={this.style['cdr-modal__text-content']}
-                      style={ { maxHeight: `${this.scrollMaxHeight}px` } }
+                      style={ {
+                        maxHeight: `${this.scrollMaxHeight}px`,
+                        paddingRight: `${this.scrollPadding}px`,
+                      } }
                       ref="content"
                       tabindex="0"
                     >

--- a/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
+++ b/src/components/modal/__tests__/__snapshots__/CdrModal.spec.js.snap
@@ -62,7 +62,7 @@ exports[`CdrModal.vue default open 1`] = `
             >
               <div
                 class="cdr-modal__text-content"
-                style="max-height: -80px;"
+                style="max-height: -80px; padding-right: 0px;"
                 tabindex="0"
               >
                 Sticky content
@@ -141,7 +141,7 @@ exports[`CdrModal.vue fullscreen snapshot 1`] = `
             >
               <div
                 class="cdr-modal__text-content"
-                style="max-height: -32px;"
+                style="max-height: -32px; padding-right: 0px;"
                 tabindex="0"
               />
             </div>
@@ -219,7 +219,7 @@ exports[`CdrModal.vue leaves optional slots empty, handleOpened 1`] = `
             >
               <div
                 class="cdr-modal__text-content"
-                style="max-height: -80px;"
+                style="max-height: -80px; padding-right: 0px;"
                 tabindex="0"
               >
                 Main content

--- a/src/components/modal/examples/Modal.vue
+++ b/src/components/modal/examples/Modal.vue
@@ -33,6 +33,12 @@
       <cdr-text class="cdr-text-dev--body-300">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sit amet dictum ipsum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aliquam non urna sit amet dolor euismod consequat vitae non nunc. Nullam vulputate enim ac pharetra sagittis. Curabitur volutpat, metus eu euismod finibus, neque turpis viverra dolor, at ornare justo libero a arcu. Suspendisse nec lectus id leo aliquam posuere id eu mauris. Aenean fermentum justo ex, vel sagittis nulla efficitur nec. Mauris aliquet urna id felis maximus, et molestie erat bibendum. Donec dolor purus, iaculis vitae tellus at, iaculis facilisis nibh. Pellentesque at ex sit amet eros elementum iaculis quis ut justo. Pellentesque consequat in sapien ac blandit. Donec ullamcorper lacus sed interdum auctor.</cdr-text>
 
       <!-- eslint-disable-next-line -->
+      <div style="display: flex; justify-content: space-between; align-items: center;" v-if="overflowContent">
+        <cdr-link>Lorem Ipsum Etsum Flotsam Jetsons</cdr-link>
+        <cdr-button>boop</cdr-button>
+      </div>
+
+      <!-- eslint-disable-next-line -->
       <cdr-text class="cdr-text-dev--body-300" v-if="overflowContent">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sit amet dictum ipsum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aliquam non urna sit amet dolor euismod consequat vitae non nunc. Nullam vulputate enim ac pharetra sagittis. Curabitur volutpat, metus eu euismod finibus, neque turpis viverra dolor, at ornare justo libero a arcu. Suspendisse nec lectus id leo aliquam posuere id eu mauris. Aenean fermentum justo ex, vel sagittis nulla efficitur nec. Mauris aliquet urna id felis maximus, et molestie erat bibendum. Donec dolor purus, iaculis vitae tellus at, iaculis facilisis nibh. Pellentesque at ex sit amet eros elementum iaculis quis ut justo. Pellentesque consequat in sapien ac blandit. Donec ullamcorper lacus sed interdum auctor.</cdr-text>
 
       <!-- eslint-disable-next-line -->


### PR DESCRIPTION
on modal open, we check to see if the content is overflowing AND what the size of the vertical scrollbar is. If overflowing and the vertical scrollbar has a width, that means a traditional permanent scrollbar is present. If overflowing and the vertical scrollbar has 0 width, that means a Mac floaty scrollbar will pop up on scroll.

If it's overflowing and there is a scrollbar present, add a small bit of padding. Otherwise the modal content juts up directly against the content.
If it's overflowing and there is no scrollbar present, add a bunch of padding so the floating scrollbar does not overlap with content.
if it's not overflowing add no padding


On Mac, you get the floaty scrollbar by default if using a trackpad. If you plug in a mouse you should see the permanent scrollbar. Though you need to re-open or resize the window after changing input device to get the padding to update to the new scroll type.
Browserstack won't seem to load an iOS device for me at the moment so can't test on mobile Mac yet. 
<img width="617" alt="Screen Shot 2021-05-24 at 12 25 13 PM" src="https://user-images.githubusercontent.com/48567940/119397805-83a47000-bc8b-11eb-9b12-197520c6f49d.png">
<img width="727" alt="Screen Shot 2021-05-24 at 12 24 58 PM" src="https://user-images.githubusercontent.com/48567940/119397819-88692400-bc8b-11eb-973f-5d7574525ed5.png">

Here's what it looks like on the bopus modal (simulated by just adding the padding-right in on future):
<img width="620" alt="Screen Shot 2021-05-24 at 12 31 55 PM" src="https://user-images.githubusercontent.com/48567940/119398215-1d6c1d00-bc8c-11eb-9fb9-2b70f462565b.png">
<img width="744" alt="Screen Shot 2021-05-24 at 12 31 42 PM" src="https://user-images.githubusercontent.com/48567940/119398218-1e9d4a00-bc8c-11eb-9412-25783fda3765.png">

