### PR TITLE
feat(container): create cdr-container component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "9.0.0-beta.3",
+  "version": "9.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4162,9 +4162,9 @@
       }
     },
     "@rei/cdr-tokens": {
-      "version": "9.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-9.0.0-alpha.1.tgz",
-      "integrity": "sha512-feXbIfAGQfa3vXxRZq43CL1+8RVr7GRPUEYR42ZZzkILZazTZUwSiCgslhnC9kqOFplaxmdzh1gWqRbuPlbfgw==",
+      "version": "9.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-9.0.0-beta.1.tgz",
+      "integrity": "sha512-6LQBBXgqKVgK0CQhLBwKv+EB7XuCy5to14BEgOvgNUTLMXeQs4OFD5xco8BXxCnIGcphu4YQcBav33EKPhP36w==",
       "dev": true
     },
     "@rei/cedar-icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "9.0.0-beta.3",
+  "version": "9.0.0-beta.8",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@betit/rollup-plugin-rename-extensions": "^0.1.0",
     "@commitlint/cli": "^9.1.2",
     "@commitlint/config-conventional": "^11.0.0",
-    "@rei/cdr-tokens": "^9.0.0-alpha.1",
+    "@rei/cdr-tokens": "^9.0.0-beta.1",
     "@rei/cedar-icons": "^2.1.0",
     "@rollup/plugin-alias": "^3.1.2",
     "@vue/babel-preset-jsx": "^1.2.4",

--- a/src/components/breadcrumb/examples/Breadcrumb.vue
+++ b/src/components/breadcrumb/examples/Breadcrumb.vue
@@ -63,12 +63,6 @@ import * as Components from 'srcdir/index';
 export default {
   name: 'Breadcrumb',
   components: { ...Components },
-  methods: {
-    handleClick(bc, e) {
-      e.preventDefault();
-      console.log(bc.item);
-    },
-  },
   data() {
     return {
       averageBreadcrumbItems: [
@@ -182,6 +176,12 @@ export default {
         },
       ],
     };
+  },
+  methods: {
+    handleClick(bc, e) {
+      e.preventDefault();
+      console.log(bc.item);
+    },
   },
 };
 </script>

--- a/src/components/container/CdrContainer.backstop.js
+++ b/src/components/container/CdrContainer.backstop.js
@@ -1,0 +1,5 @@
+module.exports = [{
+  url: 'http://localhost:3000/#/container',
+  label: 'Container',
+  responsive: true,
+}];

--- a/src/components/container/CdrContainer.jsx
+++ b/src/components/container/CdrContainer.jsx
@@ -1,0 +1,44 @@
+import clsx from 'clsx';
+import style from './styles/CdrContainer.scss';
+import modifier from '../../mixins/modifier';
+import propValidator from '../../utils/propValidator';
+
+export default {
+  name: 'CdrContainer',
+  mixins: [modifier],
+  props: {
+    /** Any valid HTML tag */
+    tag: {
+      type: String,
+      default: 'div',
+    },
+    modifier: {
+      type: String,
+      default: 'static',
+      validator: (value) => propValidator(
+        value,
+        ['static', 'fluid'],
+        false,
+      ),
+    },
+  },
+  data() {
+    return {
+      style,
+    };
+  },
+  computed: {
+    baseClass() {
+      return 'cdr-container';
+    },
+    modifierClass() {
+      return this.buildClass('modifier');
+    },
+  },
+  render() {
+    const Component = this.tag;
+    return (<Component class={clsx(this.style[this.baseClass], this.modifierClass)}>
+      {this.$slots.default}
+    </Component>);
+  },
+};

--- a/src/components/container/__tests__/CdrContainer.spec.js
+++ b/src/components/container/__tests__/CdrContainer.spec.js
@@ -1,0 +1,29 @@
+import { shallowMount } from '@vue/test-utils';
+import CdrContainer from 'componentdir/container/CdrContainer';
+
+describe('CdrContainer', () => {
+  it('matches snapshot', () => {
+    const wrapper = shallowMount(CdrContainer, {
+      slots: {
+        default: 'foo'
+      }
+    });
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it('overrides default modifier', () => {
+    const wrapper = shallowMount(CdrContainer, {
+      props: {
+        modifier: 'fluid'
+      },
+      slots: {
+        default: 'foo'
+      }
+    });
+    // cdr-container base class corresponds to "fluid"
+    // default is "static" which adds an addition class
+    expect(wrapper.classes()).not.toContain('cdr-container--fluid');
+    expect(wrapper.classes()).not.toContain('cdr-container--static');
+    expect(wrapper.classes()).toContain('cdr-container');
+  });
+});

--- a/src/components/container/__tests__/__snapshots__/CdrContainer.spec.js.snap
+++ b/src/components/container/__tests__/__snapshots__/CdrContainer.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CdrContainer matches snapshot 1`] = `
+<div
+  class="cdr-container cdr-container--static"
+>
+  foo
+</div>
+`;

--- a/src/components/container/examples/Container.vue
+++ b/src/components/container/examples/Container.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <h2>container</h2>
+    <h3>container static</h3>
+    <cdr-container>
+      <div style="width: 100%; border: 1px solid black;">
+        container
+      </div>
+    </cdr-container>
+    <br>
+    <div class="tokens-container">
+      <div style="width: 100%; border: 1px solid black;">
+        container (mixin)
+      </div>
+    </div>
+
+    <h3>container fluid</h3>
+    <cdr-container modifier="fluid">
+      <div style="width: 100%; border: 1px solid black;">
+        container fluid
+      </div>
+    </cdr-container>
+
+    <br>
+    <div class="tokens-container-fluid">
+      <div style="width: 100%; border: 1px solid black;">
+        container fluid (mixin)
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import * as Components from 'srcdir/index';
+
+export default {
+  name: 'Container',
+  components: {
+    ...Components,
+  },
+};
+</script>
+
+<style lang="scss">
+@import "node_modules/@rei/cdr-tokens/dist/scss/cdr-tokens.scss";
+
+.tokens-container {
+  @include cdr-container;
+}
+
+.tokens-container-fluid {
+  @include cdr-container-fluid;
+}
+</style>

--- a/src/components/container/styles/CdrContainer.scss
+++ b/src/components/container/styles/CdrContainer.scss
@@ -1,0 +1,10 @@
+@import '../../../css/settings/index.scss';
+
+.cdr-container {
+  @include cdr-text-default;
+  @include cdr-container-base;
+}
+
+.cdr-container--static {
+  @include cdr-container-static;
+}

--- a/src/components/examples.js
+++ b/src/components/examples.js
@@ -6,6 +6,7 @@ import captions from 'componentsdir/caption/examples/Caption';
 import card from 'componentsdir/card/examples/Cards';
 import checkbox from 'componentsdir/checkbox/examples/checkboxes';
 import chip from 'componentsdir/chip/examples/Chip';
+import container from 'componentsdir/container/examples/Container';
 import formGroup from 'componentsdir/formGroup/examples/FormGroup';
 import grid from 'componentsdir/grid/examples/Grid';
 import icon from 'componentsdir/icon/examples/Icons';
@@ -35,6 +36,7 @@ export default {
   card,
   checkbox,
   chip,
+  container,
   formGroup,
   grid,
   icon,

--- a/src/dev/router.js
+++ b/src/dev/router.js
@@ -29,6 +29,7 @@ const routes = [
   { path: '/cards', name: 'Cards', component: Examples.card },
   { path: '/checkboxes', name: 'CheckBoxes', component: Examples.checkbox },
   { path: '/chips', name: 'Chip', component: Examples.chip },
+  { path: '/containers', name: 'Container', component: Examples.container },
   { path: '/formGroups', name: 'Form Groups', component: Examples.formGroup },
   { path: '/form', name: 'Form Patterns', component: Examples.forms },
   { path: '/flex-grid', name: 'Grid flex', component: Examples.gridFlex },

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export { default as CdrCheckbox } from './components/checkbox/CdrCheckbox';
 export { default as CdrChip } from './components/chip/CdrChip';
 export { default as CdrChipGroup } from './components/chip/CdrChipGroup';
 export { default as CdrCol } from './components/flex-grid/CdrCol';
+export { default as CdrContainer } from './components/container/CdrContainer';
 export { default as CdrFormGroup } from './components/formGroup/CdrFormGroup';
 export { default as CdrGrid } from './components/grid/CdrGrid';
 // export all single icon components


### PR DESCRIPTION
cdr-container was the one sensible utility class we had. removing it means every consumer of cedar needs to apply the container mixin to a custom class that gets added to a root element on each page. (on the other hand we definitely don't want to keep it because global CSS classes are a huge anti-pattern for us)

having a cdr-container component that encapsulates that styling makes sense to me, component is simple enough that it isn't a maintenance burden and provides flexibility to consumers. whether they use the mixin or component they get the same behavior, if we change the page layout logic in the future all the logic will flow from tokens, etc.

depends on this tokens pr: https://github.com/rei/rei-cedar-tokens/pull/162 which splits up the container mixins so we can make this component more optimized