### PR TITLE
Required aria swap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "9.0.0-beta.2",
+  "version": "9.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "9.0.0-beta.2",
+  "version": "9.0.0-beta.3",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/accordion/examples/Accordion.vue
+++ b/src/components/accordion/examples/Accordion.vue
@@ -17,12 +17,12 @@
         A short label
       </template>
       <cdr-text
-        modifier="body-300"
+        class="cdr-text-dev--body-300"
       >
         This is some text. It's in a
         <cdr-text
           tag="strong"
-          modifier="body-strong-300"
+          class="cdr-text-dev--body-strong-300"
         >cdr-text paragraph with a modifier of <code>body-300</code></cdr-text> element as
         thats how you assign the correct font and line-height for text dislpay on REI.
         does not include margin or add space to the container. Lorem ipsum dolor
@@ -53,12 +53,12 @@
             A short label
           </template>
           <cdr-text
-            modifier="body-300"
+            class="cdr-text-dev--body-300"
           >
             This is some text. It's in a
             <cdr-text
               tag="strong"
-              modifier="body-strong-300"
+              class="cdr-text-dev--body-strong-300"
             >cdr-text paragraph with a modifier of <code>body-300</code></cdr-text> element as
             thats how you assign the correct font and line-height for text dislpay on REI.
             does not include margin or add space to the container. Lorem ipsum dolor
@@ -192,12 +192,12 @@
           A short label
         </template>
         <cdr-text
-          modifier="body-300"
+          class="cdr-text-dev--body-300"
         >
           This is some text. It's in a
           <cdr-text
             tag="strong"
-            modifier="body-strong-300"
+            class="cdr-text-dev--body-strong-300"
           >cdr-text paragraph with a modifier of <code>body-300</code></cdr-text> element as
           thats how you assign the correct font and line-height for text dislpay on REI.
           does not include margin or add space to the container. Lorem ipsum dolor

--- a/src/components/banner/examples/Banner.vue
+++ b/src/components/banner/examples/Banner.vue
@@ -18,7 +18,7 @@
     </cdr-banner>
     <br>
     <cdr-banner type="error">
-      <cdr-text modifier="heading-serif-strong-1200">
+      <cdr-text class="cdr-text-dev--heading-serif-strong-1200">
         <icon-x-fill /> error banner
       </cdr-text>
     </cdr-banner>

--- a/src/components/card/examples/demo/complexCard.vue
+++ b/src/components/card/examples/demo/complexCard.vue
@@ -23,7 +23,7 @@
             count="12"
             size="small"
           />
-          <cdr-text modifier="body-300">
+          <cdr-text class="cdr-text-dev--body-300">
             Card content
           </cdr-text>
         </div>

--- a/src/components/formGroup/examples/demo/Checkboxes.vue
+++ b/src/components/formGroup/examples/demo/Checkboxes.vue
@@ -20,7 +20,7 @@
     <cdr-form-group>
 
       <template slot="label">
-        <cdr-text modifier="heading-sans-600">
+        <cdr-text class="cdr-text-dev--heading-sans-600">
           Optional Label Override Example
         </cdr-text>
       </template>

--- a/src/components/image/examples/demos/Cropping.vue
+++ b/src/components/image/examples/demos/Cropping.vue
@@ -5,7 +5,7 @@
     </h3>
     <cdr-grid style="grid-template-columns: 1fr 1fr 1fr; 1fr">
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Left
         </cdr-text>
         <cdr-img
@@ -17,7 +17,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Center
         </cdr-text>
         <cdr-img
@@ -29,7 +29,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Right
         </cdr-text>
         <cdr-img
@@ -49,7 +49,7 @@
     <cdr-grid style="grid-template-columns: 1fr 1fr 1fr; 1fr">
 
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Top
         </cdr-text>
         <cdr-img
@@ -61,7 +61,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Center
         </cdr-text>
         <cdr-img
@@ -73,7 +73,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Bottom
         </cdr-text>
         <cdr-img
@@ -91,7 +91,7 @@
     </h3>
     <cdr-grid style="grid-template-columns: 1fr 1fr 1fr; 1fr">
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Reference Image
         </cdr-text>
         <cdr-img
@@ -101,7 +101,7 @@
       </div>
 
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           top, left
         </cdr-text>
         <cdr-img
@@ -112,7 +112,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           top, x-center
         </cdr-text>
         <cdr-img
@@ -123,7 +123,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           top, right
         </cdr-text>
         <cdr-img
@@ -134,7 +134,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           y-center, left
         </cdr-text>
         <cdr-img
@@ -145,7 +145,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           y-center, x-center
         </cdr-text>
         <cdr-img
@@ -156,7 +156,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           y-center, right
         </cdr-text>
         <cdr-img
@@ -167,7 +167,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           bottom, left
         </cdr-text>
         <cdr-img
@@ -178,7 +178,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           bottom, x-center
         </cdr-text>
         <cdr-img
@@ -189,7 +189,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           bottom, right
         </cdr-text>
         <cdr-img

--- a/src/components/image/examples/demos/Mods.vue
+++ b/src/components/image/examples/demos/Mods.vue
@@ -5,7 +5,7 @@
     </h3>
     <cdr-grid style="grid-template-columns: 1fr 1fr;">
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Responsive
         </cdr-text>
         <cdr-img
@@ -24,7 +24,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           Rounded
         </cdr-text>
         <cdr-img
@@ -48,7 +48,7 @@
         />
       </div>
       <div>
-        <cdr-text modifier="subheading">
+        <cdr-text class="cdr-text-dev--subheading-sans-300">
           circle
         </cdr-text>
         <cdr-img

--- a/src/components/image/examples/demos/Ratios.vue
+++ b/src/components/image/examples/demos/Ratios.vue
@@ -1,7 +1,7 @@
 <template>
   <cdr-grid style="grid-template-columns: 1fr 1fr 1fr 1fr;">
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         Square
       </cdr-text>
       <cdr-img
@@ -12,7 +12,7 @@
       />
     </div>
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         1-2
       </cdr-text>
       <cdr-img
@@ -23,7 +23,7 @@
       />
     </div>
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         2-3
       </cdr-text>
       <cdr-img
@@ -34,7 +34,7 @@
       />
     </div>
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         3-4
       </cdr-text>
       <cdr-img
@@ -45,7 +45,7 @@
       />
     </div>
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         9-16
       </cdr-text>
       <cdr-img
@@ -56,7 +56,7 @@
       />
     </div>
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         2-1
       </cdr-text>
       <cdr-img
@@ -67,7 +67,7 @@
       />
     </div>
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         3-2
       </cdr-text>
       <cdr-img
@@ -78,7 +78,7 @@
       />
     </div>
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         4-3
       </cdr-text>
       <cdr-img
@@ -89,7 +89,7 @@
       />
     </div>
     <div>
-      <cdr-text modifier="subheading">
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         16-9
       </cdr-text>
       <cdr-img

--- a/src/components/input/CdrInput.jsx
+++ b/src/components/input/CdrInput.jsx
@@ -168,7 +168,7 @@ export default {
             )}
             id={this.inputId}
             disabled={this.disabled}
-            required={this.required}
+            aria-required={this.required}
             ref="input"
             aria-invalid={!!this.error}
             aria-errormessage={!!this.error && `${this.inputId}-error`}
@@ -187,7 +187,7 @@ export default {
             )}
             id={this.inputId}
             disabled={this.disabled}
-            required={this.required}
+            aria-required={this.required}
             ref="input"
             aria-invalid={!!this.error}
             aria-errormessage={!!this.error && `${this.inputId}-error`}

--- a/src/components/input/__tests__/CdrInput.spec.js
+++ b/src/components/input/__tests__/CdrInput.spec.js
@@ -94,7 +94,7 @@ describe('CdrInput', () => {
         required: true,
       },
     });
-    expect(wrapper.vm.$refs.input.hasAttribute('required')).toBe(true);
+    expect(wrapper.find('input').attributes('aria-required')).toBe('true');
   });
 
   it('sets attrs for number type input', () => {

--- a/src/components/list/examples/demo/Resilience.vue
+++ b/src/components/list/examples/demo/Resilience.vue
@@ -28,14 +28,14 @@
     <cdr-text
       v-for="p1 in paragraphs"
       :key="p1"
-      :modifier="`body-${p1}`"
+      :class="`cdr-text-dev--body-${p1}`"
     >
       <cdr-list>
         <li>List item text</li>
         <li>Lorem ipsum dolor
           <cdr-text
             tag="span"
-            :modifier="`body-strong-${p1}`"
+            :class="`cdr-text-dev--body-strong-${p1}`"
           >
             sit amet,
           </cdr-text>
@@ -52,7 +52,7 @@
     <cdr-text
       v-for="utility in utilities"
       :key="utility"
-      :modifier="`utility-sans-${utility}`"
+      :class="`cdr-text-dev--utility-sans-${utility}`"
     >
       <cdr-list
         v-for="l1 in lists"
@@ -81,7 +81,7 @@
       >
         <cdr-text
           tag="span"
-          :modifier="`body-${paragraph}`"
+          :class="`cdr-text-dev--body-${paragraph}`"
         >
           body-{{ paragraph }}
         </cdr-text>
@@ -95,7 +95,7 @@
           >
             <cdr-text
               tag="span"
-              :modifier="`body-${paragraph}`"
+              :class="`cdr-text-dev--body-${paragraph}`"
             >
               body-{{ paragraph }}
             </cdr-text>
@@ -115,7 +115,7 @@
         random text
         <cdr-text
           tag="span"
-          :modifier="`utility-sans-${utility}`"
+          :class="`cdr-text-dev--utility-sans-${utility}`"
         >
           utility-sans-{{ utility }}
         </cdr-text>
@@ -129,7 +129,7 @@
           >
             <cdr-text
               tag="span"
-              :modifier="`utility-sans-${utility}`"
+              :class="`cdr-text-dev--utility-sans-${utility}`"
             >
               utility-sans-{{ utility }}
             </cdr-text>
@@ -147,7 +147,7 @@
         random text
         <cdr-text
           tag="span"
-          :modifier="`utility-sans-${utility}`"
+          :class="`cdr-text-dev--utility-sans-${utility}`"
         >
           utility-sans-{{ utility }}
         </cdr-text>
@@ -162,7 +162,7 @@
             random text
             <cdr-text
               tag="span"
-              :modifier="`utility-sans-${utility}`"
+              :class="`cdr-text-dev--utility-sans-${utility}`"
             >
               utility-sans-{{ utility }}
             </cdr-text>

--- a/src/components/select/CdrSelect.jsx
+++ b/src/components/select/CdrSelect.jsx
@@ -138,7 +138,7 @@ export default {
           multiple={this.multiple}
           size={this.multipleSize}
           disabled={this.disabled}
-          required={this.required}
+          aria-required={this.required}
           ref="select"
 
           aria-invalid={!!this.error}

--- a/src/components/select/__tests__/CdrSelect.spec.js
+++ b/src/components/select/__tests__/CdrSelect.spec.js
@@ -96,7 +96,7 @@ describe('cdrSelect', () => {
         required: true,
       },
     });
-    expect(wrapper.vm.$refs.select.hasAttribute('required', 'required')).toBe(true);
+    expect(wrapper.find('select').attributes('aria-required')).toBe('true');
   });
 
   it('sets select autofocus attribute correctly', () => {

--- a/src/components/tabs/examples/Tabs.vue
+++ b/src/components/tabs/examples/Tabs.vue
@@ -25,7 +25,7 @@
           :aria-labelledby="'tab-small-' + tab"
         >
           <cdr-text
-            modifier="body-300"
+            class="cdr-text-dev--body-300"
           >
             Tab {{ tab }} content
           </cdr-text>
@@ -51,7 +51,7 @@
           :aria-labelledby="'tab-full-width-' + tab"
         >
           <cdr-text
-            modifier="body-300"
+            class="cdr-text-dev--body-300"
           >
             Tab {{ tab }} content
           </cdr-text>
@@ -77,7 +77,7 @@
           :aria-labelledby="'tab-no-border-' + tab"
         >
           <cdr-text
-            modifier="body-300"
+            class="cdr-text-dev--body-300"
           >
             Tab {{ tab }} content
           </cdr-text>
@@ -100,7 +100,7 @@
           aria-labelledby="tab-auto-short"
         >
           <cdr-text
-            modifier="body-300"
+            class="cdr-text-dev--body-300"
           >
             short tab content
           </cdr-text>
@@ -112,7 +112,7 @@
           aria-labelledby="tab-auto-tall"
         >
           <cdr-text
-            modifier="body-300"
+            class="cdr-text-dev--body-300"
           >
             tall tab content. look at it go. wow, so much content.
             letters, punctuation, spaces, all together in one tab.
@@ -144,7 +144,7 @@
           :aria-labelledby="'tab-centered-' + tab"
         >
           <cdr-text
-            modifier="body-300"
+            class="cdr-text-dev--body-300"
           >
             Tab {{ tab }} content
           </cdr-text>
@@ -156,7 +156,7 @@
         >
           <cdr-text
             tag="strong"
-            modifier="subheading"
+            class="cdr-text-dev--subheading-sans-300"
           >
             Tab six Content
           </cdr-text>
@@ -168,7 +168,7 @@
         >
           <cdr-text
             tag="strong"
-            modifier="subheading"
+            class="cdr-text-dev--subheading-sans-300"
           >
             Tab seven Content
           </cdr-text>
@@ -180,7 +180,7 @@
         >
           <cdr-text
             tag="strong"
-            modifier="subheading"
+            class="cdr-text-dev--subheading-sans-300"
           >
             Tab eight Content
           </cdr-text>


### PR DESCRIPTION
- `required` -> `aria-required` on input/select
- removes the remaining cdr-text modifiers in the kitchen sink