### PR TITLE
fix(modal): remove resize handler when modal destroyed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/modal/CdrModal.jsx
+++ b/src/components/modal/CdrModal.jsx
@@ -59,6 +59,7 @@ export default {
       keyHandler: null,
       lastActive: null,
       focusHandler: null,
+      resizeHandler: null,
       isOpening: false,
       offset: null,
       headerHeight: 0,
@@ -116,15 +117,18 @@ export default {
       this.handleOpened();
     }
 
-    window.addEventListener('resize', debounce(() => {
+    this.resizeHandler = debounce(() => {
       this.measureContent();
-    }, 300));
+    }, 300);
+
+    window.addEventListener('resize', this.resizeHandler);
   },
   beforeDestroy() {
     if (this.unsubscribe) this.unsubscribe();
     if (this.opened) this.removeNoScroll();
     document.removeEventListener('focusin', this.focusHandler, true);
     document.removeEventListener('keydown', this.keyHandler);
+    window.removeEventListener('resize', this.resizeHandler);
   },
   methods: {
     measureContent() {


### PR DESCRIPTION
Patch fix for Cedar 8 and 9

Temporary branch for the cedar 8 patch: https://github.com/rei/rei-cedar/compare/v8.0.4...805-patch?expand=1

If a modal is rendered to a page, and then the component rendering it is removed from the page, the resize event handler stays attached and throws errors on resize. See https://rei.slack.com/archives/CA58YCGN4/p1624488758088200 or the linked jira ticket for more info

Instantiating a CdrModal for every element of a list is not ideal, but this is still definitely a case we should handle.