### PR TITLE
Fix safari modal again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/modal/styles/CdrModal.scss
+++ b/src/components/modal/styles/CdrModal.scss
@@ -8,7 +8,7 @@ $modal-animation-duration: 150ms;
       // Safari iOS hack: force hardware acceleration on all elements inside modal
       //     otherwise content that is offscreen will flicker/disappear when scrolling
       // Issue has to do with scrolling inside a position: fixed or relative container
-      -webkit-transform: translate3d(0,0,0);
+      will-change: transform;
     }
   }
 


### PR DESCRIPTION
the original translate3d hack we tried interferes with any modal children that use a `transform: translate` themselves 
`will-change: transform` achieves the same ios hardware acceleration hack but doesn't conflict https://aerotwist.com/blog/bye-bye-layer-hacks/