### PR TITLE
fix(img): handle img with auto ratio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "9.0.0-beta.8",
+  "version": "9.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "9.0.0-beta.8",
+  "version": "9.0.0-beta.9",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/image/CdrImg.jsx
+++ b/src/components/image/CdrImg.jsx
@@ -94,12 +94,7 @@ export default {
         const [x, y] = this.ratio.split('-');
         ratioPct = `${(y / x) * 100}%`;
       }
-      const obj = { '--ratio': ratioPct };
-      if (this.ratio === 'auto') {
-        obj.width = '100%';
-        obj.height = '100%';
-      }
-      return obj;
+      return { '--ratio': ratioPct };
     },
   },
   render() {

--- a/src/components/image/CdrImg.jsx
+++ b/src/components/image/CdrImg.jsx
@@ -84,22 +84,29 @@ export default {
         objectPosition: this.crop,
       };
     },
-    ratioPct() {
+    ratioObject() {
+      let ratioPct;
       if (this.ratio === 'square') {
-        return '100%';
-      }
-      if (this.ratio) {
+        ratioPct = '100%';
+      } else if (this.ratio === 'auto') {
+        ratioPct = '0';
+      } else {
         const [x, y] = this.ratio.split('-');
-        return `${(y / x) * 100}%`;
+        ratioPct = `${(y / x) * 100}%`;
       }
-      return '0%';
+      const obj = { '--ratio': ratioPct };
+      if (this.ratio === 'auto') {
+        obj.width = '100%';
+        obj.height = '100%';
+      }
+      return obj;
     },
   },
   render() {
     if (this.ratio) {
       return (
         <div
-          style={{ '--ratio': this.ratioPct }}
+          style={this.ratioObject}
           class={this.style['cdr-image-ratio']}
         >
           <img

--- a/src/components/image/__tests__/CdrImg.spec.js
+++ b/src/components/image/__tests__/CdrImg.spec.js
@@ -74,6 +74,28 @@ describe('CdrImg', () => {
     expect(spy.calledOnce).toBeTruthy();
   })
 
+
+  it('builds proper ratio object for auto ratio', () => {
+    const wrapper = shallowMount(CdrImg, {
+      propsData: {
+        src: 'localhost:8000/nothing-to-see-here.png',
+        ratio: 'auto'
+      },
+    });
+    expect(wrapper.vm.ratioObject['--ratio']).toBe('0');
+  });
+
+
+  it('builds proper ratio object for mathematical aspect ratio', () => {
+    const wrapper = shallowMount(CdrImg, {
+      propsData: {
+        src: 'localhost:8000/nothing-to-see-here.png',
+        ratio: '3-2'
+      },
+    });
+    expect(wrapper.vm.ratioObject['--ratio']).toBe('66.66666666666666%');
+  });
+
   it('emits error event for ratio image', () => {
     const spy = sinon.spy();
 

--- a/src/components/image/examples/demos/Ratios.vue
+++ b/src/components/image/examples/demos/Ratios.vue
@@ -13,6 +13,33 @@
     </div>
     <div>
       <cdr-text class="cdr-text-dev--subheading-sans-300">
+        Auto
+      </cdr-text>
+      <cdr-img
+        class="cdr-img-test"
+        ratio="auto"
+        crop="center"
+        alt="ratio auto"
+        src="http://placehold.it/300x100"
+      />
+    </div>
+
+    <div>
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
+        Auto in Container
+      </cdr-text>
+      <div style="width: 250px; height: 350px;">
+        <cdr-img
+          class="cdr-img-test"
+          ratio="auto"
+          crop="center"
+          alt="ratio auto"
+          src="http://placehold.it/300x100"
+        />
+      </div>
+    </div>
+    <div>
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
         1-2
       </cdr-text>
       <cdr-img

--- a/src/components/image/examples/demos/Ratios.vue
+++ b/src/components/image/examples/demos/Ratios.vue
@@ -13,7 +13,7 @@
     </div>
     <div>
       <cdr-text class="cdr-text-dev--subheading-sans-300">
-        Auto
+        Auto (min-height)
       </cdr-text>
       <cdr-img
         class="cdr-img-test"
@@ -21,21 +21,23 @@
         crop="center"
         cover
         alt="ratio auto"
+        style="min-height: 100px"
         src="http://placehold.it/300x100"
       />
     </div>
 
     <div>
       <cdr-text class="cdr-text-dev--subheading-sans-300">
-        Auto in static container
+        Auto filling container
       </cdr-text>
-      <div style="width: 100px; height: 150px">
+      <div style="width: 100%; height: 100%">
         <cdr-img
           class="cdr-img-test"
           ratio="auto"
           crop="center"
           cover
           alt="ratio auto"
+          style="width: 100%; height: 100%;"
           src="http://placehold.it/300x100"
         />
       </div>

--- a/src/components/image/examples/demos/Ratios.vue
+++ b/src/components/image/examples/demos/Ratios.vue
@@ -19,6 +19,7 @@
         class="cdr-img-test"
         ratio="auto"
         crop="center"
+        cover
         alt="ratio auto"
         src="http://placehold.it/300x100"
       />
@@ -26,17 +27,37 @@
 
     <div>
       <cdr-text class="cdr-text-dev--subheading-sans-300">
-        Auto in Container
+        Auto in static container
       </cdr-text>
-      <div style="width: 250px; height: 350px;">
+      <div style="width: 100px; height: 150px">
         <cdr-img
           class="cdr-img-test"
           ratio="auto"
           crop="center"
+          cover
           alt="ratio auto"
           src="http://placehold.it/300x100"
         />
       </div>
+    </div>
+
+    <div>
+      <cdr-text class="cdr-text-dev--subheading-sans-300">
+        Auto (grid)
+      </cdr-text>
+      <cdr-grid style="grid-template-columns: 1fr 2fr">
+        <cdr-img
+          class="cdr-img-test"
+          ratio="auto"
+          crop="center"
+          cover
+          alt="ratio auto"
+          src="http://placehold.it/300x100"
+        />
+        <div style="height: 100px">
+          content goes here
+        </div>
+      </cdr-grid>
     </div>
     <div>
       <cdr-text class="cdr-text-dev--subheading-sans-300">


### PR DESCRIPTION
https://rei.slack.com/archives/CA58YCGN4/p1623453819054200

There are 2 bugs here: 
- we weren't handling ratio="auto" in the ratioPCT logic, resulting in `NaN%` which is `undefined / 'auto'`. HOWEVER `padding-bottom: NaN%;` and `padding-bottom: `0` behave identically, so while this is weird it did not cause this bug.
- a plain cdr-img with ratio="auto" would not actually render any content because the image is functionally a 0x0 box. I don't think there is a way to handle this without breaking things. 

Our ratio logic essentially sets a height-width ratio through the use of `padding-bottom`. This works for every other ratio option because they set a padding-bottom, but for ratio="auto" this results in 0x0 unless a height is set or inherited somehow.

EA worked previously because the image was inheriting it's height from the cdr-row/cdr-col, i.e, the image would be as tall as the tallest element in the row.

Adventures/experiences also use ratio="auto" alongside a `min-height/max-height` value which allow the image to render.

