### PR TITLE
refactor input/select

### DIFF
--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -189,67 +189,64 @@ export default {
   },
   render() {
     return (
-      <div>
-        <cdr-label-standalone
-          for-id={ `${this.inputId}` }
-          label={ this.label }
-          hide-label={ this.hideLabel }
-          required={ this.required }
-          optional={ this.optional }
-          disabled={ this.disabled }
-        >
-          { this.$slots['helper-text-top'] && (
-            <template slot="helper">
-              { this.$slots['helper-text-top'] }
-            </template>
-          )}
-          { this.$slots.info && (
-            <template slot="info">
-              {this.$slots.info}
-            </template>
-          )}
-        </cdr-label-standalone>
-        <div class={this.style['cdr-input-outer-wrap']}>
-          <div class={this.wrapperClass}>
-            {this.inputEl}
-            {this.$slots['pre-icon'] && (
-              <span
-                class={this.style['cdr-input__pre-icon']}
-              >
-                {this.$slots['pre-icon']}
-              </span>
-            )}
-
-            {this.$slots['post-icon'] && (
-              <span
-                class={this.style['cdr-input__post-icon']}
-              >
-                {this.$slots['post-icon']}
-              </span>
-            )}
-          </div>
-          {this.$slots['info-action'] && (
-            <div
-              class={this.style['cdr-input__info-action']}
+      <cdr-label-standalone
+        for-id={ `${this.inputId}` }
+        label={ this.label }
+        hide-label={ this.hideLabel }
+        required={ this.required }
+        optional={ this.optional }
+        disabled={ this.disabled }
+      >
+        { this.$slots['helper-text-top'] && (
+          <template slot="helper">
+            { this.$slots['helper-text-top'] }
+          </template>
+        )}
+        { this.$slots.info && (
+          <template slot="info">
+            {this.$slots.info}
+          </template>
+        )}
+        <div class={this.wrapperClass}>
+          {this.inputEl}
+          {this.$slots['pre-icon'] && (
+            <span
+              class={this.style['cdr-input__pre-icon']}
             >
-              {this.$slots['info-action']}
-            </div>
+              {this.$slots['pre-icon']}
+            </span>
+          )}
+
+          {this.$slots['post-icon'] && (
+            <span
+              class={this.style['cdr-input__post-icon']}
+            >
+              {this.$slots['post-icon']}
+            </span>
           )}
         </div>
+
+        {this.$slots['info-action'] && (
+          <template slot="info-action">
+            {this.$slots['info-action']}
+          </template>
+        )}
+
         {(this.$slots['helper-text-bottom'])
           && !this.error && (
-            <span class={this.style['cdr-input__helper-text']}>
+            <span class={this.style['cdr-input__helper-text']} slot="helper-text-bottom">
               {this.$slots['helper-text-bottom']}
             </span>
         )}
+
         {this.error && (
-          <cdr-form-error role={this.errorRole} error={this.error}>
+          <cdr-form-error role={this.errorRole} error={this.error} slot="error">
             <template slot="error">
               {this.$slots.error}
             </template>
           </cdr-form-error>
         )}
-      </div>
+      </cdr-label-standalone>
     );
   },
 };

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -354,7 +354,7 @@ describe('CdrInput', () => {
   });
 
   it('renders info action slot', () => {
-    const wrapper = shallowMount(CdrInput, {
+    const wrapper = mount(CdrInput, {
       propsData: {
         label: 'test',
         id: 'info-action'
@@ -363,7 +363,7 @@ describe('CdrInput', () => {
         'info-action': '🤠',
       },
     });
-    expect(wrapper.find('.cdr-input__info-action').text()).toBe('🤠');
+    expect(wrapper.find('.cdr-label-standalone__info-action').text()).toBe('🤠');
   });
 
   it('renders error slot when error state is active', () => {

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CdrInput renders correctly 1`] = `
-<div>
+<div
+  class="cdr-label-standalone"
+>
   <div
-    class="cdr-label-standalone cdr-label-standalone--spacing"
+    class="cdr-label-standalone__label-wrapper"
   >
     <label
       class="cdr-label-standalone__label"
@@ -13,7 +15,7 @@ exports[`CdrInput renders correctly 1`] = `
     </label>
   </div>
   <div
-    class="cdr-label-standalone__input-wrap"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     <div
       class="cdr-input-wrap"
@@ -28,13 +30,18 @@ exports[`CdrInput renders correctly 1`] = `
       />
     </div>
   </div>
+  <div
+    class="cdr-label-standalone__post-content"
+  />
 </div>
 `;
 
 exports[`CdrInput renders number input correctly 1`] = `
-<div>
+<div
+  class="cdr-label-standalone"
+>
   <div
-    class="cdr-label-standalone cdr-label-standalone--spacing"
+    class="cdr-label-standalone__label-wrapper"
   >
     <label
       class="cdr-label-standalone__label"
@@ -44,7 +51,7 @@ exports[`CdrInput renders number input correctly 1`] = `
     </label>
   </div>
   <div
-    class="cdr-label-standalone__input-wrap"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     <div
       class="cdr-input-wrap"
@@ -62,5 +69,8 @@ exports[`CdrInput renders number input correctly 1`] = `
       />
     </div>
   </div>
+  <div
+    class="cdr-label-standalone__post-content"
+  />
 </div>
 `;

--- a/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
+++ b/src/components/input/__tests__/__snapshots__/CdrInput.spec.js.snap
@@ -13,7 +13,7 @@ exports[`CdrInput renders correctly 1`] = `
     </label>
   </div>
   <div
-    class="cdr-input-outer-wrap"
+    class="cdr-label-standalone__input-wrap"
   >
     <div
       class="cdr-input-wrap"
@@ -44,7 +44,7 @@ exports[`CdrInput renders number input correctly 1`] = `
     </label>
   </div>
   <div
-    class="cdr-input-outer-wrap"
+    class="cdr-label-standalone__input-wrap"
   >
     <div
       class="cdr-input-wrap"

--- a/src/components/input/styles/CdrInput.scss
+++ b/src/components/input/styles/CdrInput.scss
@@ -72,11 +72,10 @@
   &--preicon {
     /* $input-pre-icon-default-width = 25px with the expectation that
         slot provided icon is close to that width */
-    // TODO: use icon token here?
     padding-left: calc(#{$cdr-space-half-x} + #{$cdr-space-quarter-x} + 25px) !important;
   }
-// add right padding so input content does not overlap post-icon(s)
-// CHECK button icon width in safari?
+
+// add right padding so input content does not overlap post-icon(s)\
   &--posticon {
     padding-right: 45px;
   }
@@ -164,14 +163,6 @@
     display: inline-block;
     margin-top: $cdr-space-quarter-x;
   }
-
-  &__info-action {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 40px;
-    width: 40px;
-  }
 }
 
 /* ==========================================================================
@@ -182,8 +173,4 @@
   position: relative;
   flex-grow: 1;
   fill: $cdr-color-icon-default;
-}
-
-.cdr-input-outer-wrap {
-  display: flex;
 }

--- a/src/components/labelStandalone/CdrLabelStandalone.jsx
+++ b/src/components/labelStandalone/CdrLabelStandalone.jsx
@@ -60,23 +60,38 @@ export default {
   },
   render() {
     return (
-      <div class={this.wrapperClass}>
-        { this.labelEl }
-        { this.labelEl && this.$slots.helper && (<br/>) }
-        { this.$slots.helper && (
-          <span
-            class={this.style['cdr-label-standalone__helper']}
-          >
-            { this.$slots.helper }
-          </span>
-        )}
-        {this.$slots.info && (
-          <span
-            class={this.style['cdr-label-standalone__info']}
-          >
-            { this.$slots.info }
-          </span>
-        )}
+      <div>
+        <div class={this.wrapperClass}>
+          { this.labelEl }
+          { this.labelEl && this.$slots.helper && (<br/>) }
+          { this.$slots.helper && (
+            <span
+              class={this.style['cdr-label-standalone__helper']}
+            >
+              { this.$slots.helper }
+            </span>
+          )}
+          {this.$slots.info && (
+            <span
+              class={this.style['cdr-label-standalone__info']}
+            >
+              { this.$slots.info }
+            </span>
+          )}
+        </div>
+
+        <div class={this.style['cdr-label-standalone__input-wrap']}>
+          {this.$slots.default}
+          {this.$slots['info-action'] && (
+            <div
+              class={this.style['cdr-label-standalone__info-action']}
+            >
+              {this.$slots['info-action']}
+            </div>
+          )}
+        </div>
+        {this.$slots['helper-text-bottom']}
+        {this.$slots.error}
       </div>
     );
   },

--- a/src/components/labelStandalone/CdrLabelStandalone.jsx
+++ b/src/components/labelStandalone/CdrLabelStandalone.jsx
@@ -25,11 +25,11 @@ export default {
         [this.style['cdr-label-standalone__label--disabled']]: this.disabled,
       };
     },
-    wrapperClass() {
-      const hasContent = !this.hideLabel || this.$slots.helper || this.$slots.info;
+    inputClass() {
+      const hasLabelContent = !this.hideLabel || this.$slots.helper || this.$slots.info;
       return {
-        [this.style['cdr-label-standalone']]: true,
-        [this.style['cdr-label-standalone--spacing']]: hasContent,
+        [this.style['cdr-label-standalone__input-wrap']]: true,
+        [this.style['cdr-label-standalone__input-spacing']]: hasLabelContent,
       };
     },
     labelEl() {
@@ -60,8 +60,8 @@ export default {
   },
   render() {
     return (
-      <div>
-        <div class={this.wrapperClass}>
+      <div class={this.style['cdr-label-standalone']}>
+        <div class={this.style['cdr-label-standalone__label-wrapper']}>
           { this.labelEl }
           { this.labelEl && this.$slots.helper && (<br/>) }
           { this.$slots.helper && (
@@ -71,16 +71,9 @@ export default {
               { this.$slots.helper }
             </span>
           )}
-          {this.$slots.info && (
-            <span
-              class={this.style['cdr-label-standalone__info']}
-            >
-              { this.$slots.info }
-            </span>
-          )}
         </div>
 
-        <div class={this.style['cdr-label-standalone__input-wrap']}>
+        <div class={this.inputClass}>
           {this.$slots.default}
           {this.$slots['info-action'] && (
             <div
@@ -90,8 +83,19 @@ export default {
             </div>
           )}
         </div>
-        {this.$slots['helper-text-bottom']}
-        {this.$slots.error}
+
+        {this.$slots.info && (
+          <span
+            class={this.style['cdr-label-standalone__info']}
+          >
+            { this.$slots.info }
+          </span>
+        )}
+        
+        <div class={this.style['cdr-label-standalone__post-content']}>
+          {this.$slots['helper-text-bottom']}
+          {this.$slots.error}
+        </div>
       </div>
     );
   },

--- a/src/components/labelStandalone/CdrLabelStandalone.jsx
+++ b/src/components/labelStandalone/CdrLabelStandalone.jsx
@@ -91,7 +91,7 @@ export default {
             { this.$slots.info }
           </span>
         )}
-        
+
         <div class={this.style['cdr-label-standalone__post-content']}>
           {this.$slots['helper-text-bottom']}
           {this.$slots.error}

--- a/src/components/labelStandalone/__tests__/__snapshots__/CdrLabelStandalone.spec.js.snap
+++ b/src/components/labelStandalone/__tests__/__snapshots__/CdrLabelStandalone.spec.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CdrFormLabelStandalone matches snapshot 1`] = `
-<div>
+<div
+  class="cdr-label-standalone"
+>
   <div
-    class="cdr-label-standalone cdr-label-standalone--spacing"
+    class="cdr-label-standalone__label-wrapper"
   >
     <label
       class="cdr-label-standalone__label"
@@ -22,14 +24,17 @@ exports[`CdrFormLabelStandalone matches snapshot 1`] = `
     >
       very helpful
     </span>
-    <span
-      class="cdr-label-standalone__info"
-    >
-      very informative
-    </span>
   </div>
   <div
-    class="cdr-label-standalone__input-wrap"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
+  />
+  <span
+    class="cdr-label-standalone__info"
+  >
+    very informative
+  </span>
+  <div
+    class="cdr-label-standalone__post-content"
   />
 </div>
 `;

--- a/src/components/labelStandalone/__tests__/__snapshots__/CdrLabelStandalone.spec.js.snap
+++ b/src/components/labelStandalone/__tests__/__snapshots__/CdrLabelStandalone.spec.js.snap
@@ -1,30 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CdrFormLabelStandalone matches snapshot 1`] = `
-<div
-  class="cdr-label-standalone cdr-label-standalone--spacing"
->
-  <label
-    class="cdr-label-standalone__label"
-    for="test"
+<div>
+  <div
+    class="cdr-label-standalone cdr-label-standalone--spacing"
   >
-    Label Test 
-    <span
-      aria-label="required"
+    <label
+      class="cdr-label-standalone__label"
+      for="test"
     >
-      *
+      Label Test 
+      <span
+        aria-label="required"
+      >
+        *
+      </span>
+    </label>
+    <br />
+    <span
+      class="cdr-label-standalone__helper"
+    >
+      very helpful
     </span>
-  </label>
-  <br />
-  <span
-    class="cdr-label-standalone__helper"
-  >
-    very helpful
-  </span>
-  <span
-    class="cdr-label-standalone__info"
-  >
-    very informative
-  </span>
+    <span
+      class="cdr-label-standalone__info"
+    >
+      very informative
+    </span>
+  </div>
+  <div
+    class="cdr-label-standalone__input-wrap"
+  />
 </div>
 `;

--- a/src/components/labelStandalone/styles/CdrLabelStandalone.scss
+++ b/src/components/labelStandalone/styles/CdrLabelStandalone.scss
@@ -36,4 +36,16 @@
     right: 0;
     bottom: 0;
   }
+
+  &__info-action {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 40px;
+  }
+
+  &__input-wrap {
+    position: relative;
+    display: flex;
+  }
 }

--- a/src/components/labelStandalone/styles/CdrLabelStandalone.scss
+++ b/src/components/labelStandalone/styles/CdrLabelStandalone.scss
@@ -2,15 +2,20 @@
 @import './vars/CdrLabelStandalone.vars.scss';
 
 .cdr-label-standalone {
-  position: relative;
+  display: grid;
 
-  &--spacing {
-    margin-bottom: $cdr-space-half-x;
+  grid-template-areas:
+    "label label info"
+    "input input input"
+    "post post post";
+
+
+  &__label-wrapper {
+    grid-area: label;
   }
 
   &__label {
     @include cdr-label-standalone-label-mixin;
-    display: inline-block;
 
     &--disabled {
       @include cdr-label-standalone-disabled-mixin;
@@ -27,14 +32,18 @@
 
   &__helper {
     @include cdr-label-standalone-helper-mixin;
-    display: inline-block;
   }
 
   &__info {
     @include cdr-label-standalone-info-mixin;
-    position: absolute;
-    right: 0;
-    bottom: 0;
+    grid-area: info;
+    order: 2;
+    align-self: end;
+    justify-self: end;
+  }
+
+  &__post-content {
+    grid-area: post;
   }
 
   &__info-action {
@@ -47,5 +56,11 @@
   &__input-wrap {
     position: relative;
     display: flex;
+    grid-area: input;
   }
+
+  &__input-spacing {
+    margin-top: $cdr-space-half-x;
+  }
+
 }

--- a/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
@@ -112,7 +112,7 @@ exports[`CdrPagination renders button pagination correctly 1`] = `
           class="cdr-label-standalone"
         />
         <div
-          class="cdr-select-outer-wrap"
+          class="cdr-label-standalone__input-wrap"
         >
           <div
             class="cdr-select-wrap"
@@ -310,7 +310,7 @@ exports[`CdrPagination renders correctly 1`] = `
           class="cdr-label-standalone"
         />
         <div
-          class="cdr-select-outer-wrap"
+          class="cdr-label-standalone__input-wrap"
         >
           <div
             class="cdr-select-wrap"
@@ -502,7 +502,7 @@ exports[`CdrPagination renders scoped slot correctly 1`] = `
           class="cdr-label-standalone"
         />
         <div
-          class="cdr-select-outer-wrap"
+          class="cdr-label-standalone__input-wrap"
         >
           <div
             class="cdr-select-wrap"

--- a/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
+++ b/src/components/pagination/__tests__/__snapshots__/CdrPagination.spec.js.snap
@@ -107,9 +107,11 @@ exports[`CdrPagination renders button pagination correctly 1`] = `
     <li
       class="cdr-pagination__li--select"
     >
-      <div>
+      <div
+        class="cdr-label-standalone"
+      >
         <div
-          class="cdr-label-standalone"
+          class="cdr-label-standalone__label-wrapper"
         />
         <div
           class="cdr-label-standalone__input-wrap"
@@ -166,6 +168,9 @@ exports[`CdrPagination renders button pagination correctly 1`] = `
             </svg>
           </div>
         </div>
+        <div
+          class="cdr-label-standalone__post-content"
+        />
       </div>
     </li>
     <li>
@@ -305,9 +310,11 @@ exports[`CdrPagination renders correctly 1`] = `
     <li
       class="cdr-pagination__li--select"
     >
-      <div>
+      <div
+        class="cdr-label-standalone"
+      >
         <div
-          class="cdr-label-standalone"
+          class="cdr-label-standalone__label-wrapper"
         />
         <div
           class="cdr-label-standalone__input-wrap"
@@ -364,6 +371,9 @@ exports[`CdrPagination renders correctly 1`] = `
             </svg>
           </div>
         </div>
+        <div
+          class="cdr-label-standalone__post-content"
+        />
       </div>
     </li>
     <li>
@@ -497,9 +507,11 @@ exports[`CdrPagination renders scoped slot correctly 1`] = `
     <li
       class="cdr-pagination__li--select"
     >
-      <div>
+      <div
+        class="cdr-label-standalone"
+      >
         <div
-          class="cdr-label-standalone"
+          class="cdr-label-standalone__label-wrapper"
         />
         <div
           class="cdr-label-standalone__input-wrap"
@@ -556,6 +568,9 @@ exports[`CdrPagination renders scoped slot correctly 1`] = `
             </svg>
           </div>
         </div>
+        <div
+          class="cdr-label-standalone__post-content"
+        />
       </div>
     </li>
     <li>

--- a/src/components/select/CdrSelect.jsx
+++ b/src/components/select/CdrSelect.jsx
@@ -186,56 +186,50 @@ export default {
   },
   render() {
     return (
-      <div>
-        <cdr-label-standalone
-          for-id={ `${this.selectId}` }
-          label={ this.label }
-          hide-label={ this.hideLabel }
-          required={ this.required }
-          optional={ this.optional }
-          disabled={ this.disabled }
-        >
-          { this.$slots['helper-text'] && (
-            <template slot="helper">
-              { this.$slots['helper-text'] }
-            </template>
-          )}
-          { this.$slots.info && (
-            <template slot="info">
-              {this.$slots.info}
-            </template>
-          )}
-        </cdr-label-standalone>
-        <div class={this.style['cdr-select-outer-wrap']}>
-          <div class={this.style['cdr-select-wrap']}>
-            {this.$slots['pre-icon'] && (
-              <span
-                class={this.style['cdr-select__pre-icon']}
-              >
-                {this.$slots['pre-icon']}
-              </span>
-            )}
-            {this.selectEl}
-            <icon-caret-down
-            class={this.caretClass}
-            />
-          </div>
-          {this.$slots['info-action'] && (
-            <div
-              class={this.style['cdr-select__info-action']}
-            >
-              {this.$slots['info-action']}
-            </div>
-          )}
-        </div>
+      <cdr-label-standalone
+        for-id={ `${this.selectId}` }
+        label={ this.label }
+        hide-label={ this.hideLabel }
+        required={ this.required }
+        optional={ this.optional }
+        disabled={ this.disabled }
+      >
+        { this.$slots['helper-text'] && (
+          <template slot="helper">
+            { this.$slots['helper-text'] }
+          </template>
+        )}
+        { this.$slots.info && (
+          <template slot="info">
+            {this.$slots.info}
+          </template>
+        )}
+        {this.$slots['info-action'] && (
+          <template slot="info-action">
+            {this.$slots['info-action']}
+          </template>
+        )}
         {this.error && (
-          <cdr-form-error role={this.errorRole} error={this.error} >
+          <cdr-form-error role={this.errorRole} error={this.error} slot="error">
             <template slot="error">
               {this.$slots.error}
             </template>
           </cdr-form-error>
         )}
-      </div>
+        <div class={this.style['cdr-select-wrap']}>
+          {this.$slots['pre-icon'] && (
+            <span
+              class={this.style['cdr-select__pre-icon']}
+            >
+              {this.$slots['pre-icon']}
+            </span>
+          )}
+          {this.selectEl}
+          <icon-caret-down
+          class={this.caretClass}
+          />
+        </div>
+      </cdr-label-standalone>
     );
   },
 };

--- a/src/components/select/__tests__/CdrSelect.spec.js
+++ b/src/components/select/__tests__/CdrSelect.spec.js
@@ -174,7 +174,7 @@ describe('cdrSelect', () => {
   });
 
   it('renders info action slot', () => {
-    const wrapper = shallowMount(CdrSelect, {
+    const wrapper = mount(CdrSelect, {
       propsData: {
         label: 'test',
         id: 'info-action'
@@ -183,7 +183,7 @@ describe('cdrSelect', () => {
         'info-action': '🤠',
       },
     });
-    expect(wrapper.find('.cdr-select__info-action').text()).toBe('🤠');
+    expect(wrapper.find('.cdr-label-standalone__info-action').text()).toBe('🤠');
   });
 
   it('renders helper-text slot', () => {

--- a/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
+++ b/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cdrSelect renders correctly 1`] = `
-<div>
+<div
+  class="cdr-label-standalone"
+>
   <div
-    class="cdr-label-standalone cdr-label-standalone--spacing"
+    class="cdr-label-standalone__label-wrapper"
   >
     <label
       class="cdr-label-standalone__label"
@@ -13,7 +15,7 @@ exports[`cdrSelect renders correctly 1`] = `
     </label>
   </div>
   <div
-    class="cdr-label-standalone__input-wrap"
+    class="cdr-label-standalone__input-wrap cdr-label-standalone__input-spacing"
   >
     <div
       class="cdr-select-wrap"
@@ -35,5 +37,8 @@ exports[`cdrSelect renders correctly 1`] = `
       </svg>
     </div>
   </div>
+  <div
+    class="cdr-label-standalone__post-content"
+  />
 </div>
 `;

--- a/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
+++ b/src/components/select/__tests__/__snapshots__/CdrSelect.spec.js.snap
@@ -13,7 +13,7 @@ exports[`cdrSelect renders correctly 1`] = `
     </label>
   </div>
   <div
-    class="cdr-select-outer-wrap"
+    class="cdr-label-standalone__input-wrap"
   >
     <div
       class="cdr-select-wrap"

--- a/src/components/select/styles/CdrSelect.scss
+++ b/src/components/select/styles/CdrSelect.scss
@@ -73,17 +73,6 @@
     transform: translateY(-50%);
   }
 
-  &__info-action {
-    position: relative;
-    width: 40px;
-    & > * {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
-  }
-
   &--multiple {
     height: auto;
     padding: $cdr-space-half-x;
@@ -147,9 +136,4 @@
 .cdr-select-wrap {
   position: relative;
   flex: 1;
-}
-
-.cdr-select-outer-wrap {
-  position: relative;
-  display: flex;
 }

--- a/src/components/tabs/CdrTabs.backstop.js
+++ b/src/components/tabs/CdrTabs.backstop.js
@@ -10,18 +10,18 @@ module.exports = [
     selectors: [
       '[data-backstop="tab-default"]',
     ],
-    // hoverSelectors: [
-    //   {
-    //     target: '[data-backstop="tab-default"] li:nth-child(2) a',
-    //     capture: '[data-backstop="tab-default"]',
-    //   },
-    // ],
-    // focusSelectors: [
-    //   {
-    //     target: '[data-backstop="tab-default"] li:nth-child(2) a',
-    //     capture: '[data-backstop="tab-default"]',
-    //   },
-    // ],
+    hoverSelectors: [
+      {
+        target: '[data-backstop="tab-default"] button:nth-child(2)',
+        capture: '[data-backstop="tab-default"]',
+      },
+    ],
+    focusSelectors: [
+      {
+        target: '[data-backstop="tab-default"] button:nth-child(2)',
+        capture: '[data-backstop="tab-default"]',
+      },
+    ],
     wait: 1000,
   },
 ];

--- a/src/components/tabs/CdrTabs.backstop.js
+++ b/src/components/tabs/CdrTabs.backstop.js
@@ -10,18 +10,18 @@ module.exports = [
     selectors: [
       '[data-backstop="tab-default"]',
     ],
-    hoverSelectors: [
-      {
-        target: '[data-backstop="tab-default"] li:nth-child(2) a',
-        capture: '[data-backstop="tab-default"]',
-      },
-    ],
-    focusSelectors: [
-      {
-        target: '[data-backstop="tab-default"] li:nth-child(2) a',
-        capture: '[data-backstop="tab-default"]',
-      },
-    ],
+    // hoverSelectors: [
+    //   {
+    //     target: '[data-backstop="tab-default"] li:nth-child(2) a',
+    //     capture: '[data-backstop="tab-default"]',
+    //   },
+    // ],
+    // focusSelectors: [
+    //   {
+    //     target: '[data-backstop="tab-default"] li:nth-child(2) a',
+    //     capture: '[data-backstop="tab-default"]',
+    //   },
+    // ],
     wait: 1000,
   },
 ];


### PR DESCRIPTION
1. refactor cdr-label-standalone so that everything necessary to render a cdr-input or cdr-select gets passed in as a slot
2. refactor cdr-label-standalone to ensure info link comes after the input/select tab-order wise. https://issues.rei.com/browse/CDR-2113