### PR TITLE
Give toast more status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "11.0.0-beta.6",
+  "version": "11.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "11.0.0-beta.6",
+  "version": "11.0.0-beta.7",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/src/components/toast/CdrToast.jsx
+++ b/src/components/toast/CdrToast.jsx
@@ -116,6 +116,7 @@ export default {
                 this.style[this.baseClass],
                 this.typeClass,
               )}
+              role="status"
               ref="toastEl"
             >
           <div class={clsx(this.style['cdr-toast__main'])}>

--- a/src/components/toast/__tests__/CdrToast.spec.js
+++ b/src/components/toast/__tests__/CdrToast.spec.js
@@ -19,10 +19,21 @@ describe('CdrToast', () => {
       expect(wrapper.element).toMatchSnapshot();
     })
   });
-  it('watches for close triggers', async () => {
-    wrapper.setProps({ open: false });
+  it('handles close triggers', async () => {
+    const spyCloseToast = jest.spyOn(wrapper.vm, 'closeToast');
+    wrapper.setProps({ open: true });
     await wrapper.vm.$nextTick(() => {
-      expect(wrapper.vm.closeToast).toBeCalled();
+      wrapper.find('button').trigger('click');
+      expect(spyCloseToast).toBeCalled();
+    });
+  });
+  it('closes after 5 seconds', async () => {
+    jest.useFakeTimers();
+    const spyCloseToastWithDelay = jest.spyOn(wrapper.vm, 'closeToastWithDelay');
+    wrapper.setProps({ open: true });
+    jest.runTimersToTime(5000),
+    await wrapper.vm.$nextTick(() => {
+      expect(spyCloseToastWithDelay).toBeCalled();
     });
   });
 });

--- a/src/components/toast/__tests__/__snapshots__/CdrToast.spec.js.snap
+++ b/src/components/toast/__tests__/__snapshots__/CdrToast.spec.js.snap
@@ -9,6 +9,7 @@ exports[`CdrToast matches snapshot 1`] = `
 >
   <div
     class="cdr-toast cdr-toast--default"
+    role="status"
   >
     <div
       class="cdr-toast__main"


### PR DESCRIPTION
- Adds `role="status"` to the CdrToast component
- Bringing the test coverage for toast into the green
- `11.0.0-beta.7`