### PR TITLE
feat(breadcrumb): emit navigate emit for customizing behavior

### DIFF
--- a/src/components/breadcrumb/CdrBreadcrumb.jsx
+++ b/src/components/breadcrumb/CdrBreadcrumb.jsx
@@ -102,6 +102,7 @@ export default {
             : (<a
               class={this.style['cdr-breadcrumb__link']}
               href={breadcrumb.item.url}
+              onClick={(e) => this.$emit('navigate', breadcrumb, e)}
             >
               { breadcrumb.item.name }
             </a>)

--- a/src/components/breadcrumb/examples/Breadcrumb.vue
+++ b/src/components/breadcrumb/examples/Breadcrumb.vue
@@ -31,6 +31,14 @@
     />
 
     <h3>
+      Breadcrumb handle navigate events
+    </h3>
+    <cdr-breadcrumb
+      :items="shortBreadcrumbItems"
+      data-backstop="breadcrumbs-default"
+      @navigate="handleClick"
+    />
+    <h3>
       Scoped Slot
     </h3>
     <cdr-breadcrumb :items="reiExampleBreadcrumbItems">
@@ -55,6 +63,12 @@ import * as Components from 'srcdir/index';
 export default {
   name: 'Breadcrumb',
   components: { ...Components },
+  methods: {
+    handleClick(bc, e) {
+      e.preventDefault();
+      console.log(bc.item);
+    },
+  },
   data() {
     return {
       averageBreadcrumbItems: [


### PR DESCRIPTION
- lets us deprecate breadcrumb scoped slot and have consumers use the `navigate` event instead
- supports adding metrics or etc. behavior to breadcrumb items 